### PR TITLE
eqLogic si an abstract class

### DIFF
--- a/core/class/eqLogic.class.php
+++ b/core/class/eqLogic.class.php
@@ -19,7 +19,7 @@
 /* * ***************************Includes********************************* */
 require_once dirname(__FILE__) . '/../../core/php/core.inc.php';
 
-class eqLogic {
+abstract class eqLogic {
 	/*     * *************************Attributs****************************** */
 	const UIDDELIMITER = '__';
 	protected $id;


### PR DESCRIPTION
Pour l'utiliser, on ne dois jamais faire un new  eqLogic(), on doit toujours l'étendre donc c'est une class abstraite de fait. Autant le signaler clairement