### PR TITLE
Ajout d'un handler pour les erreurs et execeptions

### DIFF
--- a/core/php/core.inc.php
+++ b/core/php/core.inc.php
@@ -29,6 +29,9 @@ include_file('core', 'compatibility', 'config');
 include_file('core', 'utils', 'class');
 include_file('core', 'log', 'class');
 
+use Symfony\Component\Debug\ErrorHandler;
+use Symfony\Component\Debug\ExceptionHandler;
+
 try {
 	$configs = config::byKeys(array('timezone', 'log::level'));
 	if (isset($configs['timezone'])) {


### PR DESCRIPTION
Ce handler est transparent, il ne se déclenche que une erreur ou une exception n'est pas attrapé. Il n’interférè pas avec le code existant.
Et à la fin on a une page de présentation du problème très éfficace et... j'ose... belle.