### PR TITLE
Amélioration de l'interception d'erreurs DB

### DIFF
--- a/core/class/DB.class.php
+++ b/core/class/DB.class.php
@@ -97,7 +97,7 @@ class DB {
 		}
 
 		$errorInfo = $stmt->errorInfo();
-		if ($errorInfo[0] != 0000) {
+		if (null != $errorInfo[1]) {
 			throw new Exception('[MySQL] Error code : ' . $errorInfo[0] . ' (' . $errorInfo[1] . '). ' . $errorInfo[2]);
 		}
 		return $res;


### PR DESCRIPTION
Le test actuel ne permet pas de catcher les erreurs.
Si errorInfo[1] n'est pas null on peut lever l'exception.
"Si le code d'erreur SQLSTATE n'est pas défini ou s'il n'y a pas d'erreur spécifique du driver, l'élément suivant l'élément 0 sera défini à NULL." - http://php.net/manual/fr/pdo.errorinfo.php