### PR TITLE
Prevent double " on scenario expression

### DIFF
--- a/core/class/scenarioExpression.class.php
+++ b/core/class/scenarioExpression.class.php
@@ -848,7 +848,7 @@ class scenarioExpression {
 		} else {
 			log::add('scenario', 'debug', print_r($_expression, true));
 		}
-		return str_replace('""', '"', cmd::cmdToValue(str_replace(array_keys($replace1), array_values($replace1), str_replace(array_keys($replace2), array_values($replace2), $_expression)), $_quote));
+		return preg_replace('/[^!=<>\s]?"("[^!=<>\s])|([^!=<>\s]")"[^!=<>\s]?/', '$1$2', cmd::cmdToValue(str_replace(array_keys($replace1), array_values($replace1), str_replace(array_keys($replace2), array_values($replace2), $_expression)), $_quote));
 
 	}
 


### PR DESCRIPTION
Résout le bug des strings vides "" tout en gardant la correction des doubles quot

démo du regExp
http://sandbox.onlinephpfunctions.com/code/502354c1b56e3c3d153afab95ef7abfd0804ceda