### PR TITLE
Improvement shell.com.php

### DIFF
--- a/core/com/shell.com.php
+++ b/core/com/shell.com.php
@@ -22,47 +22,119 @@ require_once dirname(__FILE__) . '/../../core/php/core.inc.php';
 class com_shell {
 	/*     * ***********************Attributs************************* */
 
-	private $cmd;
-	private $background = false;
+	private static $instance;
+	
+	private $cmds = array();
+	private $background;
+	private $cache = array();
+	private $history = array();
+	
 
 	/*     * ********************Functions static********************* */
 
-	function __construct($_cmd) {
-		$this->cmd = $_cmd;
+	function __construct($_cmd, $_background = false) {
+		$this->setBackground($_background);
+		$this->addCmd($_cmd);
+	}
+	
+	/**
+	 * Get the instance of com_shell
+	 * @return com_shell
+	 */
+	public static function getInstance() {
+		if (self::$instance === null)
+		{
+			self::$instance = new self();
+		}
+		
+		return self::$instance;
 	}
 
-	/*     * ************* Functions ************************************ */
-
-	function exec() {
-		$output = array();
-		$retval = 0;
-		if ($this->getBackground()) {
-			exec($this->cmd . ' >> /dev/null 2>&1 &');
-			return;
-		} else {
-			exec($this->cmd, $output, $retval);
-			$return = implode("/n", $output);
-		}
-		if ($retval != 0) {
-			throw new Exception('Error on shell exec, return value : ' . $retval . '. Details : ' . $return);
-		}
-		return $return;
+	/**
+	 * Execute a command
+	 * @param string $_cmd
+	 * @param bool $_background
+	 */
+	public static function execute($_cmd, $_background = false) {
+		$shell = self::$instance;
+		$shell->clear();
+		$shell->addCmd($_cmd, $_background);
+		return $shell->exec();
 	}
-
-	function commandExist($_cmd) {
+	
+	/**
+	 * Test if a command exists
+	 * @param string $_cmd
+	 * @return boolean
+	 */
+	public static function commandExists($_cmd) {
 		$fp = popen("which " . $_cmd, "r");
 		$value = fgets($fp, 255);
 		$exists = !empty($value);
 		pclose($fp);
 		return $exists;
 	}
+	
+	/*     * ************* Functions ************************************ */
+
+	/**
+	 * Execute commands
+	 * @throws Exception
+	 * @return string
+	 */
+	public function exec() {
+		$output = array();
+		$retval = 0;
+		$return = array();
+		foreach ($this->cmds as $cmd) {
+			exec($cmd, $output, $retval);
+			$return[] = implode("\n", $output);
+			if ($retval != 0) {
+				throw new Exception('Error on shell exec, return value : ' . $retval . '. Details : ' . $return);
+			}
+			$this->history[] = $cmd;
+		}
+		$this->cmds = $this->cache;
+		$this->cache = array();
+		
+		return implode("\n", $return);
+	}
+
+	/**
+	 * @deprecated Replaced by com_shell::commandExists
+	 * @param string $_cmd
+	 * @return boolean
+	 */
+	public function commandExist($_cmd) {
+		return self::commandExists($_cmd);
+	}
+	
+	public function clear()	{
+		$this->cache = array_merge($this->cache, $this->cmds);
+		$this->cmds = array();
+	}
+	
+	public function clearHistory() {
+		$this->history = array();
+	}
 
 	/*     * **********************Getteur Setteur*************************** */
 
 	public function getCmd() {
-		return $this->cmd;
+		return implode("\n", $this->cmds);
 	}
-
+	
+	public function addCmd($_cmd, $_background = null) {
+		if (!self::commandExists($_cmd)) {
+			return false;
+		}
+		$bg = ($_background === null) ? $this->getBackground() : $_background;
+		$add = $bg ? ' >> /dev/null 2>&1 &' : '';
+		$this->cmds[] = $_cmd.$add;
+		
+		return true;
+	}
+	
 	public function setBackground($background) {
 		$this->background = $background;
 	}
@@ -71,6 +143,11 @@ class com_shell {
 		return $this->background;
 	}
 
+	/**
+	 * Get the history of commands
+	 * @return array
+	 */
+	public function getHistory() {
+		return $this->history;
+	}
 }
-
-?>

--- a/tests/com/shellTest.php
+++ b/tests/com/shellTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/* This file is part of Jeedom.
+ *
+ * Jeedom is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jeedom is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Jeedom. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class com_shellTest extends \PHPUnit_Framework_TestCase
+{
+	public function getBackgrounds()
+	{
+		return array(
+				array(true),
+				array(false),
+		);
+	}
+	
+	public function testGetCmd()
+	{
+		$shell = new com_shell('ls');
+		$this->assertSame('ls', $shell->getCmd());
+	}
+	
+	public function testCommandExistValid()
+	{
+		$shell = new com_shell();
+		$this->assertTrue($shell->commandExist('ls'));
+		$this->assertFalse($shell->commandExist('foo'));
+	}
+	
+	/**
+	 * @dataProvider getBackgrounds
+	 * @var bool $in
+	 */
+	public function testBackground($in)
+	{
+		$shell = new com_shell();
+		$shell->setBackground($in);
+		$this->assertSame($in, $shell->getBackground());
+	}
+	
+	public function testExec()
+	{
+		if (file_exists('foo.txt'))
+		{
+			$this->markTestSkipped(
+					'A file named foo.txt exist. Please remove it.'
+			);
+		}
+		$shell = new com_shell('touch foo.txt');
+		$return = $shell->exec();
+		$this->assertTrue(file_exists('foo.txt'));
+		$shell = new com_shell('rm foo.txt');
+		$return = $shell->exec();
+		$this->assertFalse(file_exists('foo.txt'));
+	}
+}

--- a/tests/com/shellTest.php
+++ b/tests/com/shellTest.php
@@ -16,24 +16,21 @@
  * along with Jeedom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-class com_shellTest extends \PHPUnit_Framework_TestCase
-{
-	public function getBackgrounds()
-	{
+class com_shellTest extends \PHPUnit_Framework_TestCase {
+	/******************* Base ********************/
+	public function getBackgrounds() {
 		return array(
 				array(true),
 				array(false),
 		);
 	}
-	
-	public function testGetCmd()
-	{
+
+	public function testGetCmd() {
 		$shell = new com_shell('ls');
 		$this->assertSame('ls', $shell->getCmd());
 	}
 	
-	public function testCommandExistValid()
-	{
+	public function testCommandExist() {
 		$shell = new com_shell();
 		$this->assertTrue($shell->commandExist('ls'));
 		$this->assertFalse($shell->commandExist('foo'));
@@ -43,15 +40,13 @@ class com_shellTest extends \PHPUnit_Framework_TestCase
 	 * @dataProvider getBackgrounds
 	 * @var bool $in
 	 */
-	public function testBackground($in)
-	{
+	public function testBackground($in) {
 		$shell = new com_shell();
 		$shell->setBackground($in);
 		$this->assertSame($in, $shell->getBackground());
 	}
 	
-	public function testExec()
-	{
+	public function testExec() {
 		if (file_exists('foo.txt'))
 		{
 			$this->markTestSkipped(
@@ -60,9 +55,67 @@ class com_shellTest extends \PHPUnit_Framework_TestCase
 		}
 		$shell = new com_shell('touch foo.txt');
 		$return = $shell->exec();
+		$this->assertEmpty($return);
 		$this->assertTrue(file_exists('foo.txt'));
+		
 		$shell = new com_shell('rm foo.txt');
 		$return = $shell->exec();
+		$this->assertEmpty($return);
 		$this->assertFalse(file_exists('foo.txt'));
+		
+		$shell = new com_shell('echo foo');
+		$return = $shell->exec();
+		$this->assertSame('foo', $return);
+	}
+	
+	/*************** Improvement *****************/
+	public function testInstance() {
+		$shell = com_shell::getInstance();
+		$this->assertInstanceOf('com_shell', $shell);
+	}
+	
+	public function testExecute() {
+		if (file_exists('bar.txt'))
+		{
+			$this->markTestSkipped(
+					'A file named bar.txt exist. Please remove it.'
+			);
+		}
+		$result = com_shell::execute('touch bar.txt');
+		$this->assertEmpty($result);
+		$this->assertTrue(file_exists('bar.txt'));
+		
+		$result = com_shell::execute('rm bar.txt');
+		$this->assertEmpty($result);
+		$this->assertFalse(file_exists('bar.txt'));
+		
+		$result = com_shell::execute('echo bar');
+		$this->assertSame('bar', $result);
+	}
+	
+	public function testCache() {
+		$shell = com_shell::getInstance();
+		$shell->clearHistory();
+		$shell->addCmd('echo foo');
+		$result = com_shell::execute('echo bar');
+		$this->assertSame('bar', $result);
+		$this->assertSame(array('echo bar'), $shell->getHistory());
+		$result = $shell->exec();
+		$this->assertSame('foo', $result);
+	}
+	
+	public function testHistory() {
+		$shell = com_shell::getInstance();
+		$shell->clearHistory();
+		$this->assertSame(array(), $shell->getHistory());
+		com_shell::execute('echo foo');
+		$this->assertSame(array('echo foo'), $shell->getHistory());
+		$shell->addCmd('echo bar');
+		$shell->addCmd('echo baz');
+		$this->assertSame(array('echo foo'), $shell->getHistory());
+		$shell->exec();
+		$this->assertSame(array('echo foo', 'echo bar', 'echo baz'), $shell->getHistory());
+		$shell->clearHistory();
+		$this->assertSame(array(), $shell->getHistory());
 	}
 }


### PR DESCRIPTION
Ajout des tests OK sur code original
Amélioration de la classe
- Récupération d'un singleton via com_shell::getInstance()
- Execution direct via com_shell::execute($_cmd, $_background = false);
- Système d'historique des commandes (getHistory())
- Système de cache permettant une execution direct au milieu de plusieurs addCmd()
- Parametrage du background dispo pour chaque nouvelles commandes
Ajout de tests sur les nouvelles fonctions en gardant les anciens OK (rétrocompatible)

Manque tests sur background