### PR TITLE
[FIX] préviens moi si "supérieur à" avec Telegram

### DIFF
--- a/core/class/interactQuery.class.php
+++ b/core/class/interactQuery.class.php
@@ -466,7 +466,7 @@ class interactQuery {
 			$listener->addEvent($data['cmd']->getId());
 			$listener->setOption($options);
 			$listener->save(true);
-			return array('reply' => __('C\'est noté : ', __FILE__) . str_replace('#value#', $data['cmd']->getHumanName(), $test));
+			return array('reply' => __('C\'est noté : ', __FILE__) . htmlspecialchars(str_replace('#value#', $data['cmd']->getHumanName(), $test)));
 		}
 		return null;
 	}


### PR DESCRIPTION
Crash lorsque Jeedom essaye d'envoyer le message de confirmation du "préviens moi si" à Telegram quand le test est une comparaison (supérieur ou inférieur).

Jeedom envoie le signe < ou > dans la réponse html à Telegram, exemple : C'est noté : [Cuisine][Capteur][Température] < 18

Telegram renvoie du coup une erreur du type : 
Bad Request: can't parse entities: Unsupported start tag \"\"

Il est nécessaire de transformer les < et > dans la réponse.