### PR TITLE
Update scenarioElement.class.php

### DIFF
--- a/core/class/scenarioElement.class.php
+++ b/core/class/scenarioElement.class.php
@@ -224,7 +224,7 @@ class scenarioElement {
 				$next = strtotime('+ ' . $time . ' min');
 				$cron->setSchedule(cron::convertDateToCron($next));
 				$cron->save();
-				$_scenario->setLog(__('Tâche : ', __FILE__) . $this->getId() . __(' programmé à : ', __FILE__) . date('Y-m-d H:i:00', $next) . ' (+ ' . $time . ' min)');
+				$_scenario->setLog(__('Tâche : ', __FILE__) . $this->getId() . __(' programmé à : ', __FILE__) . date('Y-m-d H:i:s', $next) . ' (+ ' . $time . ' min)');
 			}
 			return true;
 		} else if ($this->getType() == 'at') {


### PR DESCRIPTION
affiche dans le log les secondes calculées de l'heure de lancement de la tâche et non systématiquement 00 car le CRON va tenir compte des secondes même si on ne peut programmer qu'avec un pas entier de minutes (dans les tests, on s'aperçoit même qu'il y a un léger retard de quelques secondes pour l'exécution de la tâche par rapport à l'heure programmée)