### PR TITLE
fix : lien vers "Premiers pas avec Jeedom" en 404

### DIFF
--- a/desktop/modal/first.use.php
+++ b/desktop/modal/first.use.php
@@ -24,7 +24,7 @@ if (!isConnect()) {
 </div>
 <div class="col-xs-4">
    <center>
-    <a href="https://jeedom.com/doc/documentation/premiers-pas/fr_FR/doc-premiers-pas.html" target="_blank">
+    <a href="https://jeedom.github.io/documentation/premiers-pas/fr_FR/index.html" target="_blank">
         <i class="fa fa-check-square" style="font-size:12em;"></i><br/>
         {{Documentation de démarrage}}
     </a>

--- a/desktop/php/dashboard.php
+++ b/desktop/php/dashboard.php
@@ -12,7 +12,7 @@ if (!is_object($object)) {
 	$object = object::rootObject();
 }
 if (!is_object($object)) {
-	throw new Exception('{{Aucun objet racine trouvé. Pour en créer un, allez dans Outils -> Objet.<br/> Si vous ne savez pas quoi faire ou que c\'est la première fois que vous utilisez Jeedom n\'hésitez pas à consulter cette <a href="https://jeedom.com/doc/documentation/premiers-pas/fr_FR/doc-premiers-pas.html" target="_blank">page</a> et celle-là si vous avez un pack : <a href="https://jeedom.com/start" target="_blank">page</a>}}');
+	throw new Exception('{{Aucun objet racine trouvé. Pour en créer un, allez dans Outils -> Objet.<br/> Si vous ne savez pas quoi faire ou que c\'est la première fois que vous utilisez Jeedom n\'hésitez pas à consulter cette <a href="https://jeedom.github.io/documentation/premiers-pas/fr_FR/index.html" target="_blank">page</a> et celle-là si vous avez un pack : <a href="https://jeedom.com/start" target="_blank">page</a>}}');
 }
 $child_object = object::buildTree($object);
 ?>


### PR DESCRIPTION
Le lien vers la doc est mort, c'est très frustrant de tomber sur une page 404 lorsque l'on souhaite découvrir les fonctionnalités :)

je l'ai remplacé par celui présent sur la documentation hébergée sur github 