### PR TITLE
booleans, strict comparison

### DIFF
--- a/core/class/interactDef.class.php
+++ b/core/class/interactDef.class.php
@@ -71,7 +71,7 @@ class interactDef {
 		$values = array();
 		$sql = 'SELECT DISTINCT(`group`)
         FROM interactDef';
-		if ($_group != null) {
+		if ($_group !== null) {
 			$values['group'] = '%' . $_group . '%';
 			$sql .= ' WHERE `group` LIKE :group';
 		}


### PR DESCRIPTION
With booleans, only strict comparison (with !== operator) should be used to lower bug risks and to improve performances.