### PR TITLE
Refacto ajax response logic

### DIFF
--- a/core/ajax/ajax.handler.inc.php
+++ b/core/ajax/ajax.handler.inc.php
@@ -1,0 +1,17 @@
+<?php
+
+function ajaxHandle($callback)
+{
+    try {
+        require_once __DIR__ . '/../../core/php/core.inc.php';
+        include_file('core', 'authentification', 'php');
+
+        if (!headers_sent()) {
+            header('Content-Type: application/json');
+        }
+
+        echo ajax::getResponse($callback());
+    } catch (Exception $e) {
+        echo ajax::getResponse(displayException($e), $e->getCode());
+    }
+}

--- a/core/ajax/cache.ajax.php
+++ b/core/ajax/cache.ajax.php
@@ -1,5 +1,8 @@
 <?php
 
+/** @entrypoint */
+/** @ajax */
+
 /* This file is part of Jeedom.
 *
 * Jeedom is free software: you can redistribute it and/or modify
@@ -16,40 +19,34 @@
 * along with Jeedom. If not, see <http://www.gnu.org/licenses/>.
 */
 
-try {
-	require_once __DIR__ . '/../../core/php/core.inc.php';
-	include_file('core', 'authentification', 'php');
-	
-	if (!isConnect('admin')) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__), -1234);
-	}
-	
-	ajax::init(true);
-	
+require_once __DIR__ . '/ajax.handler.inc.php';
+
+ajaxHandle(function ()
+{
+    ajax::checkAccess('admin');
+
 	if (init('action') == 'flush') {
 		unautorizedInDemo();
 		cache::flush();
-		ajax::success();
+		return '';
 	}
 	
 	if (init('action') == 'flushWidget') {
 		unautorizedInDemo();
 		cache::flushWidget();
-		ajax::success();
+		return '';
 	}
 	
 	if (init('action') == 'clean') {
 		unautorizedInDemo();
 		cache::clean();
-		ajax::success();
+		return '';
 	}
 	
 	if (init('action') == 'stats') {
-		ajax::success(cache::stats());
+		return cache::stats();
 	}
 	
 	throw new Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
 	/*     * *********Catch exeption*************** */
-} catch (Exception $e) {
-	ajax::error(displayException($e), $e->getCode());
-}
+});

--- a/core/ajax/cmd.ajax.php
+++ b/core/ajax/cmd.ajax.php
@@ -1,5 +1,8 @@
 <?php
 
+/** @entrypoint */
+/** @ajax */
+
 /* This file is part of Jeedom.
 *
 * Jeedom is free software: you can redistribute it and/or modify
@@ -16,16 +19,11 @@
 * along with Jeedom. If not, see <http://www.gnu.org/licenses/>.
 */
 
-try {
-	require_once __DIR__ . '/../../core/php/core.inc.php';
-	include_file('core', 'authentification', 'php');
+require_once __DIR__ . '/ajax.handler.inc.php';
 
-	if (!isConnect()) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__));
-	}
-
-	ajax::init();
-
+ajaxHandle(function ()
+{
+    ajax::checkAccess('');
 	if (init('action') == 'toHtml') {
 		if (init('ids') != '') {
 			$return = array();
@@ -39,7 +37,7 @@ try {
 					'id' => $cmd->getId(),
 				);
 			}
-			ajax::success($return);
+			return $return;
 		} else {
 			$cmd = cmd::byId(init('id'));
 			if (!is_object($cmd)) {
@@ -48,7 +46,7 @@ try {
 			$info_cmd = array();
 			$info_cmd['id'] = $cmd->getId();
 			$info_cmd['html'] = $cmd->toHtml(init('version'), init('option'), init('cmdColor', null));
-			ajax::success($info_cmd);
+			return $info_cmd;
 		}
 	}
 
@@ -63,7 +61,7 @@ try {
 			$cmd->setIsVisible(init('isVisible'));
 			$cmd->save(true);
 		}
-		ajax::success();
+		return '';
 	}
 
 	if (init('action') == 'execCmd') {
@@ -85,7 +83,7 @@ try {
 			if (init('utid') != '') {
 				$options['utid'] = init('utid');
 			}
-			ajax::success($cmd->execCmd($options));
+			return $cmd->execCmd($options);
 		}
 
 	if (init('action') == 'getByObjectNameEqNameCmdName') {
@@ -93,7 +91,7 @@ try {
 		if (!is_object($cmd)) {
 			throw new Exception(__('Cmd inconnu : ', __FILE__) . init('object_name') . '/' . init('eqLogic_name') . '/' . init('cmd_name'));
 		}
-		ajax::success($cmd->getId());
+		return $cmd->getId();
 	}
 
 	if (init('action') == 'getByObjectNameCmdName') {
@@ -101,7 +99,7 @@ try {
 		if (!is_object($cmd)) {
 			throw new Exception(__('Cmd inconnu : ', __FILE__) . init('object_name') . '/' . init('cmd_name'), 9999);
 		}
-		ajax::success(utils::o2a($cmd));
+		return utils::o2a($cmd);
 	}
 
 	if (init('action') == 'byId') {
@@ -109,23 +107,19 @@ try {
 		if (!is_object($cmd)) {
 			throw new Exception(__('Commande inconnue : ', __FILE__) . init('id'), 9999);
 		}
-		ajax::success(jeedom::toHumanReadable(utils::o2a($cmd)));
+		return jeedom::toHumanReadable(utils::o2a($cmd));
 	}
 
 	if (init('action') == 'copyHistoryToCmd') {
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+        ajax::checkAccess('admin');
 		unautorizedInDemo();
-		ajax::success(history::copyHistoryToCmd(init('source_id'), init('target_id')));
+		return history::copyHistoryToCmd(init('source_id'), init('target_id'));
 	}
 
 	if (init('action') == 'replaceCmd') {
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+        ajax::checkAccess('admin');
 		unautorizedInDemo();
-		ajax::success(jeedom::replaceTag(array('#' . str_replace('#', '', init('source_id')) . '#' => '#' . str_replace('#', '', init('target_id')) . '#')));
+		return jeedom::replaceTag(array('#' . str_replace('#', '', init('source_id')) . '#' => '#' . str_replace('#', '', init('target_id')) . '#'));
 	}
 
 	if (init('action') == 'byHumanName') {
@@ -134,13 +128,11 @@ try {
 		if (!is_object($cmd)) {
 			throw new Exception(__('Commande inconnue : ', __FILE__) . init('humanName'), 9999);
 		}
-		ajax::success(utils::o2a($cmd));
+		return utils::o2a($cmd);
 	}
 
 	if (init('action') == 'usedBy') {
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+        ajax::checkAccess('admin');
 		$cmd = cmd::byId(init('id'));
 		if (!is_object($cmd)) {
 			throw new Exception(__('Commande inconnue : ', __FILE__) . init('id'), 9999);
@@ -165,15 +157,15 @@ try {
 			$info['link'] = $scenario->getLinkToConfiguration();
 			$return['scenario'][] = $info;
 		}
-		ajax::success($return);
+		return $return;
 	}
 
 	if (init('action') == 'getHumanCmdName') {
-		ajax::success(cmd::cmdToHumanReadable('#' . init('id') . '#'));
+		return cmd::cmdToHumanReadable('#' . init('id') . '#');
 	}
 
 	if (init('action') == 'byEqLogic') {
-		ajax::success(utils::o2a(cmd::byEqLogicId(init('eqLogic_id'))));
+		return utils::o2a(cmd::byEqLogicId(init('eqLogic_id')));
 	}
 
 	if (init('action') == 'getCmd') {
@@ -188,13 +180,11 @@ try {
 		if ($eqLogic->getObject_id() > 0) {
 			$return['object_name'] = $eqLogic->getObject()->getName();
 		}
-		ajax::success($return);
+		return $return;
 	}
 
 	if (init('action') == 'save') {
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+        ajax::checkAccess('admin');
 		unautorizedInDemo();
 		$cmd_ajax = jeedom::fromHumanReadable(json_decode(init('cmd'), true));
 		$cmd = cmd::byId($cmd_ajax['id']);
@@ -203,13 +193,11 @@ try {
 		}
 		utils::a2o($cmd, $cmd_ajax);
 		$cmd->save();
-		ajax::success(utils::o2a($cmd));
+		return utils::o2a($cmd);
 	}
 
 	if (init('action') == 'multiSave') {
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+        ajax::checkAccess('admin');
 		unautorizedInDemo();
 		$cmds = json_decode(init('cmd'), true);
 		foreach ($cmds as $cmd_ajax) {
@@ -220,13 +208,11 @@ try {
 			utils::a2o($cmd, $cmd_ajax);
 			$cmd->save(true);
 		}
-		ajax::success();
+		return '';
 	}
 
 	if (init('action') == 'changeHistoryPoint') {
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+        ajax::checkAccess('admin');
 		unautorizedInDemo();
 		$history = history::byCmdIdDatetime(init('cmd_id'), init('datetime'));
 		if (!is_object($history)) {
@@ -251,7 +237,7 @@ try {
 			$history->setValue($value);
 			$history->save(null, true);
 		}
-		ajax::success();
+		return '';
 	}
 
 	if (init('action') == 'getHistory') {
@@ -389,7 +375,7 @@ try {
 			$data[] = array((strtotime($dateEnd . " UTC") * 1000), $last[1]);
 		}
 		$return['data'] = $data;
-		ajax::success($return);
+		return $return;
 	}
 
 	if (init('action') == 'emptyHistory') {
@@ -402,7 +388,7 @@ try {
 			throw new Exception(__('Commande ID inconnu : ', __FILE__) . init('id'));
 		}
 		$cmd->emptyHistory(init('date'));
-		ajax::success();
+		return '';
 	}
 
 	if (init('action') == 'setOrder') {
@@ -438,7 +424,7 @@ try {
 			}
 			$eqLogic['eqLogic']->save(true);
 		}
-		ajax::success();
+		return '';
 	}
 
 	if (init('action') == 'getDeadCmd') {
@@ -459,11 +445,9 @@ try {
 				$return[$plugin_id]['cmd'] = eqLogic::deadCmdGeneric($plugin_id);
 			}
 		}
-		ajax::success($return);
+		return $return;
 	}
 
 	throw new Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
 	/*     * *********Catch exeption*************** */
-} catch (Exception $e) {
-	ajax::error(displayException($e), $e->getCode());
-}
+});

--- a/core/ajax/cron.ajax.php
+++ b/core/ajax/cron.ajax.php
@@ -1,5 +1,8 @@
 <?php
 
+/** @entrypoint */
+/** @ajax */
+
 /* This file is part of Jeedom.
  *
  * Jeedom is free software: you can redistribute it and/or modify
@@ -16,20 +19,15 @@
  * along with Jeedom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-try {
-	require_once __DIR__ . '/../php/core.inc.php';
-	include_file('core', 'authentification', 'php');
+require_once __DIR__ . '/ajax.handler.inc.php';
 
-	if (!isConnect('admin')) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__));
-	}
-
-	ajax::init();
-
+ajaxHandle(function ()
+{
+    ajax::checkAccess('admin');
 	if (init('action') == 'save') {
 		unautorizedInDemo();
 		utils::processJsonObject('cron', init('crons'));
-		ajax::success();
+		return '';
 	}
 
 	if (init('action') == 'remove') {
@@ -39,7 +37,7 @@ try {
 			throw new Exception(__('Cron id inconnu', __FILE__));
 		}
 		$cron->remove();
-		ajax::success();
+		return '';
 	}
 
 	if (init('action') == 'all') {
@@ -47,7 +45,7 @@ try {
 		foreach ($crons as $cron) {
 			$cron->refresh();
 		}
-		ajax::success(utils::o2a($crons));
+		return utils::o2a($crons);
 	}
 
 	if (init('action') == 'start') {
@@ -57,7 +55,7 @@ try {
 		}
 		$cron->run();
 		sleep(1);
-		ajax::success();
+		return '';
 	}
 
 	if (init('action') == 'stop') {
@@ -67,12 +65,10 @@ try {
 		}
 		$cron->halt();
 		sleep(1);
-		ajax::success();
+		return '';
 	}
 
 	throw new Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
 
 	/*     * *********Catch exeption*************** */
-} catch (Exception $e) {
-	ajax::error(displayException($e), $e->getCode());
-}
+});

--- a/core/ajax/dataStore.ajax.php
+++ b/core/ajax/dataStore.ajax.php
@@ -1,5 +1,8 @@
 <?php
 
+/** @entrypoint */
+/** @ajax */
+
 /* This file is part of Jeedom.
  *
  * Jeedom is free software: you can redistribute it and/or modify
@@ -16,23 +19,18 @@
  * along with Jeedom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-try {
-	require_once __DIR__ . '/../../core/php/core.inc.php';
-	include_file('core', 'authentification', 'php');
+require_once __DIR__ . '/ajax.handler.inc.php';
 
-	if (!isConnect()) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__));
-	}
-
-	ajax::init();
-
+ajaxHandle(function ()
+{
+    ajax::checkAccess('');
 	if (init('action') == 'remove') {
 		$dataStore = dataStore::byId(init('id'));
 		if (!is_object($dataStore)) {
 			throw new Exception(__('Dépôt de données inconnu. Vérifiez l\'ID : ', __FILE__) . init('id'));
 		}
 		$dataStore->remove();
-		ajax::success();
+		return '';
 	}
 
 	if (init('action') == 'save') {
@@ -49,7 +47,7 @@ try {
 		}
 		$dataStore->setValue(init('value'));
 		$dataStore->save();
-		ajax::success();
+		return '';
 	}
 
 	if (init('action') == 'all') {
@@ -82,11 +80,9 @@ try {
 		} else {
 			$return = utils::o2a($dataStore);
 		}
-		ajax::success($return);
+		return $return;
 	}
 
 	throw new Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
 	/*     * *********Catch exeption*************** */
-} catch (Exception $e) {
-	ajax::error(displayException($e), $e->getCode());
-}
+});

