### PR TITLE
With booleans, only strict comparison

### DIFF
--- a/core/class/eqLogic.class.php
+++ b/core/class/eqLogic.class.php
@@ -763,7 +763,7 @@ class eqLogic {
 			$this->batteryStatus();
 		}
 		if ($this->_timeoutUpdated) {
-			if ($this->getTimeout() == null) {
+			if ($this->getTimeout() === null) {
 				foreach (message::byPluginLogicalId('core', 'noMessage' . $this->getId()) as $message) {
 					$message->remove();
 				}


### PR DESCRIPTION
(with === operator) should be used to lower bug risks and to improve performances.