### PR TITLE
Return this for setters, user::connect() fluent usage

### DIFF
--- a/core/class/user.class.php
+++ b/core/class/user.class.php
@@ -71,15 +71,15 @@ class user {
 					if ($entries['count'] > 0) {
 						$user = self::byLogin($_login);
 						if (is_object($user)) {
-							$user->setPassword($sMdp);
-							$user->setOptions('lastConnection', date('Y-m-d H:i:s'));
+							$user->setPassword($sMdp)
+                                                             ->setOptions('lastConnection', date('Y-m-d H:i:s'));
 							$user->save();
 							return $user;
 						}
-						$user = new user;
-						$user->setLogin($_login);
-						$user->setPassword($sMdp);
-						$user->setOptions('lastConnection', date('Y-m-d H:i:s'));
+						$user = (new \user)
+                                                        ->setLogin($_login)
+                                                        ->setPassword($sMdp)
+                                                        ->setOptions('lastConnection', date('Y-m-d H:i:s'));
 						$user->save();
 						log::add("connection", "info", __('Utilisateur créé depuis le LDAP : ', __FILE__) . $_login);
 						jeedom::event('user_connect');
@@ -231,7 +231,7 @@ class user {
 	}
 
 	public function validateTwoFactorCode($_code) {
-		$google2fa = new Google2FA();
+		$google2fa = new \Google2FA();
 		return $google2fa->verifyKey($this->getOptions('twoFactorAuthentificationSecret'), $_code);
 	}
 
@@ -251,14 +251,17 @@ class user {
 
 	public function setId($id) {
 		$this->id = $id;
+                return $this;
 	}
 
 	public function setLogin($login) {
 		$this->login = $login;
+                return $this;
 	}
 
 	public function setPassword($password) {
 		$this->password = (!is_sha1($password)) ? sha1($password) : $password;
+                return $this;
 	}
 
 	public function getOptions($_key = '', $_default = '') {
@@ -267,6 +270,7 @@ class user {
 
 	public function setOptions($_key, $_value) {
 		$this->options = utils::setJsonAttr($this->options, $_key, $_value);
+                return $this;
 	}
 
 	public function getRights($_key = '', $_default = '') {
@@ -275,6 +279,7 @@ class user {
 
 	public function setRights($_key, $_value) {
 		$this->rights = utils::setJsonAttr($this->rights, $_key, $_value);
+                return $this;
 	}
 
 	public function getEnable() {
@@ -283,6 +288,7 @@ class user {
 
 	public function setEnable($enable) {
 		$this->enable = $enable;
+                return $this;
 	}
 
 	public function getHash() {
@@ -299,6 +305,7 @@ class user {
 
 	public function setHash($hash) {
 		$this->hash = $hash;
+                return $this;
 	}
 
 }


### PR DESCRIPTION
J'ai mis un \ pour la création de user car en php7 c'est en premier lieu le namespace courant qui est parcouru pour chercher user.en php5 c'est en premier lieu le namespace global mais il faut penser à la suite.