### PR TITLE
Correction du nom de la function d'affichage des exceptions

### DIFF
--- a/core/ajax/cache.ajax.php
+++ b/core/ajax/cache.ajax.php
@@ -43,5 +43,5 @@ try {
 	throw new Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
 	/*     * *********Catch exeption*************** */
 } catch (Exception $e) {
-	ajax::error(displayExeption($e), $e->getCode());
+	ajax::error(displayException($e), $e->getCode());
 }

--- a/core/ajax/cmd.ajax.php
+++ b/core/ajax/cmd.ajax.php
@@ -367,5 +367,5 @@ try {
 	throw new Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
 	/*     * *********Catch exeption*************** */
 } catch (Exception $e) {
-	ajax::error(displayExeption($e), $e->getCode());
+	ajax::error(displayException($e), $e->getCode());
 }

--- a/core/ajax/config.ajax.php
+++ b/core/ajax/config.ajax.php
@@ -98,6 +98,6 @@ try {
 	throw new Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
 /*     * *********Catch exeption*************** */
 } catch (Exception $e) {
-	ajax::error(displayExeption($e), $e->getCode());
+	ajax::error(displayException($e), $e->getCode());
 }
 ?>

--- a/core/ajax/cron.ajax.php
+++ b/core/ajax/cron.ajax.php
@@ -72,5 +72,5 @@ try {
 
 	/*     * *********Catch exeption*************** */
 } catch (Exception $e) {
-	ajax::error(displayExeption($e), $e->getCode());
+	ajax::error(displayException($e), $e->getCode());
 }

--- a/core/ajax/dataStore.ajax.php
+++ b/core/ajax/dataStore.ajax.php
@@ -84,6 +84,6 @@ try {
 	throw new Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
 	/*     * *********Catch exeption*************** */
 } catch (Exception $e) {
-	ajax::error(displayExeption($e), $e->getCode());
+	ajax::error(displayException($e), $e->getCode());
 }
 ?>

--- a/core/ajax/eqLogic.ajax.php
+++ b/core/ajax/eqLogic.ajax.php
@@ -391,5 +391,5 @@ try {
 	throw new Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
 	/*     * *********Catch exeption*************** */
 } catch (Exception $e) {
-	ajax::error(displayExeption($e), $e->getCode());
+	ajax::error(displayException($e), $e->getCode());
 }

--- a/core/ajax/event.ajax.php
+++ b/core/ajax/event.ajax.php
@@ -33,6 +33,6 @@ try {
 	throw new Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
 /*     * *********Catch exeption*************** */
 } catch (Exception $e) {
-	ajax::error(displayExeption($e), $e->getCode());
+	ajax::error(displayException($e), $e->getCode());
 }
 ?>

--- a/core/ajax/interact.ajax.php
+++ b/core/ajax/interact.ajax.php
@@ -111,5 +111,5 @@ try {
 	throw new Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
 	/*     * *********Catch exeption*************** */
 } catch (Exception $e) {
-	ajax::error(displayExeption($e), $e->getCode());
+	ajax::error(displayException($e), $e->getCode());
 }

--- a/core/ajax/jeedom.ajax.php
+++ b/core/ajax/jeedom.ajax.php
@@ -319,5 +319,5 @@ try {
 	throw new Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
 	/*     * *********Catch exeption*************** */
 } catch (Exception $e) {
-	ajax::error(displayExeption($e), $e->getCode());
+	ajax::error(displayException($e), $e->getCode());
 }

--- a/core/ajax/log.ajax.php
+++ b/core/ajax/log.ajax.php
@@ -48,5 +48,5 @@ try {
 	throw new Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
 	/*     * *********Catch exeption*************** */
 } catch (Exception $e) {
-	ajax::error(displayExeption($e), $e->getCode());
+	ajax::error(displayException($e), $e->getCode());
 }

--- a/core/ajax/message.ajax.php
+++ b/core/ajax/message.ajax.php
@@ -59,5 +59,5 @@ try {
 	throw new Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
 	/*     * *********Catch exeption*************** */
 } catch (Exception $e) {
-	ajax::error(displayExeption($e), $e->getCode());
+	ajax::error(displayException($e), $e->getCode());
 }

--- a/core/ajax/network.ajax.php
+++ b/core/ajax/network.ajax.php
@@ -41,6 +41,6 @@ try {
 	throw new Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
 	/*     * *********Catch exeption*************** */
 } catch (Exception $e) {
-	ajax::error(displayExeption($e), $e->getCode());
+	ajax::error(displayException($e), $e->getCode());
 }
 ?>

--- a/core/ajax/object.ajax.php
+++ b/core/ajax/object.ajax.php
@@ -204,5 +204,5 @@ try {
 	throw new Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
 	/*     * *********Catch exeption*************** */
 } catch (Exception $e) {
-	ajax::error(displayExeption($e), $e->getCode());
+	ajax::error(displayException($e), $e->getCode());
 }

--- a/core/ajax/plan.ajax.php
+++ b/core/ajax/plan.ajax.php
@@ -221,5 +221,5 @@ try {
 	throw new Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
 	/*     * *********Catch exeption*************** */
 } catch (Exception $e) {
-	ajax::error(displayExeption($e), $e->getCode());
+	ajax::error(displayException($e), $e->getCode());
 }

