### PR TITLE
Interact - Some logs in INFO instead of DEBUG

### DIFF
--- a/core/class/interactQuery.class.php
+++ b/core/class/interactQuery.class.php
@@ -542,7 +542,7 @@ class interactQuery {
 				if (isset($cmds[0]) && isset($cmds[0]['cmd'])) {
 					self::addLastInteract(str_replace('#', '', $cmds[0]['cmd']), $_parameters['identifier']);
 				}
-				log::add('interact', 'info', 'J\'ai reçu : ' . $_query . ".J'ai compris : " . $interactQuery->getQuery() . ".J'ai répondu : " . $reply);
+				log::add('interact', 'info', 'J\'ai reçu : ' . $_query . ". J'ai compris : " . $interactQuery->getQuery() . ". J'ai répondu : " . $reply);
 				return array('reply' => ucfirst($reply));
 			}
 		}
@@ -552,7 +552,7 @@ class interactQuery {
 		}
 		if ($reply == '' && config::byKey('interact::noResponseIfEmpty', 'core', 0) == 0 && (!isset($_parameters['emptyReply']) || $_parameters['emptyReply'] == 0)) {
 			$reply = self::dontUnderstand($_parameters);
-			log::add('interact', 'info', 'J\'ai reçu : ' . $_query . ".Je n'ai rien compris. J'ai répondu : " . $reply);
+			log::add('interact', 'info', 'J\'ai reçu : ' . $_query . ". Je n'ai rien compris. J'ai répondu : " . $reply);
 		}
 		if (!is_array($reply)) {
 			$reply = array('reply' => ucfirst($reply));

--- a/core/class/interactQuery.class.php
+++ b/core/class/interactQuery.class.php
@@ -532,7 +532,7 @@ class interactQuery {
 		if ($reply == '') {
 			$reply = self::pluginReply($_query, $_parameters);
 			if ($reply !== null) {
-				log::add('interact', 'debug', 'J\'ai reçu : ' . $_query . '. Un plugin a répondu : ' . print_r($reply, true));
+				log::add('interact', 'info', 'J\'ai reçu : ' . $_query . '. Un plugin a répondu : ' . print_r($reply, true));
 				return $reply;
 			}
 			$interactQuery = interactQuery::recognize($_query);
@@ -542,7 +542,7 @@ class interactQuery {
 				if (isset($cmds[0]) && isset($cmds[0]['cmd'])) {
 					self::addLastInteract(str_replace('#', '', $cmds[0]['cmd']), $_parameters['identifier']);
 				}
-				log::add('interact', 'debug', 'J\'ai reçu : ' . $_query . ".J'ai compris : " . $interactQuery->getQuery() . ".J'ai répondu : " . $reply);
+				log::add('interact', 'info', 'J\'ai reçu : ' . $_query . ".J'ai compris : " . $interactQuery->getQuery() . ".J'ai répondu : " . $reply);
 				return array('reply' => ucfirst($reply));
 			}
 		}
@@ -552,12 +552,12 @@ class interactQuery {
 		}
 		if ($reply == '' && config::byKey('interact::noResponseIfEmpty', 'core', 0) == 0 && (!isset($_parameters['emptyReply']) || $_parameters['emptyReply'] == 0)) {
 			$reply = self::dontUnderstand($_parameters);
-			log::add('interact', 'debug', 'J\'ai reçu : ' . $_query . ".Je n'ai rien compris. J'ai répondu : " . $reply);
+			log::add('interact', 'info', 'J\'ai reçu : ' . $_query . ".Je n'ai rien compris. J'ai répondu : " . $reply);
 		}
 		if (!is_array($reply)) {
 			$reply = array('reply' => ucfirst($reply));
 		}
-		log::add('interact', 'debug', 'J\'ai reçu : ' . $_query . ". Je réponds : " . print_r($reply, true));
+		log::add('interact', 'info', 'J\'ai reçu : ' . $_query . ". Je réponds : " . print_r($reply, true));
 		if (isset($_parameters['reply_cmd']) && is_object($_parameters['reply_cmd']) && isset($_parameters['force_reply_cmd'])) {
 			$_parameters['reply_cmd']->execCmd(array('message' => $reply['reply']));
 			return true;


### PR DESCRIPTION
Bonjour,
Avec la multiplication des possibilité d'Interaction Alexa, Google Home, Siri, Javris... il peut être nécessaire de voir ce qui a été envoyé au moteur d'interaction, sans avoir besoin de parser 300 lignes de débug.
Je suggère de passer le log de certains retour actuellement en DEBUG en INFO, afin de plus facilement pouvoir s'y retrouver.
En passant, super taff avec Jeedom, je suis fan ;)

Hi,
As voice assistants continue to populate our houses (Alexa, Google Home, Siri, Javris...), we may need to have a better look at what is sent to Jeedom Interaction Engine.
I suggest that some "result" logs switch from DEBUG to INFO in order to improve visibility.
Very nice work btw :)