### PR TITLE
throw exception instead of returning obscure error codes

### DIFF
--- a/core/class/history.class.php
+++ b/core/class/history.class.php
@@ -451,13 +451,13 @@ class history {
 		}
 
 		if ($cmd->getIsHistorized() != 1) {
-			return -2;
+			throw new Exception(__('Commande non historisee: ', __FILE__) . $_cmd_id);
 		}
 
 		$histories = array_reverse(history::all($_cmd_id));
 		$c = count($histories);
 		if ($c == 0) {
-			return -1;
+			throw new Exception(__('Historique de commande vide: ', __FILE__) . $_cmd_id);
 		}
 
 		$currentValue = $histories[0]->getValue();


### PR DESCRIPTION
When using these functions, for example in the expression evaluator, we get an exception if the command is not found (which is great), but -1 or -2 if the command is not historized or its history is empty. I think we should throw different exceptions for all these cases, unless the return value is actually used.

Sorry for not going further in my research/commit (other functions need updating) : I'm writing in the Github web interface from a laptop in my basement and I spent 1 hour investigating why I got -1 or -2 answers for some commands! I had to look at the code to understand, hence my commit!