### PR TITLE
Update init.sh

### DIFF
--- a/install/OS_specific/Docker/init.sh
+++ b/install/OS_specific/Docker/init.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 echo 'Start init'
 
+if ! [ -f /.dockerinit ]; then
+	touch /.dockerinit
+	chmod 755 /.dockerinit
+fi
+
 if [ -z ${ROOT_PASSWORD} ]; then
 	ROOT_PASSWORD=$(cat /dev/urandom | tr -cd 'a-f0-9' | head -c 20)
 	echo "Use generate password : ${ROOT_PASSWORD}"


### PR DESCRIPTION
Sur certain docker managers (exemple unRaid DockerMAN), dockerinit n'est pas créé, et jeedom.class.php ne détecte pas le système Docker correctement et reste sur DIY.

Cela pose des problèmes de lancement de démons ou autre, basés sur jeedom::getHardwareName().