--- a/core/ajax/eqLogic.ajax.php
+++ b/core/ajax/eqLogic.ajax.php
@@ -1,5 +1,8 @@
 <?php
 
+/** @entrypoint */
+/** @ajax */
+
 /* This file is part of Jeedom.
 *
 * Jeedom is free software: you can redistribute it and/or modify
@@ -16,16 +19,11 @@
 * along with Jeedom. If not, see <http://www.gnu.org/licenses/>.
 */
 
-try {
-	require_once __DIR__ . '/../../core/php/core.inc.php';
-	include_file('core', 'authentification', 'php');
-	
-	if (!isConnect()) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__));
-	}
-	
-	ajax::init();
-	
+require_once __DIR__ . '/ajax.handler.inc.php';
+
+ajaxHandle(function ()
+{
+    ajax::checkAccess('');
 	if (init('action') == 'getEqLogicObject') {
 		$object = jeeObject::byId(init('object_id'));
 		
@@ -44,7 +42,7 @@ try {
 				$return['eqLogic'][] = $info_eqLogic;
 			}
 		}
-		ajax::success($return);
+		return $return;
 	}
 	
 	if (init('action') == 'byId') {
@@ -52,7 +50,7 @@ try {
 		if (!is_object($eqLogic)) {
 			throw new Exception(__('EqLogic inconnu. Vérifiez l\'ID', __FILE__));
 		}
-		ajax::success(utils::o2a($eqLogic));
+		return utils::o2a($eqLogic);
 	}
 	
 	if (init('action') == 'toHtml') {
@@ -70,7 +68,7 @@ try {
 					'object_id' => $eqLogic->getObject_id(),
 				);
 			}
-			ajax::success($return);
+			return $return;
 		} else {
 			$eqLogic = eqLogic::byId(init('id'));
 			if (!is_object($eqLogic)) {
@@ -81,7 +79,7 @@ try {
 			$info_eqLogic['type'] = $eqLogic->getEqType_name();
 			$info_eqLogic['object_id'] = $eqLogic->getObject_id();
 			$info_eqLogic['html'] = $eqLogic->toHtml(init('version'));
-			ajax::success($info_eqLogic);
+			return $info_eqLogic;
 		}
 	}
 	
@@ -98,7 +96,7 @@ try {
 				'object_id' => $eqLogic->getObject_id(),
 			);
 		}
-		ajax::success($return);
+		return $return;
 	}
 	
 	if (init('action') == 'htmlBattery') {
@@ -121,7 +119,7 @@ try {
 				'object_id' => $eqLogic->getObject_id(),
 			);
 		}
-		ajax::success($return);
+		return $return;
 	}
 	
 	if (init('action') == 'listByType') {
@@ -130,17 +128,17 @@ try {
 			$return[$eqLogic->getId()] = utils::o2a($eqLogic);
 			$return[$eqLogic->getId()]['humanName'] = $eqLogic->getHumanName();
 		}
-		ajax::success(array_values($return));
+		return array_values($return);
 	}
 	
 	if (init('action') == 'listByObjectAndCmdType') {
 		$object_id = (init('object_id') != -1) ? init('object_id') : null;
-		ajax::success(eqLogic::listByObjectAndCmdType($object_id, init('typeCmd'), init('subTypeCmd')));
+		return eqLogic::listByObjectAndCmdType($object_id, init('typeCmd'), init('subTypeCmd'));
 	}
 	
 	if (init('action') == 'listByObject') {
 		$object_id = (init('object_id') != -1) ? init('object_id') : null;
-		ajax::success(utils::o2a(eqLogic::byObjectId($object_id, init('onlyEnable', true), init('onlyVisible', false), init('eqType_name', null), init('logicalId', null), init('orderByName', false))));
+		return utils::o2a(eqLogic::byObjectId($object_id, init('onlyEnable', true), init('onlyVisible', false), init('eqType_name', null), init('logicalId', null), init('orderByName', false)));
 	}
 	
 	if (init('action') == 'listByTypeAndCmdType') {
@@ -158,14 +156,12 @@ try {
 			}
 			$return[] = $info;
 		}
