### PR TITLE
operator of comaparaison

### DIFF
--- a/desktop/php/battery.php
+++ b/desktop/php/battery.php
@@ -66,7 +66,7 @@ foreach ($list as $eqLogic) {
 		echo '<span class="pull-right" style="font-size : 0.8em;margin-bottom: 3px;margin-right: 5px;cursor:default;" title="Piles">' . $eqLogic->getConfiguration('battery_type', '') . '</span>';
 	}
 	echo '<span class="pull-left" style="font-size : 0.8em;margin-bottom: 3px;margin-left: 5px;cursor:default;" title="Plugin">' . ucfirst($eqLogic->getEqType_name()) . '</span>';
-	if ($eqLogic->getConfiguration('battery_danger_threshold') != '' or $eqLogic->getConfiguration('battery_warning_threshold') != '') {
+	if ($eqLogic->getConfiguration('battery_danger_threshold') != '' || $eqLogic->getConfiguration('battery_warning_threshold') != '') {
 		echo '<i class="icon techno-fingerprint41 pull-right" style="position:absolute;bottom: 3px;right: 3px;cursor:default;" title="Seuil manuel défini"></i>';
 	}
 	echo '</div>';


### PR DESCRIPTION
The or operator does not have the same precedence as ||.
            This could lead to unexpected behavior, use || instead.