### PR TITLE
Nettoyage html

### DIFF
--- a/core/template/dashboard/eqLogic.html
+++ b/core/template/dashboard/eqLogic.html
@@ -1,7 +1,7 @@
 <div class="eqLogic eqLogic-widget" data-eqLogic_id="#id#" data-version="dashboard" style="background-color: #background_color#;max-width: #max_width#;#style#" data-category="#category#">
-    <center class="widget-name">
+    <p class="widget-name">
         <a href="#eqLink#" style="font-size : 1.5em;">#name#</a> <span style="font-size: 0.85em;position: relative;top:-2px;">#object_name#</span>
-    </center>
+    </p>
     <div class="verticalAlign">
         <center>
             #cmd#

--- a/desktop/css/commun.css
+++ b/desktop/css/commun.css
@@ -102,7 +102,9 @@ body {
     -moz-border-radius:3px !important;
     border-radius:3px !important;
 }
-
+.eqLogic-widget .widget-name{
+    text-align:center;
+    }
 .cmd-widget .statistiques{
     position : absolute; 
     bottom: 0;


### PR DESCRIPTION
Sur le titre des widgets, suppression de la balise center deprecated en html5 et passage par du css dans common.css pour la mise en forme