### PR TITLE
bugfix checkAllUpdate creating new core update

### DIFF
--- a/core/class/update.class.php
+++ b/core/class/update.class.php
@@ -65,7 +65,7 @@ class update {
 				}
 			}
 		}
-		if (!$findCore) {
+		if (!$findCore && ($_filter == '' || $_filter == 'core')) {
 			$update = new update();
 			$update->setType('core');
 			$update->setLogicalId('jeedom');


### PR DESCRIPTION
Lors de l'appel de la fonction checkAllUpdate, si un $_filter est passé, une ligne est insérée automatiquement pour le core dans la table update. Ceci a pour effet de multiplier les cores dans la page de mise à jour.