### PR TITLE
Update cmd.info.numeric.line.html

### DIFF
--- a/core/template/dashboard/cmd.info.numeric.line.html
+++ b/core/template/dashboard/cmd.info.numeric.line.html
@@ -1,5 +1,5 @@
 <div class="tooltips cmd cmd-widget #history#" data-type="info" data-subtype="numeric" data-cmd_id="#id#" data-cmd_uid="#uid#" data-version="#version#" style="display: block;">
-	<center><span style="font-size : 12px !important;#hideCmdName#" class="cmdName">#name_display#</span> <strong class="state" style="font-size: 12px;"></strong>#unite#</center>
+	<center><span style="font-size : 12px !important;#hideCmdName#" class="cmdName">#name_display#</span> <strong class="state" style="font-size: 12px;"></strong> #unite#</center>
 	<script>
 		jeedom.cmd.update['#id#'] = function(_options){
 			$('.cmd[data-cmd_id=#id#]').attr('title','Valeur du '+_options.valueDate+', collectée le '+_options.collectDate)


### PR DESCRIPTION
Ajout d'un espace devant #unite# afin d'avoir la valeur et l'unité séparée par un espace insécable pour plus de visibilité (espace imposé par le SI).