### PR TITLE
add history statistics tmplmultistate

### DIFF
--- a/core/template/dashboard/cmd.info.numeric.tmplmultistate.html
+++ b/core/template/dashboard/cmd.info.numeric.tmplmultistate.html
@@ -8,6 +8,11 @@
 	<div class="value">
 		<span class="timeCmd label label-default #history#" data-type="info"></span>
 	</div>
+	<div class="cmdStats #hide_history#">
+    		<div class="col-xs-12 center-block">
+      		<span title='Min' class='tooltips'>#minHistoryValue#</span>|<span title='Moyenne' class='tooltips'>#averageHistoryValue#</span>|<span title='Max' class='tooltips'>#maxHistoryValue#</span> <i class="#tendance#"></i>
+    		</div>
+  	</div>
 	<script>
 		jeedom.cmd.update['#id#'] = function(_options){
 			var cmd = $('.cmd[data-cmd_id=#id#]');

--- a/core/template/dashboard/cmd.info.string.tmplmultistate.html
+++ b/core/template/dashboard/cmd.info.string.tmplmultistate.html
@@ -8,6 +8,11 @@
 	<div class="value">
 		<span class="timeCmd label label-default #history#" data-type="info"></span>
 	</div>
+	<div class="cmdStats #hide_history#">
+    		<div class="col-xs-12 center-block">
+      		<span title='Min' class='tooltips'>#minHistoryValue#</span>|<span title='Moyenne' class='tooltips'>#averageHistoryValue#</span>|<span title='Max' class='tooltips'>#maxHistoryValue#</span> <i class="#tendance#"></i>
+    		</div>
+  	</div>
 	<script>
 		jeedom.cmd.update['#id#'] = function(_options){
 			var cmd = $('.cmd[data-cmd_id=#id#]');


### PR DESCRIPTION
Le template multistate offre de nombreuses possibilités sauf celles d'afficher les statistiques d'historique.
Je propose donc d'ajouter cette possibilité - pour le moment uniquement sur les templates multistate info/numérique et info/string