### PR TITLE
Correction abréviations des noms des mois français. Fonction date_fr

### DIFF
--- a/core/php/utils.inc.php
+++ b/core/php/utils.inc.php
@@ -644,8 +644,8 @@ function date_fr($date_en) {
 		);
 		$texte_short = array(
 			"Lun", "Mar", "Mer", "Jeu", "Ven", "Sam", "Dim",
-			"Jan", "Fev", "Mar", "Avr", "Mai", "Jui",
-			"Jui", "Aou;", "Sep", "Oct", "Nov", "Dec",
+			"Janv.", "Févr.", "Mars", "Avril", "Mai", "Juin",
+			"Juil.", "Août", "Sept.", "Oct.", "Nov.", "Déc.",
 		);
 		break;
 		case 'de_DE':


### PR DESCRIPTION
Jui et Jui pour juin et juillet
Aou; pour aout
Alignement sur les abréviations du système pour faire comme si les locales étaient correctement installées.
Je me demande si les noms des mois ne devrait pas être complétement en minuscule (comme les locales fr)?