### PR TITLE
Fix table body which is filled indefinitely

### DIFF
--- a/desktop/js/update.js
+++ b/desktop/js/update.js
@@ -205,6 +205,7 @@ function printUpdate() {
         },
         success: function (data) {
             $('#table_update tbody').empty();
+            $('#table_updateOther tbody').empty();
             for (var i in data) {
                 addUpdate(data[i]);
             }


### PR DESCRIPTION
Bonjour,

Voici un correctif pour un petit bug dans le centre de mise à jour. La table de l'onglet "Autres" (pour les objets non plugins et non core) se remplit indéfiniment à chaque rafraichissement.

Il manque juste ce petit correctif.