### PR TITLE
Update nginx_default_without_jeedom

### DIFF
--- a/install/nginx_default_without_jeedom
+++ b/install/nginx_default_without_jeedom
@@ -11,7 +11,9 @@ server {
         location / {
                 try_files $uri $uri/ /index.html /index.php;
         }
-
+        location /jeedom {
+                rewrite ^/jeedom$ / redirect;
+        }
         location ~ ^/tmp/(.*)$ {
                 deny all;
         }


### PR DESCRIPTION
Redirection /jeedom vers / pour eviter les soucis de /jeedom inutile.