### PR TITLE
Memcached::Connect doesn't exist

### DIFF
--- a/core/class/cache.class.php
+++ b/core/class/cache.class.php
@@ -68,7 +68,7 @@ class cache {
 				break;
 			case 'MemcachedCache':
 				$memcached = new Memcached();
-				$memcached->connect(config::byKey('cache::memcacheaddr'), config::byKey('cache::memcacheport'));
+				$memcached->addServer(config::byKey('cache::memcacheaddr'), config::byKey('cache::memcacheport'));
 				self::$cache = new \Doctrine\Common\Cache\MemcachedCache();
 				self::$cache->setMemcached($memcached);
 				break;


### PR DESCRIPTION
Only one of these 2 options is possible :

Memcache::Connect() : https://secure.php.net/manual/en/memcache.connect.php

or 

Memcached::addServer() https://secure.php.net/manual/en/book.memcached.php