### PR TITLE
improve cache-control on apache

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -35,15 +35,23 @@ Options -Indexes
 </IfModule>
 
 <IfModule mod_headers.c>
-	<FilesMatch "\.(css|js|png|jpeg|jpg|ttf|woff)$">
-		Header set Cache-Control "max-age=7200"
+	<FilesMatch "\.(css|js|png|jpeg|jpg|ttf|woff|woff2|svg)$">
+		Header merge Cache-Control public
+		ExpiresDefault "access plus 2 hours"
 	</FilesMatch>
-	<FilesMatch ".*(getResources.php)">
-		Header set Cache-Control "max-age=7200"
+	<FilesMatch ".*(getResource.php)">
+		Header merge Cache-Control public
+		ExpiresDefault "access plus 2 hours"
 	</FilesMatch>
 	<FilesMatch ".*(getJS.php)">
-		Header set Cache-Control "max-age=7200"
+		Header merge Cache-Control public
+		ExpiresDefault "access plus 2 hours"
 	</FilesMatch>
+	<If "%{QUERY_STRING} =~ /(md5=.+|version=.+|v=[0-9].*)/">
+		ExpiresDefault "access plus 1 year"
+		Header merge Cache-Control public
+		Header merge Cache-Control immutable
+	</If>
 </IfModule>
 
 <IfModule mod_mime.c>


### PR DESCRIPTION
1/ Rajout des extensions woff2 et svg pour le cache-control (dans mon installation, il y a ce genre de fichiers)
2/ J’ai l’impression qu’il y a une coquille sur getResource.php (pluriel/singulier)
3/ Utilisation de mod_expires pour une gestion plus aisée, et permettre une « surcharge » de la valeur
4/ Ajout d’une expiration « infini » pour les requêtes contenant une indication de version (md5=, version=, v=) dans la query (j’aurais pu le faire aussi pour les extension du genre fichier.v*.js)