### PR TITLE
PHP Strict Standards:  Non-static method interactQuery::pluginReply()…

### DIFF
--- a/core/class/interactQuery.class.php
+++ b/core/class/interactQuery.class.php
@@ -313,7 +313,7 @@ class interactQuery {
 		return preg_match('/( |^)' . preg_quote($word, '/') . '( |$)/', $string);
 	}
 
-	public function pluginReply($_query, $_parameters = array()) {
+	public static function pluginReply($_query, $_parameters = array()) {
 		try {
 			foreach (plugin::listPlugin(true) as $plugin) {
 				if (config::byKey('functionality::interact::enable', $plugin->getId(), 1) == 0) {


### PR DESCRIPTION
… should not be called statically

[Sun Jul 09 12:01:00.412180 2017] [:error] [pid 44048] [client 127.0.0.1:50277] PHP Strict Standards:  Non-static method interactQuery::pluginReply() should not be called statically in /var/www/html/core/class/interactQuery.class.php on line 400