-		ajax::success($return);
+		return $return;
 	}
 	
 	if (init('action') == 'setIsEnable') {
 		unautorizedInDemo();
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+        ajax::checkAccess('admin');
 		$eqLogic = eqLogic::byId(init('id'));
 		if (!is_object($eqLogic)) {
 			throw new Exception(__('EqLogic inconnu. Vérifiez l\'ID', __FILE__));
@@ -175,7 +171,7 @@ try {
 		}
 		$eqLogic->setIsEnable(init('isEnable'));
 		$eqLogic->save(true);
-		ajax::success();
+		return '';
 	}
 	
 	if (init('action') == 'setOrder') {
@@ -192,7 +188,7 @@ try {
 			utils::a2o($eqLogic, $eqLogic_json);
 			$eqLogic->save(true);
 		}
-		ajax::success();
+		return '';
 	}
 	
 	if (init('action') == 'removes') {
@@ -208,7 +204,7 @@ try {
 			}
 			$eqLogic->remove();
 		}
-		ajax::success();
+		return '';
 	}
 	
 	if (init('action') == 'setIsVisibles') {
@@ -225,7 +221,7 @@ try {
 			$eqLogic->setIsVisible(init('isVisible'));
 			$eqLogic->save(true);
 		}
-		ajax::success();
+		return '';
 	}
 	
 	if (init('action') == 'setIsEnables') {
@@ -242,14 +238,12 @@ try {
 			$eqLogic->setIsEnable(init('isEnable'));
 			$eqLogic->save();
 		}
-		ajax::success();
+		return '';
 	}
 	
 	if (init('action') == 'simpleSave') {
 		unautorizedInDemo();
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+        ajax::checkAccess('admin');
 		$eqLogicSave = json_decode(init('eqLogic'), true);
 		$eqLogic = eqLogic::byId($eqLogicSave['id']);
 		if (!is_object($eqLogic)) {
@@ -261,14 +255,12 @@ try {
 		}
 		utils::a2o($eqLogic, $eqLogicSave);
 		$eqLogic->save();
-		ajax::success();
+		return '';
 	}
 	
 	if (init('action') == 'copy') {
 		unautorizedInDemo();
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+        ajax::checkAccess('admin');
 		$eqLogic = eqLogic::byId(init('id'));
 		if (!is_object($eqLogic)) {
 			throw new Exception(__('EqLogic inconnu. Vérifiez l\'ID', __FILE__));
@@ -276,7 +268,7 @@ try {
 		if (init('name') == '') {
 			throw new Exception(__('Le nom de la copie de l\'équipement ne peut être vide', __FILE__));
 		}
-		ajax::success(utils::o2a($eqLogic->copy(init('name'))));
+		return utils::o2a($eqLogic->copy(init('name')));
 	}
 	
 	if (init('action') == 'getUseBeforeRemove') {
@@ -307,14 +299,12 @@ try {
 				}
 			}
 		}
-		ajax::success($used);
+		return $used;
 	}
 	
 	if (init('action') == 'remove') {
 		unautorizedInDemo();
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+        ajax::checkAccess('admin');
 		$eqLogic = eqLogic::byId(init('id'));
 		if (!is_object($eqLogic)) {
 			throw new Exception(__('EqLogic inconnu. Vérifiez l\'ID ', __FILE__) . init('id'));
@@ -323,7 +313,7 @@ try {
 			throw new Exception(__('Vous n\'êtes pas autorisé à faire cette action', __FILE__));
 		}
 		$eqLogic->remove();
-		ajax::success();
+		return '';
 	}
 	
 	if (init('action') == 'get') {
@@ -337,14 +327,12 @@ try {
 		}
 		$return = utils::o2a($eqLogic);
 		$return['cmd'] = utils::o2a($eqLogic->getCmd());
-		ajax::success(jeedom::toHumanReadable($return));
+		return jeedom::toHumanReadable($return);
 	}
 	
 	if (init('action') == 'save') {
 		unautorizedInDemo();
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+        ajax::checkAccess('admin');
 		
 		$eqLogicsSave = json_decode(init('eqLogic'), true);
 		
@@ -416,7 +404,7 @@ try {
 					throw new Exception($e->getMessage());
 				}
 			}
-			ajax::success(utils::o2a($eqLogic));
+			return utils::o2a($eqLogic);
 		}
 	}
 	
@@ -428,11 +416,9 @@ try {
 			}
 			$alerts[] = $eqLogic->toHtml(init('version'));
 		}
-		ajax::success($alerts);
+		return $alerts;
 	}
 	
 	throw new Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
 	/*     * *********Catch exeption*************** */
-} catch (Exception $e) {
-	ajax::error(displayException($e), $e->getCode());
-}
+});

--- a/core/ajax/event.ajax.php
+++ b/core/ajax/event.ajax.php
@@ -1,5 +1,8 @@
 <?php
 
+/** @entrypoint */
+/** @ajax */
+
 /* This file is part of Jeedom.
  *
  * Jeedom is free software: you can redistribute it and/or modify
@@ -16,22 +19,15 @@
  * along with Jeedom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-try {
-	require_once __DIR__ . '/../../core/php/core.inc.php';
-	include_file('core', 'authentification', 'php');
+require_once __DIR__ . '/ajax.handler.inc.php';
 
-	if (!isConnect()) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__), -1234);
-	}
-
-	ajax::init();
-
+ajaxHandle(function ()
+{
+    ajax::checkAccess('');
 	if (init('action') == 'changes') {
-		ajax::success(event::changes(init('datetime', 0), 59));
+		return event::changes(init('datetime', 0), 59);
 	}
 
 	throw new Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
 /*     * *********Catch exeption*************** */
-} catch (Exception $e) {
-	ajax::error(displayException($e), $e->getCode());
-}
+});

--- a/core/ajax/listener.ajax.php
+++ b/core/ajax/listener.ajax.php
@@ -1,5 +1,8 @@
 <?php
 
+/** @entrypoint */
+/** @ajax */
+
 /* This file is part of Jeedom.
  *
  * Jeedom is free software: you can redistribute it and/or modify
@@ -16,20 +19,15 @@
  * along with Jeedom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-try {
-	require_once __DIR__ . '/../php/core.inc.php';
-	include_file('core', 'authentification', 'php');
+require_once __DIR__ . '/ajax.handler.inc.php';
 
-	if (!isConnect('admin')) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__));
-	}
-
-	ajax::init();
-
+ajaxHandle(function ()
+{
+    ajax::checkAccess('admin');
 	if (init('action') == 'save') {
 		unautorizedInDemo();
 		utils::processJsonObject('listener', init('listeners'));
-		ajax::success();
+		return '';
 	}
 
 	if (init('action') == 'remove') {
@@ -39,7 +37,7 @@ try {
 			throw new Exception(__('Listerner id inconnu', __FILE__));
 		}
 		$listener->remove();
-		ajax::success();
+		return '';
 	}
 
 	if (init('action') == 'all') {
@@ -51,12 +49,10 @@ try {
 			}
 			$listener['event_str'] = jeedom::toHumanReadable(trim($listener['event_str'], ','));
 		}
-		ajax::success($listeners);
+		return $listeners;
 	}
 
 	throw new Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
 
 	/*     * *********Catch exeption*************** */
-} catch (Exception $e) {
-	ajax::error(displayException($e), $e->getCode());
-}
+});

--- a/core/ajax/log.ajax.php
+++ b/core/ajax/log.ajax.php
@@ -1,5 +1,8 @@
 <?php
 
+/** @entrypoint */
+/** @ajax */
+
 /* This file is part of Jeedom.
  *
  * Jeedom is free software: you can redistribute it and/or modify
@@ -16,44 +19,37 @@
  * along with Jeedom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-try {
-	require_once __DIR__ . '/../../core/php/core.inc.php';
-	include_file('core', 'authentification', 'php');
+require_once __DIR__ . '/ajax.handler.inc.php';
 
-	if (!isConnect('admin')) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__));
-	}
-
-	ajax::init();
-
+ajaxHandle(function ()
+{
+    ajax::checkAccess('admin');
 	if (init('action') == 'clear') {
 		unautorizedInDemo();
 		log::clear(init('log'));
-		ajax::success();
+		return '';
 	}
 
 	if (init('action') == 'remove') {
 		unautorizedInDemo();
 		log::remove(init('log'));
-		ajax::success();
+		return '';
 	}
 
 	if (init('action') == 'list') {
-		ajax::success(log::liste());
+		return log::liste();
 	}
 
 	if (init('action') == 'removeAll') {
 		unautorizedInDemo();
 		log::removeAll();
-		ajax::success();
+		return '';
 	}
 
 	if (init('action') == 'get') {
-		ajax::success(log::get(init('log'), init('start', 0), init('nbLine', 99999)));
+		return log::get(init('log'), init('start', 0), init('nbLine', 99999));
 	}
 
 	throw new Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
 	/*     * *********Catch exeption*************** */
-} catch (Exception $e) {
-	ajax::error(displayException($e), $e->getCode());
-}
+});

--- a/core/ajax/message.ajax.php
+++ b/core/ajax/message.ajax.php
@@ -1,5 +1,8 @@
 <?php
 
+/** @entrypoint */
+/** @ajax */
+
 /* This file is part of Jeedom.
  *
  * Jeedom is free software: you can redistribute it and/or modify
@@ -16,23 +19,18 @@
  * along with Jeedom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-try {
-	require_once __DIR__ . '/../../core/php/core.inc.php';
-	include_file('core', 'authentification', 'php');
+require_once __DIR__ . '/ajax.handler.inc.php';
 
-	if (!isConnect()) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__));
-	}
-
-	ajax::init();
-
+ajaxHandle(function ()
+{
+    ajax::checkAccess('');
 	if (init('action') == 'clearMessage') {
 		message::removeAll(init('plugin'));
-		ajax::success();
+		return '';
 	}
 
 	if (init('action') == 'nbMessage') {
-		ajax::success(message::nbMessage());
+		return message::nbMessage();
 	}
 
 	if (init('action') == 'all') {
@@ -44,7 +42,7 @@ try {
 		foreach ($messages as &$message) {
 			$message['message'] = htmlentities($message['message']);
 		}
-		ajax::success($messages);
+		return $messages;
 	}
 
 	if (init('action') == 'removeMessage') {
@@ -53,11 +51,9 @@ try {
 			throw new Exception(__('Message inconnu. Vérifiez l\'ID', __FILE__));
 		}
 		$message->remove();
-		ajax::success();
+		return '';
 	}
 
 	throw new Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
 	/*     * *********Catch exeption*************** */
-} catch (Exception $e) {
-	ajax::error(displayException($e), $e->getCode());
-}
+});

--- a/core/ajax/migrate.ajax.php
+++ b/core/ajax/migrate.ajax.php
@@ -1,5 +1,8 @@
 <?php
 
+/** @entrypoint */
+/** @ajax */
+
 /* This file is part of Jeedom.
  *
  * Jeedom is free software: you can redistribute it and/or modify
@@ -16,62 +19,55 @@
  * along with Jeedom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-try {
-	require_once dirname(__FILE__) . '/../../core/php/core.inc.php';
-	include_file('core', 'authentification', 'php');
+require_once __DIR__ . '/ajax.handler.inc.php';
 
-	if (!isConnect('admin')) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__));
-	}
-
-	ajax::init();
-
+ajaxHandle(function ()
+{
+    ajax::checkAccess('admin');
 	if (init('action') == 'usbTry') {
 		$usbTry = migrate::usbTry();
-		ajax::success($usbTry);
+		return $usbTry;
 	}
 	
 	if (init('action') == 'backupToUsb') {
 		$backupToUsb = migrate::backupToUsb();
-		ajax::success($backupToUsb);
+		return $backupToUsb;
 	}
 	
 	if (init('action') == 'imageToUsb') {
 		$imageToUsb = migrate::imageToUsb();
-		ajax::success($imageToUsb);
+		return $imageToUsb;
 	}
 	
 	if (init('action') == 'freeSpaceUsb') {
 		$freeSpaceUsb = migrate::freeSpaceUsb();
-		ajax::success($freeSpaceUsb);
+		return $freeSpaceUsb;
 	}
 	
 	if (init('action') == 'getStep') {
 		$valueMigrate = config::byKey('stepMigrate');
-		ajax::success($valueMigrate);
+		return $valueMigrate;
 	}
 	
 	if (init('action') == 'setStep') {
 		if(init('stepValues')){
 			config::save('stepMigrate', init('stepValues'));
-			ajax::success(init('stepValues'));
+			return init('stepValues');
 		}
 	}
 	if (init('action') == 'renameImage'){
 		$renameImage = migrate::renameImage();
-		ajax::success($renameImage);
+		return $renameImage;
 	}
 	if (init('action') == 'GoBackupInstall'){
 		$GoBackupInstall = migrate::GoBackupInstall();
-		ajax::success($GoBackupInstall);
+		return $GoBackupInstall;
 	}
 	if (init('action') == 'finalisation'){
 		$finalisation = migrate::finalisation();
-		ajax::success($finalisation);
+		return $finalisation;
 	}
 
 	throw new Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
 	/*     * *********Catch exeption*************** */
