### PR TITLE
remove PHP WARNING function statechangesbetween when using 3 args (cm…

### DIFF
--- a/core/class/scenarioExpression.class.php
+++ b/core/class/scenarioExpression.class.php
@@ -480,7 +480,7 @@ class scenarioExpression {
 		return history::stateChanges($cmd_id, $_value, $startHist, date('Y-m-d H:i:s'));
 	}
 
-	public static function stateChangesBetween($_cmd_id, $_value, $_startDate, $_endDate) {
+	public static function stateChangesBetween($_cmd_id, $_value, $_startDate, $_endDate = null) {
 		if (!is_numeric(str_replace('#', '', $_cmd_id))) {
 			$cmd = cmd::byId(str_replace('#', '', cmd::humanReadableToCmd($_cmd_id)));
 		} else { $cmd = cmd::byId(str_replace('#', '', $_cmd_id));}


### PR DESCRIPTION
…d+start+end)


Exemple de condition :
SI stateChangesBetween(#[Cuisine][Volet][Etat]#,7:00,10:00) == 0 

=> on retrouve dans le log Scenario_execution : 
PHP Warning: Missing argument 4 for scenarioExpression::stateChangesBetween() in /var/www/html/core/class/scenarioExpression.class.php on line 491