### PR TITLE
Correction expression régulière

### DIFF
--- a/core/class/scenarioExpression.class.php
+++ b/core/class/scenarioExpression.class.php
@@ -824,7 +824,7 @@ class scenarioExpression {
 
 	public static function getRequestTags($_expression) {
 		$return = array();
-		preg_match_all("/#([a-zA-Z]*)#/", $_expression, $matches);
+		preg_match_all("/#([a-zA-Z]*(12)?)#/", $_expression, $matches);
 		if (count($matches) == 0) {
 			return $return;
 		}


### PR DESCRIPTION
Avec la précédente expression régulière, le tag #heure12# ne fonctionnait pas.
J'ai essayé de tester différentes combinaisons et ça à l'air de matcher correctement (mais je ne suis pas expert en ER).