### PR TITLE
make the filter generic + only filter cmds if the cache is set

### DIFF
--- a/core/class/event.class.php
+++ b/core/class/event.class.php
@@ -94,12 +94,12 @@ class event {
 			return $_data;
 		}
 		$return = array('datetime' => $_data['datetime'], 'result' => array());
-		$filters = cache::byKey('mobile::event')->getValue(array());
+		$filters = cache::byKey($_filter.'::event')->getValue(array());
 		foreach ($_data['result'] as $value) {
 			if (isset($_filter::$_listenEvents) && !in_array($value['name'], $_filter::$_listenEvents)) {
 				continue;
 			}
-			if ($value['name'] == 'cmd::update' && !in_array($value['option']['cmd_id'], $filters)) {
+			if (count($filters)>0 && $value['name'] == 'cmd::update' && !in_array($value['option']['cmd_id'], $filters)) {
 				continue;
 			}
 			$return['result'][] = $value;


### PR DESCRIPTION
Here is a proposal about making the cmd list in cache more generic for all plugins 

and only filter if there is actual cmds in that cache var