### PR TITLE
Comparaison invalide

### DIFF
--- a/core/class/DB.class.php
+++ b/core/class/DB.class.php
@@ -97,7 +97,7 @@ class DB {
 		}
 
 		$errorInfo = $stmt->errorInfo();
-		if ($errorInfo[0] != 0000) {
+		if ($errorInfo[0] !== '0000') {
 			throw new Exception('[MySQL] Error code : ' . $errorInfo[0] . ' (' . $errorInfo[1] . '). ' . $errorInfo[2]);
 		}
 		return $res;


### PR DESCRIPTION
si on fait une comparaison avec 0000, en réalité on compare avec 0 alors que si on fait une comparaison avec '0000' on compare la chaine de caractère.
000000000 === 0