### PR TITLE
Valeur du fichier default.config.ini ignoré

### DIFF
--- a/core/class/config.class.php
+++ b/core/class/config.class.php
@@ -147,7 +147,7 @@ class config {
 			if (isset($defaultConfiguration[$_plugin][$_key])) {
 				self::$cache[$_plugin . '::' . $_key] = $defaultConfiguration[$_plugin][$_key];
 			}
-			if ($_default !== '') {
+			elseif ($_default !== '') {
 				self::$cache[$_plugin . '::' . $_key] = $_default;
 			}
 		} else {


### PR DESCRIPTION
Si une valeur par défaut est passé à la méthode byKey, la valeur trouvé dans le fichier default.config.ini sera ignorée.