### PR TITLE
strict comparator

### DIFF
--- a/core/class/history.class.php
+++ b/core/class/history.class.php
@@ -183,7 +183,7 @@ class history {
 
 			$mode = $cmd->getConfiguration('historizeMode', 'avg');
 
-			while ($oldest['oldest'] != null) {
+			while ($oldest['oldest'] !== null) {
 				$values = array(
 					'cmd_id' => $sensors['cmd_id'],
 					'oldest' => $oldest['oldest'],


### PR DESCRIPTION
With booleans, only strict comparison (with !== operator) should be used to lower bug risks and to improve performances.