### PR TITLE
Update scenarioElement.class.php: correction si A l’heure actuelle

### DIFF
--- a/core/class/scenarioElement.class.php
+++ b/core/class/scenarioElement.class.php
@@ -242,7 +242,7 @@ class scenarioElement {
 			if (!is_numeric($next) || $next < 0) {
 				throw new Exception(__('Bloc type A : ', __FILE__) . $this->getId() . __(', heure programmée invalide : ', __FILE__) . $next);
 			}
-			if ($next < date('Gi')) {
+			if ($next <= date('Gi')) {
 				$next = str_repeat('0', 4 - strlen($next)) . $next;
 				$next = date('Y-m-d', strtotime('+1 day' . date('Y-m-d'))) . ' ' . substr($next, 0, 2) . ':' . substr($next, 2, 4);
 			} else {


### PR DESCRIPTION
Suite à la suppression du +1 minutes, il y a une erreur si on planifie à l’heure actuelle (il essaye de planifier aujourd’hui et non demain)