### PR TITLE
Bugfix Static method should not contain $this

### DIFF
--- a/core/class/user.class.php
+++ b/core/class/user.class.php
@@ -311,8 +311,12 @@ class user {
 
 	/*     * *********************Méthodes d'instance************************* */
 
+	/**
+         * 
+         * @throws Exception
+         */
 	public static function preInsert() {
-		if (count(self::byLogin($this->getLogin())) > 0) {
+		if (count(self::byLogin(self::getLogin())) > 0) {
 			throw new Exception(__('Ce nom d\'utilisateur est déja pris', __FILE__));
 		}
 	}


### PR DESCRIPTION
Using $this in static method causes a runtime error. You should use self or static instead.