### PR TITLE
Fix bad path and unknown function, not really necessary in that case

### DIFF
--- a/core/class/system.class.php
+++ b/core/class/system.class.php
@@ -32,11 +32,9 @@ class system {
 	/*     * ***********************Methode static*************************** */
 
 	public static function loadCommand() {
-		if (file_exists(dirname(__FILE__) . '/../../config/system_cmd.json')) {
-			$content = file_get_contents(dirname(__FILE__) . '/../../config/system_cmd.json');
-			if (is_json($content)) {
-				self::$_command['custom'] = json_decode($content, true);
-			}
+		if (file_exists(dirname(__FILE__) . '/../config/system_cmd.json')) {
+			$content = file_get_contents(dirname(__FILE__) . '/../config/system_cmd.json');
+			self::$_command['custom'] = json_decode($content, true);
 		}
 		return self::$_command;
 	}


### PR DESCRIPTION
I removed the `is_json` check, because the function is unknown. It is declared in utils.inc.php, but we can't include this file easily, because some functions like `init` are declared in utils.inc.php and in setup.php.

If the file is not really a valid json file, the behavior is still correct, even without the removed check.