### PR TITLE
Fix mispelled variable name in SQL exception handling during install

### DIFF
--- a/install/install.php
+++ b/install/install.php
@@ -43,7 +43,7 @@ try {
 	try {
 		DB::compareAndFix(json_decode(file_get_contents(__DIR__.'/database.json'),true));
 	} catch (\Exception $e) {
-		echo "***ERREUR*** " . $ex->getMessage() . "\n";
+		echo "***ERREUR*** " . $e->getMessage() . "\n";
 	}
 	echo "OK\n";
 	echo "Post installation...\n";


### PR DESCRIPTION
The current version in install/install.php does not report correctly exceptions which occur during SQL connection, since the exception is named $e yet is used with name $ex.

Here is the current log:

[START INSTALL]
****Install jeedom from 4.0.35 (2019-12-26 13:36:24)****

Installation de Jeedom 4.0.35
Installation de la base de données...PHP Notice:  Undefined variable: ex in /var/www/html/install/install.php on line 57
PHP Fatal error:  Uncaught Error: Call to a member function getMessage() on null in /var/www/html/install/install.php:57
Stack trace:
#0 {main}
  thrown in /var/www/html/install/install.php on line 57
Ne peut installer jeedom - Annulation
