### PR TITLE
Fix: use double-quotes for Samba authentication

### DIFF
--- a/core/repo/samba.repo.php
+++ b/core/repo/samba.repo.php
@@ -127,7 +127,7 @@ class repo_samba {
 	}
 
 	public static function makeSambaCommand($_cmd, $_type = 'backup') {
-		return 'sudo smbclient ' . config::byKey('samba::' . $_type . '::share') . ' -U ' . config::byKey('samba::' . $_type . '::username') . '%' . config::byKey('samba::' . $_type . '::password') . ' -I ' . config::byKey('samba::' . $_type . '::ip') . ' -c "' . $_cmd . '"';
+		return 'sudo smbclient ' . config::byKey('samba::' . $_type . '::share') . ' -U "' . config::byKey('samba::' . $_type . '::username') . '%' . config::byKey('samba::' . $_type . '::password') . '" -I ' . config::byKey('samba::' . $_type . '::ip') . ' -c "' . $_cmd . '"';
 	}
 
 	public static function sortByDatetime($a, $b) {


### PR DESCRIPTION
If you have a special character in your Samba password, the backup will fail.
With double-quotes you can have ( or ) in your password 

Other characters can fail too…