### PR TITLE
Skyline-ch : ldap compatibilité synology

### DIFF
--- a/core/class/user.class.php
+++ b/core/class/user.class.php
@@ -60,12 +60,14 @@ class user {
 				$ad = ldap_connect(config::byKey('ldap:host'), config::byKey('ldap:port'));
 				ldap_set_option($ad, LDAP_OPT_PROTOCOL_VERSION, 3);
 				ldap_set_option($ad, LDAP_OPT_REFERRALS, 0);
-				if (!ldap_bind($ad, 'uid=' . $_login . ',' . config::byKey('ldap:basedn'), $_mdp)) {
+				$sLink_identifier = '=' . $_login . config::byKey('ldap::complement') . ',' . config::byKey('ldap:basedn');
+				log::add("connection", "debug", __('$sLink_identifier : ', __FILE__).$sLink_identifier);
+				if (!ldap_bind($ad, "uid" . $sLink_identifier, $_mdp)) {
 					log::add("connection", "info", __('Mot de passe erroné (', __FILE__) . $_login . ')');
 					return false;
 				}
 				log::add("connection", "debug", __('Bind user OK', __FILE__));
-				$result = ldap_search($ad, config::byKey('ldap::usersearch') . '=' . $_login . ',' . config::byKey('ldap:basedn'), config::byKey('ldap:filter'));
+				$result = ldap_search($ad, config::byKey('ldap::usersearch') . $sLink_identifier, config::byKey('ldap:filter'));
 				log::add("connection", "info", __('Recherche LDAP (', __FILE__) . $_login . ')');
 				if ($result) {
 					$entries = ldap_get_entries($ad, $result);

--- a/core/class/user.class.php
+++ b/core/class/user.class.php
@@ -60,7 +60,7 @@ class user {
 				$ad = ldap_connect(config::byKey('ldap:host'), config::byKey('ldap:port'));
 				ldap_set_option($ad, LDAP_OPT_PROTOCOL_VERSION, 3);
 				ldap_set_option($ad, LDAP_OPT_REFERRALS, 0);
-				$sLink_identifier = '=' . $_login . config::byKey('ldap::complement') . ',' . config::byKey('ldap:basedn');
+				$sLink_identifier = '=' . $_login . config::byKey('ldap:complement') . ',' . config::byKey('ldap:basedn');
 				log::add("connection", "debug", __('$sLink_identifier : ', __FILE__).$sLink_identifier);
 				if (!ldap_bind($ad, "uid" . $sLink_identifier, $_mdp)) {
 					log::add("connection", "info", __('Mot de passe erroné (', __FILE__) . $_login . ')');

--- a/desktop/php/administration.php
+++ b/desktop/php/administration.php
@@ -426,6 +426,12 @@ echo $CONFIG['db']['password'];
 								<input type="text" class="configKey form-control" data-l1key="ldap::usersearch" />
 							</div>
 						</div>
+                      	<div class="form-group">
+							<label class="col-lg-2 col-md-3 col-sm-4 col-xs-6 control-label">{{Complément}}</label>
+							<div class="col-lg-3 col-md-4 col-sm-5 col-xs-6">
+								<input type="text"  class="configKey form-control" data-l1key="ldap:complement" />
+							</div>
+						</div>
 						<div class="form-group">
 							<label class="col-lg-2 col-md-3 col-sm-4 col-xs-6 control-label">{{Filtre (optionnel)}}</label>
 							<div class="col-lg-3 col-md-4 col-sm-5 col-xs-6">


### PR DESCRIPTION
Ajout d'un champ dans la configuration LDAP pour pouvoir ajouter un complément entre uid=$login et le base DN.

cela permet dans le cas d'un serveur DLAP d'ajouter un manque pour faire fonctionner avec le serveur LDAP de synology.

Situation avant modification pour la valeur Link_identifier : 
exemple : uid=NOM-USER,dc=domaine,dc=home

après modification si accèpter le résultat serais : 
exemple : uid=NOM-USER,cn=users,dc=domaine,dc=home

Syntaxe pour le champ "complément" : 
,cn=users

comme ont peux le voir si dessus il faut que la valeur commence par une "," puis les informations que l'on souhaite ajouter