### PR TITLE
renomage de jeeObject en JeeObject

### DIFF
--- a/core/class/jeeObject.class.php
+++ b/core/class/jeeObject.class.php
@@ -19,7 +19,7 @@
 /* * ***************************Includes********************************* */
 require_once dirname(__FILE__) . '/../../core/php/core.inc.php';
 
-class jeeObject {
+class JeeObject {
 	/*     * *************************Attributs****************************** */
 
 	private $id;


### PR DESCRIPTION
Il faudrait faire de même sur toutes les occurrences pour se rapprocher du standard PSR-2. iL faut aussi changer le nom du fichier