### PR TITLE
Modification fonction collectDate pour internationalisation

### DIFF
--- a/core/class/scenarioExpression.class.php
+++ b/core/class/scenarioExpression.class.php
@@ -651,17 +651,19 @@ class scenarioExpression {
 		return strtotime('now') - strtotime($scenario->getLastLaunch());
 	}
 
-	public static function collectDate($_cmd, $_format = 'Y-m-d H:i:s') {
-		$cmd = cmd::byId(trim(str_replace('#', '', $_cmd)));
-		if (!is_object($cmd)) {
-			return -1;
-		}
-		if ($cmd->getType() != 'info') {
-			return -2;
-		}
-		$cmd->execCmd();
-		return date($_format, strtotime($cmd->getCollectDate()));
-	}
+	public static function collectDate($_cmd, $_format = '%Y-%m-%d %H:%M:%S', $_lang = 'fr_FR.utf8') {
+         	$cmd = cmd::byId(trim(str_replace('#', '', $_cmd)));
+      		if (!is_object($cmd)) {
+         		return -1;
+      		}
+      		if ($cmd->getType() != 'info') {
+         		return -2;
+      		}
+      		$cmd->execCmd();
+         	
+		setlocale(LC_TIME, $_lang);
+      		return strftime($_format, strtotime($cmd->getCollectDate()));
+   }
 
 	public static function valueDate($_cmd_id, $_format = 'Y-m-d H:i:s') {
 		$cmd = cmd::byId(trim(str_replace('#', '', $_cmd_id)));


### PR DESCRIPTION
Ajout et modification pour pouvoir avoir les nom dans les date en FR ou autre langue.
Ajout d'un paramètre 3 qui contiens une chaine de caractère représentant la langue.
PHP référence : 
http://php.net/manual/fr/function.setlocale.php
http://php.net/manual/fr/function.strftime.php

Attention le format est différent de la fonction Date