### PR TITLE
Mysql : Index de table

### DIFF
--- a/install/update/3.0.10.sql
+++ b/install/update/3.0.10.sql
@@ -1,0 +1,6 @@
+ALTER TABLE history ADD INDEX date_time (datetime ASC);
+ALTER TABLE historyArch ADD INDEX date_time (datetime ASC);
+ALTER TABLE history ADD INDEX history5min_commands1_idx (cmd_id ASC, datetime ASC);
+ALTER TABLE historyArch ADD INDEX history5min_commands1_idx (cmd_id ASC, datetime ASC);
+ALTER TABLE scenario ADD INDEX isActive (isActive ASC);
+ALTER TABLE eqLogic ADD INDEX isEnable (isEnable ASC);


### PR DESCRIPTION
Bonjour,

Mon Jeedom ram depuis la V3. Je n'arrive pas à trouver la raison, mais il me semble que certains index de table manquent.
Pour l'analyse : modifier fichier /etc/mysql/my.cnf
slow_query_log_file = /var/log/mysql/mysql-slow.log
slow_query_log = 1
long_query_time = 2

A+
Thomas