### PR TITLE
better rand

### DIFF
--- a/core/class/scenarioExpression.class.php
+++ b/core/class/scenarioExpression.class.php
@@ -147,7 +147,7 @@ class scenarioExpression {
 	/*     * ********************Fonctions utilisées dans le calcul des conditions********************************* */
 
 	public static function rand($_min, $_max) {
-		return rand($_min, $_max);
+		return mt_rand($_min, $_max);
 	}
 
 	public static function randText($_sValue) {


### PR DESCRIPTION
http://php.net/manual/en/function.mt-rand.php

from php Doc

 "Many random number generators of older libcs have dubious or unknown characteristics and are slow. The mt_rand() function is a drop-in replacement for the older rand(). It uses a random number generator with known characteristics using the » Mersenne Twister, which will produce random numbers four times faster than what the average libc rand() provides. "

Je me pose de sérieuses questions sur l'utilité réelle de cette méthode. 