### PR TITLE
strict comparison

### DIFF
--- a/core/class/eqLogic.class.php
+++ b/core/class/eqLogic.class.php
@@ -926,7 +926,7 @@ class eqLogic {
 			$this->batteryStatus();
 		}
 		if ($this->_timeoutUpdated) {
-			if ($this->getTimeout() == null) {
+			if ($this->getTimeout() === null) {
 				foreach (message::byPluginLogicalId('core', 'noMessage' . $this->getId()) as $message) {
 					$message->remove();
 				}
@@ -1103,7 +1103,7 @@ class eqLogic {
 	}
 
 	public function hasRight($_right, $_user = null) {
-		if ($_user != null) {
+		if ($_user !== null) {
 			if ($_user->getProfils() == 'admin' || $_user->getProfils() == 'user') {
 				return true;
 			}


### PR DESCRIPTION
With booleans and null, only strict comparison (with === operator) should be used to lower bug risks and to improve performances.