### PR TITLE
With booleans, only strict comparison

### DIFF
--- a/core/php/authentification.php
+++ b/core/php/authentification.php
@@ -79,7 +79,7 @@ function login($_login, $_password, $_twoFactor = null) {
 		return false;
 	}
 	if (network::getUserLocation() != 'internal' && $user->getOptions('twoFactorAuthentification', 0) == 1 && $user->getOptions('twoFactorAuthentificationSecret') != '') {
-		if (trim($_twoFactor) == '' || $_twoFactor == null || !$user->validateTwoFactorCode($_twoFactor)) {
+		if (trim($_twoFactor) == '' || $_twoFactor === null || !$user->validateTwoFactorCode($_twoFactor)) {
 			sleep(5);
 			return false;
 		}


### PR DESCRIPTION
(with === operator) should be used to lower bug risks and to improve performances.