-} catch (Exception $e) {
-	ajax::error(displayException($e), $e->getCode());
-}
+});

--- a/core/ajax/network.ajax.php
+++ b/core/ajax/network.ajax.php
@@ -1,5 +1,8 @@
 <?php
 
+/** @entrypoint */
+/** @ajax */
+
 /* This file is part of Jeedom.
  *
  * Jeedom is free software: you can redistribute it and/or modify
@@ -16,32 +19,25 @@
  * along with Jeedom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-try {
-	require_once __DIR__ . '/../../core/php/core.inc.php';
-	include_file('core', 'authentification', 'php');
+require_once __DIR__ . '/ajax.handler.inc.php';
 
-	if (!isConnect('admin')) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__));
-	}
-
-	ajax::init();
-
+ajaxHandle(function ()
+{
+    ajax::checkAccess('admin');
 	if (init('action') == 'restartDns') {
 		unautorizedInDemo();
 		config::save('market::allowDNS', 1);
 		network::dns_start();
-		ajax::success();
+		return '';
 	}
 
 	if (init('action') == 'stopDns') {
 		unautorizedInDemo();
 		config::save('market::allowDNS', 0);
 		network::dns_stop();
-		ajax::success();
+		return '';
 	}
 
 	throw new Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
 	/*     * *********Catch exeption*************** */
-} catch (Exception $e) {
-	ajax::error(displayException($e), $e->getCode());
-}
+});

--- a/core/ajax/note.ajax.php
+++ b/core/ajax/note.ajax.php
@@ -1,5 +1,8 @@
 <?php
 
+/** @entrypoint */
+/** @ajax */
+
 /* This file is part of Jeedom.
  *
  * Jeedom is free software: you can redistribute it and/or modify
@@ -16,33 +19,22 @@
  * along with Jeedom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-try {
+require_once __DIR__ . '/ajax.handler.inc.php';
 
-	require_once __DIR__ . '/../../core/php/core.inc.php';
-	include_file('core', 'authentification', 'php');
-
-	if (!isConnect()) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__));
-	}
-
+ajaxHandle(function ()
+{
 	if (init('action') == 'all') {
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
-		ajax::success(utils::o2a(note::all()));
+        ajax::checkAccess('admin');
+		return utils::o2a(note::all());
 	}
 
 	if (init('action') == 'byId') {
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
-		ajax::success(utils::o2a(note::byId(init('id'))));
+        ajax::checkAccess('admin');
+		return utils::o2a(note::byId(init('id')));
 	}
 
 	if (init('action') == 'save') {
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+        ajax::checkAccess('admin');
 		$note_json = json_decode(init('note'), true);
 		if (isset($note_json['id'])) {
 			$note = note::byId($note_json['id']);
@@ -52,25 +44,21 @@ try {
 		}
 		utils::a2o($note, $note_json);
 		$note->save();
-		ajax::success(utils::o2a($note));
+		return utils::o2a($note);
 	}
 
 	if (init('action') == 'remove') {
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+        ajax::checkAccess('admin');
 		$note = note::byId(init('id'));
 		if (!is_object($note)) {
 			throw new Exception(__('Note inconnue. Vérifiez l\'ID', __FILE__));
 		}
 		$note->remove();
-		ajax::success();
+		return '';
 	}
 
-	ajax::init();
+    ajax::checkAccess('');
 
 	throw new Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
 	/*     * *********Catch exeption*************** */
-} catch (Exception $e) {
-	ajax::error(displayException($e), $e->getCode());
-}
+});

--- a/core/ajax/plan.ajax.php
+++ b/core/ajax/plan.ajax.php
@@ -1,5 +1,8 @@
 <?php
 
+/** @entrypoint */
+/** @ajax */
+
 /* This file is part of Jeedom.
 *
 * Jeedom is free software: you can redistribute it and/or modify
@@ -16,20 +19,13 @@
 * along with Jeedom. If not, see <http://www.gnu.org/licenses/>.
 */
 
