### PR TITLE
Set jQuery UI Dialog to not be "modal"

### DIFF
--- a/desktop/js/utils.js
+++ b/desktop/js/utils.js
@@ -198,7 +198,7 @@ if (isset(jeedom_langage)) {
 
     $("#md_modal").dialog({
         autoOpen: false,
-        modal: true,
+        modal: false,
         closeText: '',
         height: (jQuery(window).height() - 100),
         width: ((jQuery(window).width() - 50) < 1500) ? (jQuery(window).width() - 50) : 1500,
@@ -215,7 +215,7 @@ if (isset(jeedom_langage)) {
 
     $("#md_modal2").dialog({
         autoOpen: false,
-        modal: true,
+        modal: false,
         closeText: '',
         height: (jQuery(window).height() - 150),
         width: ((jQuery(window).width() - 150) < 1200) ? (jQuery(window).width() - 50) : 1200,


### PR DESCRIPTION
On Firefox, it is currently impossible to use the Bootbox dialog form when inside of a jQuery UI Dialog box (#md_modal, #md_modal2), thus blocking any serious usage of Jeedom with Firefox (openzwave plugin for example requires it when you want to configure a Z-Wave module).

This change makes it possible by disabling the "modal" option for Dialog. This option was triggerring some event hijacking the user input as soon as "mousedown" event is fired on the <select> of the Bootbox, resulting in the <select> dropdown menu closing as soon as it appears.

Pros: Firefox support!
Cons: This is only a workaround as it does not show the background semi-opaque layer anymore. I can't reproduce it on my own testcase (http://testcase.watercooled.org/firefox-bootbox-jquery-ui-dialog/): something else (yet another pluging?) must be messing with the Bootbox and the Dialog... This commit is to be reverted as soon as a long term fix is found.