### PR TITLE
Permet d'utiliser #eq_name# (nom de l'équipement) dans l'URL de push global

### DIFF
--- a/core/class/cmd.class.php
+++ b/core/class/cmd.class.php
@@ -1221,6 +1221,7 @@ class cmd {
 			'#cmd_name#' => urlencode($this->getName()),
 			'#cmd_id#' => $this->getId(),
 			'#humanname#' => urlencode($this->getHumanName()),
+			'#eq_name#' => urlencode($this->getEqLogic()->getName()),
 		);
 		$url = str_replace(array_keys($replace), $replace, $url);
 		log::add('event', 'info', __('Appels de l\'URL de push pour la commande ', __FILE__) . $this->getHumanName() . ' : ' . $url);


### PR DESCRIPTION
J'utilise l'URL de push global pour stocker les événements Jeedom et j'avais besoin de récupérer le nom de l'équipement.