-try {
-	require_once __DIR__ . '/../../core/php/core.inc.php';
-	include_file('core', 'authentification', 'php');
-	
-	if (!isConnect()) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__));
-	}
-	
-	ajax::init();
-	
+require_once __DIR__ . '/ajax.handler.inc.php';
+
+ajaxHandle(function ()
+{
+    ajax::checkAccess('');
 	if (init('action') == 'save') {
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+        ajax::checkAccess('admin');
 		unautorizedInDemo();
 		$plans = json_decode(init('plans'), true);
 		foreach ($plans as $plan_ajax) {
@@ -40,7 +36,7 @@ try {
 			utils::a2o($plan, jeedom::fromHumanReadable($plan_ajax));
 			$plan->save();
 		}
-		ajax::success();
+		return '';
 	}
 	
 	if (init('action') == 'execute') {
@@ -48,7 +44,7 @@ try {
 		if (!is_object($plan)) {
 			throw new Exception(__('Aucun plan correspondant', __FILE__));
 		}
-		ajax::success($plan->execute());
+		return $plan->execute();
 	}
 	
 	if (init('action') == 'planHeader') {
@@ -59,30 +55,26 @@ try {
 				$return[] = $result;
 			}
 		}
-		ajax::success($return);
+		return $return;
 	}
 	
 	if (init('action') == 'create') {
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+        ajax::checkAccess('admin');
 		unautorizedInDemo();
 		$plan = new plan();
 		utils::a2o($plan, json_decode(init('plan'), true));
 		$plan->save();
-		ajax::success($plan->getHtml(init('version')));
+		return $plan->getHtml(init('version'));
 	}
 	
 	if (init('action') == 'copy') {
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+		ajax::checkAccess('admin');
 		unautorizedInDemo();
 		$plan = plan::byId(init('id'));
 		if (!is_object($plan)) {
 			throw new Exception(__('Aucun plan correspondant', __FILE__));
 		}
-		ajax::success($plan->copy()->getHtml(init('version', 'dashboard')));
+		return $plan->copy()->getHtml(init('version', 'dashboard'));
 	}
 	
 	if (init('action') == 'get') {
@@ -90,32 +82,28 @@ try {
 		if (!is_object($plan)) {
 			throw new Exception(__('Aucun plan correspondant', __FILE__));
 		}
-		ajax::success($plan->getHtml('dashboard'));
+		return $plan->getHtml('dashboard');
 	}
 	
 	if (init('action') == 'remove') {
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+		ajax::checkAccess('admin');
 		unautorizedInDemo();
 		$plan = plan::byId(init('id'));
 		if (!is_object($plan)) {
 			throw new Exception(__('Aucun plan correspondant', __FILE__));
 		}
-		ajax::success($plan->remove());
+		return $plan->remove();
 	}
 	
 	if (init('action') == 'removePlanHeader') {
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+		ajax::checkAccess('admin');
 		unautorizedInDemo();
 		$planHeader = planHeader::byId(init('id'));
 		if (!is_object($planHeader)) {
 			throw new Exception(__('Objet inconnu. Vérifiez l\'ID', __FILE__));
 		}
 		$planHeader->remove();
-		ajax::success();
+		return '';
 	}
 	
 	if (init('action') == 'allHeader') {
@@ -126,7 +114,7 @@ try {
 			unset($info_planHeader['image']);
 			$return[] = $info_planHeader;
 		}
-		ajax::success($return);
+		return $return;
 	}
 	
 	if (init('action') == 'getPlanHeader') {
@@ -139,13 +127,11 @@ try {
 		}
 		$return = utils::o2a($planHeader);
 		$return['image'] = $planHeader->displayImage();
-		ajax::success($return);
+		return $return;
 	}
 	
 	if (init('action') == 'savePlanHeader') {
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+		ajax::checkAccess('admin');
 		unautorizedInDemo();
 		$planHeader_ajax = json_decode(init('planHeader'), true);
 		$planHeader = null;
@@ -157,25 +143,21 @@ try {
 		}
 		utils::a2o($planHeader, $planHeader_ajax);
 		$planHeader->save();
-		ajax::success(utils::o2a($planHeader));
+		return utils::o2a($planHeader);
 	}
 	
 	if (init('action') == 'copyPlanHeader') {
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+		ajax::checkAccess('admin');
 		unautorizedInDemo();
 		$planHeader = planHeader::byId(init('id'));
 		if (!is_object($planHeader)) {
 			throw new Exception(__('Plan header inconnu. Vérifiez l\'ID ', __FILE__) . init('id'));
 		}
-		ajax::success(utils::o2a($planHeader->copy(init('name'))));
+		return utils::o2a($planHeader->copy(init('name')));
 	}
 	
 	if (init('action') == 'removeImageHeader') {
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+		ajax::checkAccess('admin');
 		unautorizedInDemo();
 		$planHeader = planHeader::byId(init('id'));
 		if (!is_object($planHeader)) {
@@ -185,13 +167,11 @@ try {
 		$planHeader->setImage('sha512', '');
 		$planHeader->save();
 		@unlink( __DIR__ . '/../../data/plan/' . $filename);
-		ajax::success();
+		return '';
 	}
 	
 	if (init('action') == 'uploadImage') {
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+		ajax::checkAccess('admin');
 		unautorizedInDemo();
 		$planHeader = planHeader::byId(init('id'));
 		if (!is_object($planHeader)) {
@@ -226,13 +206,11 @@ try {
 		$planHeader->setConfiguration('desktopSizeX', $img_size[0]);
 		$planHeader->setConfiguration('desktopSizeY', $img_size[1]);
 		$planHeader->save();
-		ajax::success();
+		return '';
 	}
 	
 	if (init('action') == 'uploadImagePlan') {
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+		ajax::checkAccess('admin');
 		unautorizedInDemo();
 		$plan = plan::byId(init('id'));
 		if (!is_object($plan)) {
@@ -262,11 +240,9 @@ try {
 		$plan->setDisplay('height', $img_size[1]);
 		$plan->setDisplay('path', 'data/plan/plan_' . $plan->getId() . '/' . $name);
 		$plan->save();
-		ajax::success();
+		return '';
 	}
 	
 	throw new Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
 	/*     * *********Catch exeption*************** */
-} catch (Exception $e) {
-	ajax::error(displayException($e), $e->getCode());
-}
+});

--- a/core/ajax/plan3d.ajax.php
+++ b/core/ajax/plan3d.ajax.php
@@ -1,5 +1,8 @@
 <?php
 
+/** @entrypoint */
+/** @ajax */
+
 /* This file is part of Jeedom.
  *
  * Jeedom is free software: you can redistribute it and/or modify
@@ -16,20 +19,13 @@
  * along with Jeedom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-try {
-	require_once __DIR__ . '/../../core/php/core.inc.php';
-	include_file('core', 'authentification', 'php');
+require_once __DIR__ . '/ajax.handler.inc.php';
 
-	if (!isConnect()) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__));
-	}
-
-	ajax::init();
-
+ajaxHandle(function ()
+{
+    ajax::checkAccess('');
 	if (init('action') == 'save') {
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+        ajax::checkAccess('admin');
 		unautorizedInDemo();
 		$plan3ds = json_decode(init('plan3ds'), true);
 		foreach ($plan3ds as $plan3d_ajax) {
@@ -40,7 +36,7 @@ try {
 			utils::a2o($plan3d, jeedom::fromHumanReadable($plan3d_ajax));
 			$plan3d->save();
 		}
-		ajax::success();
+		return '';
 	}
 
 	if (init('action') == 'plan3dHeader') {
@@ -50,18 +46,16 @@ try {
 			$info['additionalData'] = $plan3d->additionalData();
 			$return[] = $info;
 		}
-		ajax::success($return);
+		return $return;
 	}
 
 	if (init('action') == 'create') {
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+        ajax::checkAccess('admin');
 		unautorizedInDemo();
 		$plan3d = new plan3d();
 		utils::a2o($plan3d, json_decode(init('plan3d'), true));
 		$plan3d->save();
-		ajax::success($plan3d->getHtml(init('version')));
+		return $plan3d->getHtml(init('version'));
 	}
 
 	if (init('action') == 'get') {
@@ -71,40 +65,36 @@ try {
 		}
 		$return = jeedom::toHumanReadable(utils::o2a($plan3d));
 		$return['additionalData'] = $plan3d->additionalData();
-		ajax::success($return);
+		return $return;
 	}
 
 	if (init('action') == 'byName') {
 		$plan3d = plan3d::byName3dHeaderId(init('name'), init('plan3dHeader_id'));
 		if (!is_object($plan3d)) {
-			ajax::success();
+			return '';
 		}
-		ajax::success($plan3d->getHtml());
+		return $plan3d->getHtml();
 	}
 
 	if (init('action') == 'remove') {
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+        ajax::checkAccess('admin');
 		unautorizedInDemo();
 		$plan3d = plan3d::byId(init('id'));
 		if (!is_object($plan3d)) {
 			throw new Exception(__('Aucun plan3d correspondant', __FILE__));
 		}
-		ajax::success($plan3d->remove());
+		return $plan3d->remove();
 	}
 
 	if (init('action') == 'removeplan3dHeader') {
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+        ajax::checkAccess('admin');
 		unautorizedInDemo();
 		$plan3dHeader = plan3dHeader::byId(init('id'));
 		if (!is_object($plan3dHeader)) {
 			throw new Exception(__('Objet inconnu verifiez l\'id', __FILE__));
 		}
 		$plan3dHeader->remove();
-		ajax::success();
+		return '';
 	}
 
 	if (init('action') == 'allHeader') {
@@ -115,7 +105,7 @@ try {
 			unset($info_plan3dHeader['image']);
 			$return[] = $info_plan3dHeader;
 		}
-		ajax::success($return);
+		return $return;
 	}
 
 	if (init('action') == 'getplan3dHeader') {
@@ -127,13 +117,11 @@ try {
 			throw new Exception(__('Code d\'acces invalide', __FILE__), -32005);
 		}
 		$return = utils::o2a($plan3dHeader);
-		ajax::success($return);
+		return $return;
 	}
 
 	if (init('action') == 'saveplan3dHeader') {
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+        ajax::checkAccess('admin');
 		unautorizedInDemo();
 		$plan3dHeader_ajax = json_decode(init('plan3dHeader'), true);
 		$plan3dHeader = null;
@@ -145,13 +133,11 @@ try {
 		}
 		utils::a2o($plan3dHeader, $plan3dHeader_ajax);
 		$plan3dHeader->save();
-		ajax::success(utils::o2a($plan3dHeader));
+		return utils::o2a($plan3dHeader);
 	}
 
 	if (init('action') == 'uploadModel') {
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+        ajax::checkAccess('admin');
 		unautorizedInDemo();
 		$plan3dHeader = plan3dHeader::byId(init('id'));
 		if (!is_object($plan3dHeader)) {
@@ -200,11 +186,9 @@ try {
 			$plan3dHeader->setConfiguration('mtlfile', $mtlfile[0]);
 		}
 		$plan3dHeader->save();
-		ajax::success();
+		return '';
 	}
 
 	throw new Exception(__('Aucune methode correspondante à : ', __FILE__) . init('action'));
 	/*     * *********Catch exeption*************** */
-} catch (Exception $e) {
-	ajax::error(displayExeption($e), $e->getCode());
-}
+});

--- a/core/ajax/plugin.ajax.php
+++ b/core/ajax/plugin.ajax.php
@@ -1,5 +1,8 @@
 <?php
 
+/** @entrypoint */
+/** @ajax */
+
 /* This file is part of Jeedom.
 *
 * Jeedom is free software: you can redistribute it and/or modify
@@ -16,20 +19,13 @@
 * along with Jeedom. If not, see <http://www.gnu.org/licenses/>.
 */
 
-try {
-	require_once __DIR__ . '/../../core/php/core.inc.php';
-	include_file('core', 'authentification', 'php');
+require_once __DIR__ . '/ajax.handler.inc.php';
 
-	if (!isConnect()) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__));
-	}
-
-	ajax::init();
-
+ajaxHandle(function ()
+{
+    ajax::checkAccess('');
 	if (init('action') == 'getConf') {
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+        ajax::checkAccess('admin');
 		$plugin = plugin::byId(init('id'));
 		$update = update::byLogicalId(init('id'));
 		$return = utils::o2a($plugin);
@@ -67,58 +63,48 @@ try {
 		$return['update'] = utils::o2a($update);
 		$return['logs'] = array();
 		$return['logs'][-1] = array('id' => -1, 'name' => 'local', 'log' => $plugin->getLogList());
-		ajax::success($return);
+		return $return;
 	}
 
 	if (init('action') == 'toggle') {
 		unautorizedInDemo();
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+		ajax::checkAccess('admin');
 		$plugin = plugin::byId(init('id'));
 		if (!is_object($plugin)) {
 			throw new Exception(__('Plugin introuvable : ', __FILE__) . init('id'));
 		}
 		$plugin->setIsEnable(init('state'));
-		ajax::success();
+		return '';
 	}
 
 	if (init('action') == 'all') {
-		if (!isConnect()) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
-		ajax::success(utils::o2a(plugin::listPlugin(init('activateOnly',false))));
+        ajax::checkAccess(''); // Double appel
+		return utils::o2a(plugin::listPlugin(init('activateOnly',false)));
 	}
 
 	if (init('action') == 'getDependancyInfo') {
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+		ajax::checkAccess('admin');
 
 		$return = array('state' => 'nok', 'log' => 'nok');
 		$plugin = plugin::byId(init('id'));
 		if (is_object($plugin)) {
 			$return = $plugin->dependancy_info();
 		}
-		ajax::success($return);
+		return $return;
 	}
 
 	if (init('action') == 'dependancyInstall') {
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+		ajax::checkAccess('admin');
 		unautorizedInDemo();
 		$plugin = plugin::byId(init('id'));
 		if (!is_object($plugin)) {
-			ajax::success();
+			return '';
 		}
-		ajax::success($plugin->dependancy_install());
+		return $plugin->dependancy_install();
 	}
 
 	if (init('action') == 'getDeamonInfo') {
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+		ajax::checkAccess('admin');
 		$plugin_id = init('id');
 		$return = array('launchable_message' => '', 'launchable' => 'nok', 'state' => 'nok', 'log' => 'nok', 'auto' => 0);
 		$plugin = plugin::byId(init('id'));
@@ -126,48 +112,40 @@ try {
 			$return = $plugin->deamon_info();
 		}
 		$return['plugin'] = utils::o2a($plugin);
-		ajax::success($return);
+		return $return;
 	}
 
 	if (init('action') == 'deamonStart') {
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+		ajax::checkAccess('admin');
 		unautorizedInDemo();
 		$plugin_id = init('id');
 		$plugin = plugin::byId(init('id'));
 		if (!is_object($plugin)) {
-			ajax::success();
+			return '';
 		}
-		ajax::success($plugin->deamon_start(init('forceRestart', 0)));
+		return $plugin->deamon_start(init('forceRestart', 0));
 	}
 
 	if (init('action') == 'deamonStop') {
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+		ajax::checkAccess('admin');
 		unautorizedInDemo();
 		$plugin = plugin::byId(init('id'));
 		if (!is_object($plugin)) {
-			ajax::success();
+			return '';
 		}
-		ajax::success($plugin->deamon_stop());
+		return $plugin->deamon_stop();
 	}
 
 	if (init('action') == 'deamonChangeAutoMode') {
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+		ajax::checkAccess('admin');
 		unautorizedInDemo();
 		$plugin = plugin::byId(init('id'));
 		if (!is_object($plugin)) {
-			ajax::success();
+			return '';
 		}
-		ajax::success($plugin->deamon_changeAutoMode(init('mode')));
+		return $plugin->deamon_changeAutoMode(init('mode'));
 	}
 
 	throw new Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
 	/*     * *********Catch exeption*************** */
-} catch (Exception $e) {
-	ajax::error(displayException($e), $e->getCode());
-}
+});

--- a/core/ajax/repo.ajax.php
+++ b/core/ajax/repo.ajax.php
@@ -1,5 +1,8 @@
 <?php
 
+/** @entrypoint */
+/** @ajax */
+
 /* This file is part of Jeedom.
 *
 * Jeedom is free software: you can redistribute it and/or modify
@@ -16,39 +19,34 @@
 * along with Jeedom. If not, see <http://www.gnu.org/licenses/>.
 */
 
-try {
-	require_once __DIR__ . '/../php/core.inc.php';
-	include_file('core', 'authentification', 'php');
-	
-	if (!isConnect('admin')) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__));
-	}
-	
-	ajax::init();
-	
+require_once __DIR__ . '/ajax.handler.inc.php';
+
+ajaxHandle(function ()
+{
+    ajax::checkAccess('admin');
 	if (init('action') == 'uploadCloud') {
 		unautorizedInDemo();
 		repo_market::backup_send(init('backup'));
-		ajax::success();
+		return '';
 	}
 	
 	if (init('action') == 'restoreCloud') {
 		unautorizedInDemo();
 		$class = 'repo_' . init('repo');
 		$class::backup_restore(init('backup'));
-		ajax::success();
+		return '';
 	}
 	
 	if (init('action') == 'pullInstall') {
 		unautorizedInDemo();
 		$class = 'repo_' . init('repo');
-		ajax::success($class::pullInstall());
+		return $class::pullInstall();
 	}
 	
 	if (init('action') == 'sendReportBug') {
 		unautorizedInDemo();
 		$class = 'repo_' . init('repo');
-		ajax::success($class::saveTicket(json_decode(init('ticket'), true)));
+		return $class::saveTicket(json_decode(init('ticket'), true));
 	}
 	
 	if (init('action') == 'install') {
@@ -69,13 +67,13 @@ try {
 		$update->setConfiguration('version', init('version', 'stable'));
 		$update->save();
 		$update->doUpdate();
-		ajax::success();
+		return '';
 	}
 	
 	if (init('action') == 'test') {
 		$class = 'repo_' . init('repo');
 		$class::test();
-		ajax::success();
+		return '';
 	}
 	
 	if (init('action') == 'remove') {
@@ -97,7 +95,7 @@ try {
 				$update->deleteObjet();
 			}
 		}
-		ajax::success();
+		return '';
 	}
 	
 	if (init('action') == 'save') {
@@ -111,24 +109,24 @@ try {
 		}
 		utils::a2o($repo, $repo_ajax);
 		$repo->save();
-		ajax::success();
+		return '';
 	}
 	
 	if (init('action') == 'getInfo') {
 		$class = 'repo_' . init('repo');
-		ajax::success($class::getInfo(init('logicalId')));
+		return $class::getInfo(init('logicalId'));
 	}
 	
 	if (init('action') == 'byLogicalId') {
 		$class = 'repo_' . init('repo');
 		if (init('noExecption', 0) == 1) {
 			try {
-				ajax::success(utils::o2a($class::byLogicalIdAndType(init('logicalId'), init('type'))));
+				return utils::o2a($class::byLogicalIdAndType(init('logicalId'), init('type')));
 			} catch (Exception $e) {
-				ajax::success();
+				return '';
 			}
 		} else {
-			ajax::success(utils::o2a($class::byLogicalIdAndType(init('logicalId'), init('type'))));
+			return utils::o2a($class::byLogicalIdAndType(init('logicalId'), init('type')));
 		}
 	}
 	
@@ -140,17 +138,15 @@ try {
 			throw new Exception(__('Impossible de trouver l\'objet associé : ', __FILE__) . init('id'));
 		}
 		$repo->setRating(init('rating'));
-		ajax::success();
+		return '';
 	}
 	
 	if (init('action') == 'backupList') {
 		$class = 'repo_' . init('repo');
-		ajax::success($class::backup_list());
+		return $class::backup_list();
 	}
 	
 	throw new Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
 	
 	/*     * *********Catch exeption*************** */
-} catch (Exception $e) {
-	ajax::error(displayException($e), $e->getCode());
-}
+});

