### PR TITLE
Using the release branch instead of the stable one

### DIFF
--- a/install/OS_specific/Docker/init.sh
+++ b/install/OS_specific/Docker/init.sh
@@ -41,7 +41,7 @@ if [ -f /var/www/html/core/config/common.config.php ]; then
 else
 	echo 'Start jeedom installation'
 	rm -rf /root/install.sh
-	wget https://raw.githubusercontent.com/jeedom/core/stable/install/install.sh -O /root/install.sh
+	wget https://raw.githubusercontent.com/jeedom/core/release/install/install.sh -O /root/install.sh
 	chmod +x /root/install.sh
 	/root/install.sh -s 6
 fi


### PR DESCRIPTION
The stable branch does not exist (anymore ?) so we should use the release one instead otherwise the page could not be found and the install script is failing.