### PR TITLE
Modif fonction backup_list()

### DIFF
--- a/core/repo/samba.repo.php
+++ b/core/repo/samba.repo.php
@@ -184,13 +184,12 @@ class repo_samba {
 	public static function backup_list() {
 		$return = array();
 		foreach (self::ls(config::byKey('samba::backup::folder')) as $file) {
-			if ($file['filename'] == '.' || $file['filename'] == '..') {
-				continue;
+			if (!(strpos($file['filename'],'.tar.gz') === false) ) { // Si ça contient .tar.gz, on l'ajoute à l'objet que l'on va retourner
+			  $return[] = $file['filename'];
 			}
-			$return[] = $file['filename'];
 		}
 		return $return;
-	}
+	}	
 	
 	public static function backup_restore($_backup) {
 		$backup_dir = calculPath(config::byKey('backup::path'));


### PR DESCRIPTION
Bonjour,

Je propose une modification de la fonction backup_list() afin qu'elle n'affiche que les fichiers contenant .tar.gz au lieu des dossiers et autres fichiers présent dans le répertoire Samba ou sont déposées les sauvegardes.
J'ai pu le valider en V3.3.29 et V4.0.8

Merci pour la prise en compte
TaG