--- a/core/ajax/report.ajax.php
+++ b/core/ajax/report.ajax.php
@@ -1,5 +1,8 @@
 <?php
 
+/** @entrypoint */
+/** @ajax */
+
 /* This file is part of Jeedom.
  *
  * Jeedom is free software: you can redistribute it and/or modify
@@ -16,24 +19,18 @@
  * along with Jeedom. If not, see <http://www.gnu.org/licenses/>.
  */
 
-try {
+require_once __DIR__ . '/ajax.handler.inc.php';
 
-	require_once __DIR__ . '/../php/core.inc.php';
-	include_file('core', 'authentification', 'php');
-
-	if (!isConnect('admin')) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__), -1234);
-	}
-
-	ajax::init(true);
-
+ajaxHandle(function ()
+{
+    ajax::checkAccess('admin');
 	if (init('action') == 'list') {
 		$return = array();
 		$path = __DIR__ . '/../../data/report/' . init('type') . '/' . init('id') . '/';
 		foreach (ls($path, '*') as $value) {
 			$return[$value] = array('name' => $value);
 		}
-		ajax::success($return);
+		return $return;
 	}
 
 	if (init('action') == 'get') {
@@ -42,7 +39,7 @@ try {
 		$return['path'] = $path;
 		$return['type'] = init('type');
 		$return['id'] = init('id');
-		ajax::success($return);
+		return $return;
 	}
 
 	if (init('action') == 'remove') {
@@ -53,7 +50,7 @@ try {
 		if (file_exists($path)) {
 			throw new Exception(__('Impossible de supprimer : ', __FILE__) . $path);
 		}
-		ajax::success();
+		return '';
 	}
 
 	if (init('action') == 'removeAll') {
@@ -61,11 +58,9 @@ try {
 		foreach (ls($path, '*') as $value) {
 			unlink($path . $value);
 		}
-		ajax::success($return);
+		return $return; // FIXME: variable inconnue
 	}
 
 	throw new Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
 	/*     * *********Catch exeption*************** */
-} catch (Exception $e) {
-	ajax::error(displayException($e), $e->getCode());
-}
+});

--- a/core/ajax/scenario.ajax.php
+++ b/core/ajax/scenario.ajax.php
@@ -1,5 +1,8 @@
 <?php
 
+/** @entrypoint */
+/** @ajax */
+
 /* This file is part of Jeedom.
 *
 * Jeedom is free software: you can redistribute it and/or modify
@@ -16,16 +19,11 @@
 * along with Jeedom. If not, see <http://www.gnu.org/licenses/>.
 */
 
-try {
-	require_once __DIR__ . '/../../core/php/core.inc.php';
-	include_file('core', 'authentification', 'php');
+require_once __DIR__ . '/ajax.handler.inc.php';
 
-	if (!isConnect()) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__));
-	}
-
-	ajax::init();
-
+ajaxHandle(function ()
+{
+    ajax::checkAccess('');
 	if (init('action') == 'changeState') {
 		$scenario = scenario::byId(init('id'));
 		if (!is_object($scenario)) {
@@ -53,7 +51,7 @@ try {
 			$scenario->save();
 			break;
 		}
-		ajax::success();
+		return '';
 	}
 
 	if (init('action') == 'listScenarioHtml') {
@@ -63,7 +61,7 @@ try {
 				$return[] = $scenario->toHtml(init('version'));
 			}
 		}
-		ajax::success($return);
+		return $return;
 	}
 
 	if (init('action') == 'setOrder') {
@@ -80,7 +78,7 @@ try {
 			utils::a2o($scenario, $scenario_json);
 			$scenario->save(true);
 		}
-		ajax::success();
+		return '';
 	}
 
 	if (init('action') == 'testExpression') {
@@ -92,11 +90,11 @@ try {
 		if (trim($return['result']) == trim($return['evaluate'])) {
 			$return['correct'] = 'nok';
 		}
-		ajax::success($return);
+		return $return;
 	}
 
 	if (init('action') == 'getTemplate') {
-		ajax::success(scenario::getTemplate());
+		return scenario::getTemplate();
 	}
 
 	if (init('action') == 'convertToTemplate') {
@@ -116,7 +114,7 @@ try {
 		if (!file_exists($path . '/' . $name)) {
 			throw new Exception(__('Impossible de créer le template, vérifiez les droits : ', __FILE__) . $path . '/' . $name);
 		}
-		ajax::success();
+		return '';
 	}
 
 	if (init('action') == 'removeTemplate') {
@@ -125,7 +123,7 @@ try {
 		if (file_exists($path . '/' . init('template'))) {
 			unlink($path . '/' . init('template'));
 		}
-		ajax::success();
+		return '';
 	}
 
 	if (init('action') == 'loadTemplateDiff') {
@@ -171,7 +169,7 @@ try {
 				}
 			}
 		}
-		ajax::success($return);
+		return $return;
 	}
 
 	if (init('action') == 'applyTemplate') {
@@ -214,7 +212,7 @@ try {
 			$scenario_db->setScenarioElement($scenario_element_list);
 		}
 		$scenario_db->save();
-		ajax::success();
+		return '';
 	}
 
 	if (init('action') == 'all') {
@@ -225,7 +223,7 @@ try {
 			$info_scenario['humanName'] = $scenario->getHumanName();
 			$return[] = $info_scenario;
 		}
-		ajax::success($return);
+		return $return;
 	}
 
 	if (init('action') == 'saveAll') {
@@ -241,18 +239,16 @@ try {
 				$scenario->save();
 			}
 		}
-		ajax::success();
+		return '';
 	}
 
 	if (init('action') == 'autoCompleteGroup') {
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+        ajax::checkAccess('admin');
 		$return = array();
 		foreach (scenario::listGroup(init('term')) as $group) {
 			$return[] = $group['group'];
 		}
-		ajax::success($return);
+		return $return;
 	}
 
 	if (init('action') == 'toHtml') {
@@ -270,20 +266,18 @@ try {
 			foreach ($scenarios as $scenario) {
 				$return[] = $scenario->toHtml(init('version'));
 			}
-			ajax::success($return);
+			return $return;
 		} else {
 			$scenario = scenario::byId(init('id'));
 			if (is_object($scenario)) {
-				ajax::success($scenario->toHtml(init('version')));
+				return $scenario->toHtml(init('version'));
 			}
 		}
-		ajax::success();
+		return '';
 	}
 
 	if (init('action') == 'remove') {
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+        ajax::checkAccess('admin');
 		unautorizedInDemo();
 		$scenario = scenario::byId(init('id'));
 		if (!is_object($scenario)) {
@@ -293,13 +287,11 @@ try {
 			throw new Exception(__('Vous n\'êtes pas autorisé à faire cette action', __FILE__));
 		}
 		$scenario->remove();
-		ajax::success();
+		return '';
 	}
 
 	if (init('action') == 'emptyLog') {
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+        ajax::checkAccess('admin');
 		$scenario = scenario::byId(init('id'));
 		if (!is_object($scenario)) {
 			throw new Exception(__('Scénario ID inconnu', __FILE__));
@@ -310,19 +302,17 @@ try {
 		if (file_exists(__DIR__ . '/../../log/scenarioLog/scenario' . $scenario->getId() . '.log')) {
 			unlink(__DIR__ . '/../../log/scenarioLog/scenario' . $scenario->getId() . '.log');
 		}
-		ajax::success();
+		return '';
 	}
 
 	if (init('action') == 'copy') {
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+        ajax::checkAccess('admin');
 		unautorizedInDemo();
 		$scenario = scenario::byId(init('id'));
 		if (!is_object($scenario)) {
 			throw new Exception(__('Scénario ID inconnu', __FILE__));
 		}
-		ajax::success(utils::o2a($scenario->copy(init('name'))));
+		return utils::o2a($scenario->copy(init('name')));
 	}
 
 	if (init('action') == 'get') {
@@ -352,13 +342,11 @@ try {
 			}
 			$return['scenario_link']['scenario'][$scenarioLink->getId()] = array('name' => $scenarioLink->getHumanName(),'isActive' => $scenarioLink->getIsActive());
 		}
-		ajax::success($return);
+		return $return;
 	}
 
 	if (init('action') == 'save') {
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+        ajax::checkAccess('admin');
 		if (!is_json(init('scenario'))) {
 			throw new Exception(__('Champs json invalide', __FILE__));
 		}
@@ -405,7 +393,7 @@ try {
 			$scenario_db->setScenarioElement($scenario_element_list);
 		}
 		$scenario_db->save();
-		ajax::success(utils::o2a($scenario_db));
+		return utils::o2a($scenario_db);
 	}
 
 	if (init('action') == 'actionToHtml') {
@@ -425,9 +413,9 @@ try {
 					'id' => $param['id'],
 				);
 			}
-			ajax::success($return);
+			return $return;
 		}
-		ajax::success(scenarioExpression::getExpressionOptions(init('expression'), init('option')));
+		return scenarioExpression::getExpressionOptions(init('expression'), init('option'));
 	}
 
 	if (init('action') == 'templateupload') {
@@ -455,12 +443,10 @@ try {
 		if (!file_exists($uploaddir . '/' . $_FILES['file']['name'])) {
 			throw new Exception(__('Impossible de téléverser le fichier (limite du serveur web ?)', __FILE__));
 		}
-		ajax::success();
+		return '';
 
 	}
 
 	throw new Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
 	/*     * *********Catch exeption*************** */
-} catch (Exception $e) {
-	ajax::error(displayException($e), $e->getCode());
-}
+});

