### PR TITLE
Strict comparaison for boolean

### DIFF
--- a/desktop/modal/eqLogic.configure.php
+++ b/desktop/modal/eqLogic.configure.php
@@ -312,7 +312,7 @@ foreach (jeedom::getConfiguration('eqLogic:displayType') as $key => $value) {
 				if (is_array($parameter['allow_displayType']) && !in_array($key, $parameter['allow_displayType'])) {
 					continue;
 				}
-				if ($parameter['allow_displayType'] == false) {
+				if ($parameter['allow_displayType'] === false) {
 					continue;
 				}
 				$default = '';


### PR DESCRIPTION
With booleans, only strict comparison (with === operator) should be used to lower bug risks and to improve performances.