### PR TITLE
correct display of string containing " such as JSON content

### DIFF
--- a/core/template/dashboard/cmd.info.string.default.html
+++ b/core/template/dashboard/cmd.info.string.default.html
@@ -11,6 +11,6 @@
 				$('.cmd[data-cmd_id=#id#]').addClass('label label-danger');
 			}
 		}
-		jeedom.cmd.update['#id#']({display_value:"#state#",valueDate:'#valueDate#',collectDate:'#collectDate#',alertLevel:'#alertLevel#'});
+		jeedom.cmd.update['#id#']({display_value:'#state#',valueDate:'#valueDate#',collectDate:'#collectDate#',alertLevel:'#alertLevel#'});
 	</script>
 </div>


### PR DESCRIPTION
JSON string are not displayed (field is empty) on the desktop dashboard by the default core template.
They are correctly displayed on the mobile dashboard, and on the desktop dashboard using the tile core template.
The proposed modification aligns all the string templates.