--- a/core/ajax/timeline.ajax.php
+++ b/core/ajax/timeline.ajax.php
@@ -1,5 +1,8 @@
 <?php
 
+/** @entrypoint */
+/** @ajax */
+
 /* This file is part of Jeedom.
 *
 * Jeedom is free software: you can redistribute it and/or modify
@@ -16,16 +19,11 @@
 * along with Jeedom. If not, see <http://www.gnu.org/licenses/>.
 */
 
-try {
-  require_once __DIR__ . '/../../core/php/core.inc.php';
-  include_file('core', 'authentification', 'php');
-  
-  if (!isConnect()) {
-    throw new Exception(__('401 - Accès non autorisé', __FILE__), -1234);
-  }
-  
-  ajax::init();
-  
+require_once __DIR__ . '/ajax.handler.inc.php';
+
+ajaxHandle(function ()
+{
+  ajax::checkAccess('');
   if (init('action') == 'byFolder') {
     $return = array();
     $events = timeline::byFolder(init('folder','main'));
@@ -35,21 +33,19 @@ try {
         $return[] = $info;
       }
     }
-    ajax::success($return);
+    return $return;
   }
   
   if (init('action') == 'deleteAll') {
     unautorizedInDemo();
-    ajax::success(timeline::cleaning(true));
+    return timeline::cleaning(true);
   }
   
   if (init('action') == 'listFolder') {
     unautorizedInDemo();
-    ajax::success(timeline::listFolder());
+    return timeline::listFolder();
   }
   
   throw new Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
   /*     * *********Catch exeption*************** */
-} catch (Exception $e) {
-  ajax::error(displayException($e), $e->getCode());
-}
+});

--- a/core/ajax/update.ajax.php
+++ b/core/ajax/update.ajax.php
@@ -1,5 +1,8 @@
 <?php
 
+/** @entrypoint */
+/** @ajax */
+
 /* This file is part of Jeedom.
 *
 * Jeedom is free software: you can redistribute it and/or modify
@@ -16,18 +19,13 @@
 * along with Jeedom. If not, see <http://www.gnu.org/licenses/>.
 */
 
-try {
-	require_once __DIR__ . '/../../core/php/core.inc.php';
-	include_file('core', 'authentification', 'php');
+require_once __DIR__ . '/ajax.handler.inc.php';
 
-	if (!isConnect()) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__), -1234);
-	}
-
-	ajax::init();
-
+ajaxHandle(function ()
+{
+    ajax::checkAccess('');
 	if (init('action') == 'nbUpdate') {
-		ajax::success(update::nbNeedUpdate());
+		return update::nbNeedUpdate();
 	}
 
 	if (!isConnect('admin')) {
@@ -48,13 +46,13 @@ try {
 			}
 			$return[] = $infos;
 		}
-		ajax::success($return);
+		return $return;
 	}
 
 	if (init('action') == 'checkAllUpdate') {
 		unautorizedInDemo();
 		update::checkAllUpdate();
-		ajax::success();
+		return '';
 	}
 
 	if (init('action') == 'update') {
@@ -87,7 +85,7 @@ try {
 				log::add('update', 'alert', __("[END UPDATE ERROR]", __FILE__));
 			}
 		}
-		ajax::success();
+		return '';
 	}
 
 	if (init('action') == 'remove') {
@@ -101,7 +99,7 @@ try {
 			throw new Exception(__('Aucune correspondance pour l\'ID : ' . init('id'), __FILE__));
 		}
 		$update->deleteObjet();
-		ajax::success();
+		return '';
 	}
 
 	if (init('action') == 'checkUpdate') {
@@ -114,13 +112,13 @@ try {
 			throw new Exception(__('Aucune correspondance pour l\'ID : ' . init('id'), __FILE__));
 		}
 		$update->checkUpdate();
-		ajax::success();
+		return '';
 	}
 
 	if (init('action') == 'updateAll') {
 		unautorizedInDemo();
 		jeedom::update(json_decode(init('options', '{}'), true));
-		ajax::success();
+		return '';
 	}
 
 	if (init('action') == 'save') {
@@ -150,13 +148,13 @@ try {
 				$update->save();
 			}
 		}
-		ajax::success(utils::o2a($update));
+		return utils::o2a($update);
 	}
 
 	if (init('action') == 'saves') {
 		unautorizedInDemo();
 		utils::processJsonObject('update', init('updates'));
-		ajax::success();
+		return '';
 	}
 
 	if (init('action') == 'preUploadFile') {
@@ -178,11 +176,9 @@ try {
 		if (!file_exists($uploaddir . '/' . $filename)) {
 			throw new Exception(__('Impossible de téléverser le fichier (limite du serveur web ?)', __FILE__));
 		}
-		ajax::success($uploaddir . '/' . $filename);
+		return $uploaddir . '/' . $filename;
 	}
 
 	throw new Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
 	/*     * *********Catch exeption*************** */
-} catch (Exception $e) {
-	ajax::error(displayException($e), $e->getCode());
-}
+});

--- a/core/ajax/view.ajax.php
+++ b/core/ajax/view.ajax.php
@@ -1,5 +1,8 @@
 <?php
 
+/** @entrypoint */
+/** @ajax */
+
 /* This file is part of Jeedom.
 *
 * Jeedom is free software: you can redistribute it and/or modify
@@ -16,31 +19,24 @@
 * along with Jeedom. If not, see <http://www.gnu.org/licenses/>.
 */
 
