### PR TITLE
Install: set innodb_file_per_table=1 in mysql conf

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -216,6 +216,7 @@ step_7_jeedom_customization() {
 		echo "innodb_flush_method = O_DIRECT" >> /etc/mysql/conf.d/jeedom_my.cnf
 		echo "innodb_flush_log_at_trx_commit = 2" >> /etc/mysql/conf.d/jeedom_my.cnf
 		echo "innodb_log_file_size = 32M" >> /etc/mysql/conf.d/jeedom_my.cnf
+		echo "innodb_file_per_table = 1" >> /etc/mysql/conf.d/jeedom_my.cnf
     fi
 
   	systemctl start mysql > /dev/null 2>&1


### PR DESCRIPTION
In MySQL 5.5 (current version in Debian Jessie used by jeedom), innodb_file_per_table is not enabled by default.
It allows to have a .ibd file per table, allowing easier restoration in case of corruption. Since jeedom is heavily used on devices using sdcards, plaggued by corruption problems, it should be a good idea to set it.

This commit is to be reverted as soon as jeedom recommends using a version of debian shipping with MySQL 5.7 (or, better, MariaDB?).