--- a/core/ajax/plugin.ajax.php
+++ b/core/ajax/plugin.ajax.php
@@ -164,6 +164,6 @@ try {
 	throw new Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
 	/*     * *********Catch exeption*************** */
 } catch (Exception $e) {
-	ajax::error(displayExeption($e), $e->getCode());
+	ajax::error(displayException($e), $e->getCode());
 }
 ?>

--- a/core/ajax/repo.ajax.php
+++ b/core/ajax/repo.ajax.php
@@ -128,5 +128,5 @@ try {
 
 	/*     * *********Catch exeption*************** */
 } catch (Exception $e) {
-	ajax::error(displayExeption($e), $e->getCode());
+	ajax::error(displayException($e), $e->getCode());
 }

--- a/core/ajax/report.ajax.php
+++ b/core/ajax/report.ajax.php
@@ -67,5 +67,5 @@ try {
 	throw new Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
 	/*     * *********Catch exeption*************** */
 } catch (Exception $e) {
-	ajax::error(displayExeption($e), $e->getCode());
+	ajax::error(displayException($e), $e->getCode());
 }

--- a/core/ajax/scenario.ajax.php
+++ b/core/ajax/scenario.ajax.php
@@ -395,6 +395,6 @@ try {
 	throw new Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
 	/*     * *********Catch exeption*************** */
 } catch (Exception $e) {
-	ajax::error(displayExeption($e), $e->getCode());
+	ajax::error(displayException($e), $e->getCode());
 }
 ?>

--- a/core/ajax/update.ajax.php
+++ b/core/ajax/update.ajax.php
@@ -175,5 +175,5 @@ try {
 	throw new Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
 	/*     * *********Catch exeption*************** */
 } catch (Exception $e) {
-	ajax::error(displayExeption($e), $e->getCode());
+	ajax::error(displayException($e), $e->getCode());
 }

--- a/core/ajax/user.ajax.php
+++ b/core/ajax/user.ajax.php
@@ -279,6 +279,6 @@ try {
 	throw new Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
 	/*     * *********Catch exeption*************** */
 } catch (Exception $e) {
-	ajax::error(displayExeption($e), $e->getCode());
+	ajax::error(displayException($e), $e->getCode());
 }
 ?>

--- a/core/ajax/view.ajax.php
+++ b/core/ajax/view.ajax.php
@@ -150,6 +150,6 @@ try {
 	throw new Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
 	/*     * *********Catch exeption*************** */
 } catch (Exception $e) {
-	ajax::error(displayExeption($e), $e->getCode());
+	ajax::error(displayException($e), $e->getCode());
 }
 ?>

--- a/core/php/utils.inc.php
+++ b/core/php/utils.inc.php
@@ -198,6 +198,11 @@ function mySqlIsHere() {
 }
 
 function displayExeption($e) {
+    trigger_error('La fonction displayExeption devient displayException', E_USER_DEPRECATED);
+    return displayException($e);
+}
+
+function displayException(Exception $e) {
 	$message = '<span id="span_errorMessage">' . $e->getMessage() . '</span>';
 	if (DEBUG) {
 		$message .= '<a class="pull-right bt_errorShowTrace cursor">Show traces</a>';

--- a/desktop/php/index.php
+++ b/desktop/php/index.php
@@ -465,12 +465,12 @@ try {
 	} catch (Exception $e) {
 		ob_end_clean();
 		echo '<div class="alert alert-danger div_alert">';
-		echo displayExeption($e);
+		echo displayException($e);
 		echo '</div>';
 	} catch (Error $e) {
 		ob_end_clean();
 		echo '<div class="alert alert-danger div_alert">';
-		echo displayExeption($e);
+		echo displayException($e);
 		echo '</div>';
 	}
 	?>

--- a/index.php
+++ b/index.php
@@ -46,12 +46,12 @@ try {
 			} catch (Exception $e) {
 				ob_end_clean();
 				echo '<div class="alert alert-danger div_alert">';
-				echo translate::exec(displayExeption($e), 'desktop/' . init('p') . '.php');
+				echo translate::exec(displayException($e), 'desktop/' . init('p') . '.php');
 				echo '</div>';
 			} catch (Error $e) {
 				ob_end_clean();
 				echo '<div class="alert alert-danger div_alert">';
-				echo translate::exec(displayExeption($e), 'desktop/' . init('p') . '.php');
+				echo translate::exec(displayException($e), 'desktop/' . init('p') . '.php');
 				echo '</div>';
 			}
 		} elseif (isset($_GET['configure'])) {
@@ -64,12 +64,12 @@ try {
 			} catch (Exception $e) {
 				ob_end_clean();
 				echo '<div class="alert alert-danger div_alert">';
-				echo translate::exec(displayExeption($e), 'desktop/' . init('p') . '.php');
+				echo translate::exec(displayException($e), 'desktop/' . init('p') . '.php');
 				echo '</div>';
 			} catch (Error $e) {
 				ob_end_clean();
 				echo '<div class="alert alert-danger div_alert">';
-				echo translate::exec(displayExeption($e), 'desktop/' . init('p') . '.php');
+				echo translate::exec(displayException($e), 'desktop/' . init('p') . '.php');
 				echo '</div>';
 			}
 		} else {


### PR DESCRIPTION
Création d'une fonction conservant le nom afin de conserver la compatibilité tout en indiquant que la fonction est dépréciée dans les logs.
Intégration de la PR de ColonelMoutarde https://github.com/jeedom/core/pull/970
Remplacement dans le code de toutes les occurrences de displayExeption en displayException.