-try {
-	require_once __DIR__ . '/../../core/php/core.inc.php';
-	include_file('core', 'authentification', 'php');
+require_once __DIR__ . '/ajax.handler.inc.php';
 
-	if (!isConnect()) {
-		throw new Exception(__('401 - Accès non autorisé', __FILE__));
-	}
-
-	ajax::init();
-
+ajaxHandle(function ()
+{
+    ajax::checkAccess('');
 	if (init('action') == 'remove') {
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+        ajax::checkAccess('admin');
 		unautorizedInDemo();
 		$view = view::byId(init('id'));
 		if (!is_object($view)) {
 			throw new Exception(__('Vue non trouvée. Vérifiez l\'iD', __FILE__));
 		}
 		$view->remove();
-		ajax::success();
+		return '';
 	}
 
 	if (init('action') == 'all') {
-		ajax::success(utils::o2a(view::all()));
+		return utils::o2a(view::all());
 	}
 
 	if (init('action') == 'get') {
@@ -58,20 +54,18 @@ try {
 			foreach (view::all() as $view) {
 				$return[$view->getId()] = $view->toAjax(init('version', 'dashboard'), init('html'));
 			}
-			ajax::success($return);
+			return $return;
 		} else {
 			$view = view::byId(init('id'));
 			if (!is_object($view)) {
 				throw new Exception(__('Vue non trouvée. Vérifiez l\'ID', __FILE__));
 			}
-			ajax::success($view->toAjax(init('version', 'dashboard'), init('html')));
+			return $view->toAjax(init('version', 'dashboard'), init('html'));
 		}
 	}
 
 	if (init('action') == 'save') {
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+        ajax::checkAccess('admin');
 		unautorizedInDemo();
 		$view = view::byId(init('view_id'));
 		if (!is_object($view)) {
@@ -100,7 +94,7 @@ try {
 				}
 			}
 		}
-		ajax::success(utils::o2a($view));
+		return utils::o2a($view);
 	}
 
 	if (init('action') == 'getEqLogicviewZone') {
@@ -115,13 +109,11 @@ try {
 			$infoViewDatat['html'] = $viewData->getLinkObject()->toHtml(init('version'));
 			$return['viewData'][] = $infoViewDatat;
 		}
-		ajax::success($return);
+		return $return;
 	}
 
 	if (init('action') == 'setComponentOrder') {
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+        ajax::checkAccess('admin');
 		unautorizedInDemo();
 		$components = json_decode(init('components'), true);
 		$sql = '';
@@ -149,13 +141,11 @@ try {
 		if ($sql != '') {
 			DB::Prepare($sql, array(), DB::FETCH_TYPE_ROW);
 		}
-		ajax::success();
+		return '';
 	}
 
 	if (init('action') == 'setOrder') {
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+        ajax::checkAccess('admin');
 		unautorizedInDemo();
 		$order = 1;
 		foreach (json_decode(init('views'), true) as $id) {
@@ -166,13 +156,11 @@ try {
 				$order++;
 			}
 		}
-		ajax::success();
+		return '';
 	}
 
 	if (init('action') == 'removeImage') {
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+        ajax::checkAccess('admin');
 		unautorizedInDemo();
 		$view = view::byId(init('id'));
 		if (!is_object($view)) {
@@ -181,13 +169,11 @@ try {
 		$view->setImage('sha512', '');
 		$view->save();
 		@rrmdir(__DIR__ . '/../../core/img/view');
-		ajax::success();
+		return '';
 	}
 
 	if (init('action') == 'uploadImage') {
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+        ajax::checkAccess('admin');
 		unautorizedInDemo();
 		$view = view::byId(init('id'));
 		if (!is_object($view)) {
@@ -218,11 +204,9 @@ try {
 			throw new \Exception(__('Impossible de sauvegarder l\'image',__FILE__));
 		}
 		$view->save();
-		ajax::success();
+		return '';
 	}
 
 	throw new Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
 	/*     * *********Catch exeption*************** */
-} catch (Exception $e) {
-	ajax::error(displayException($e), $e->getCode());
-}
+});

--- a/core/ajax/widgets.ajax.php
+++ b/core/ajax/widgets.ajax.php
@@ -1,5 +1,8 @@
 <?php
 
+/** @entrypoint */
+/** @ajax */
+
 /* This file is part of Jeedom.
 *
 * Jeedom is free software: you can redistribute it and/or modify
@@ -16,19 +19,14 @@
 * along with Jeedom. If not, see <http://www.gnu.org/licenses/>.
 */
 
-try {
-  
-  require_once __DIR__ . '/../../core/php/core.inc.php';
-  include_file('core', 'authentification', 'php');
-  
-  if (!isConnect('admin')) {
-    throw new Exception(__('401 - Accès non autorisé', __FILE__), -1234);
-  }
-  
-  ajax::init(true);
-  
+require_once __DIR__ . '/ajax.handler.inc.php';
+
+ajaxHandle(function ()
+{
+  ajax::checkAccess('admin');
+
   if (init('action') == 'all') {
-    ajax::success(utils::o2a(widgets::all()));
+    return utils::o2a(widgets::all());
   }
   
   if (init('action') == 'byId') {
@@ -41,7 +39,7 @@ try {
         $result['usedBy'][$cmd->getId()] = $cmd->getHumanName();
       }
     }
-    ajax::success($result);
+    return $result;
   }
   
   if (init('action') == 'remove') {
@@ -50,7 +48,7 @@ try {
       throw new Exception(__('Widgets inconnue - Vérifiez l\'id', __FILE__).init('id'));
     }
     $widgets->remove();
-    ajax::success();
+    return '';
   }
   
   if (init('action') == 'save') {
@@ -64,29 +62,27 @@ try {
     }
     utils::a2o($widgets, $widgets_json);
     $widgets->save();
-    ajax::success(utils::o2a($widgets));
+    return utils::o2a($widgets);
   }
   
   if (init('action') == 'getTemplateConfiguration') {
-    ajax::success(widgets::getTemplateConfiguration(init('template')));
+    return widgets::getTemplateConfiguration(init('template'));
   }
   
   if (init('action') == 'getPreview') {
     $widget = widgets::byId(init('id'));
     $usedBy = $widget->getUsedBy();
     if(!is_array($usedBy) || count($usedBy) == 0){
-      ajax::success(array('html' => '<div class="alert alert-warning">'.__('Aucune commande affectée au widget, prévisualisation impossible',__FILE__).'</div>'));
+      return array('html' => '<div class="alert alert-warning">'.__('Aucune commande affectée au widget, prévisualisation impossible',__FILE__).'</div>');
     }
-    ajax::success(array('html' =>$usedBy[0]->getEqLogic()->toHtml('dashboard')));
+    return array('html' =>$usedBy[0]->getEqLogic()->toHtml('dashboard'));
   }
   
   if (init('action') == 'replacement') {
-    ajax::success(widgets::replacement(init('version'),init('replace'),init('by')));
+    return widgets::replacement(init('version'),init('replace'),init('by'));
   }
   
   throw new Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
   
   /*     * *********Catch exeption*************** */
-} catch (Exception $e) {
-  ajax::error(displayException($e), $e->getCode());
-}
+});

--- a/core/class/ajax.class.php
+++ b/core/class/ajax.class.php
@@ -24,16 +24,30 @@ class ajax {
 
 	/*     * *********************Methode static ************************* */
 
+    /**
+     * @deprecated
+     */
 	public static function init($_checkToken = true) {
 		if (!headers_sent()) {
 			header('Content-Type: application/json');
 		}
-		if ($_checkToken && init('jeedom_token') != self::getToken()) {
-			self::error(__('Token d\'accès invalide', __FILE__));
-		}
+		if ($_checkToken) {
+		    self::checkToken();
+        }
 	}
 
-	public static function getToken() {
+	public static function checkToken() {
+        if (init('jeedom_token') != self::getToken()) {
+            throw new Exception(__('Token d\'accès invalide', __FILE__));
+        }
+    }
+
+    public static function checkAccess($right) {
+        self::checkToken();
+        checkAccess(__FILE__, $right);
+    }
+
+    public static function getToken() {
 		if (session_status() == PHP_SESSION_NONE) {
 			@session_start();
 			@session_write_close();
@@ -46,11 +60,13 @@ class ajax {
 		return $_SESSION['jeedom_token'];
 	}
 
+    /** @deprecated Use ajax::getResponse instead */
 	public static function success($_data = '') {
 		echo self::getResponse($_data);
 		die();
 	}
 
+    /** @deprecated Use ajax::getResponse instead */
 	public static function error($_data = '', $_errorCode = 0) {
 		echo self::getResponse($_data, $_errorCode);
 		die();

--- a/core/php/downloadFile.php
+++ b/core/php/downloadFile.php
@@ -58,15 +58,11 @@ try {
 			throw new Exception(__('Fichier non trouvé : ', __FILE__) . $pathfile);
 		}
 	} elseif (is_dir(str_replace('*', '', $pathfile))) {
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+        ajax::checkAccess('admin');
 		system('cd ' . dirname($pathfile) . ';tar cfz ' . jeedom::getTmpFolder('downloads') . '/archive.tar.gz * > /dev/null 2>&1');
 		$pathfile = jeedom::getTmpFolder('downloads') . '/archive.tar.gz';
 	} else {
-		if (!isConnect('admin')) {
-			throw new Exception(__('401 - Accès non autorisé', __FILE__));
-		}
+        ajax::checkAccess('admin');
 		$pattern = array_pop(explode('/', $pathfile));
 		system('cd ' . dirname($pathfile) . ';tar cfz ' . jeedom::getTmpFolder('downloads') . '/archive.tar.gz ' . $pattern . '> /dev/null 2>&1');
 		$pathfile = jeedom::getTmpFolder('downloads') . '/archive.tar.gz';

--- a/core/php/utils.inc.php
+++ b/core/php/utils.inc.php
@@ -1029,6 +1029,12 @@ function sanitizeAccent($_message) {
 		}
 		return $GLOBALS['isConnect::' . $_right];
 	}
+
+	function checkAccess($file, $right = '') {
+        if (!isConnect($right)) {
+            throw new Exception(__('401 - Accès non autorisé', $file));
+        }
+    }
 	
 	function ZipErrorMessage($code) {
 		switch ($code) {


### PR DESCRIPTION
Refacto de la logique ajax
- Centralise la gestion des requètes.
- Ajout de « helpers » pour les autorisations.
- Séparation de la définition du header et de la vérification du token de session. Deprecation de `ajax::init`
- Deprecation de `ajax::success` et `ajax::error` (à cause des `die()`), fonctionne toujours (pas de BC)