### PR TITLE
Allow direct link to a specific tab hash on administration panel

### DIFF
--- a/desktop/js/administration.js
+++ b/desktop/js/administration.js
@@ -678,3 +678,14 @@ function saveObjectSummary() {
         }
     });
 }
+
+//https://stackoverflow.com/questions/7862233/twitter-bootstrap-tabs-go-to-specific-tab-on-page-reload-or-hyperlink
+// Javascript to enable link to tab
+var url = document.location.toString();
+if (url.match('#')) {
+    $('.nav-tabs a[href="#' + url.split('#')[1] + '"]').tab('show');
+} 
+// Change hash for page-reload
+$('.nav-tabs a').on('shown.bs.tab', function (e) {
+    window.location.hash = e.target.hash;
+})


### PR DESCRIPTION
Based on this SO [twitter-bootstrap-tabs-go-to-specific-tab-on-page-reload-or-hyperlink](https://stackoverflow.com/questions/7862233/twitter-bootstrap-tabs-go-to-specific-tab-on-page-reload-or-hyperlink)

Allow to directly open a tab by adding a hash to the url
Example : window.location.assign("index.php?v=d&p=administration#networktab");