### PR TITLE
"function" est réservé depuis MySQL 8.0.1

### DIFF
--- a/core/class/cron.class.php
+++ b/core/class/cron.class.php
@@ -79,7 +79,7 @@ class cron {
 		$sql = 'SELECT ' . DB::buildField(__CLASS__) . '
 		FROM cron
 		WHERE class=:class
-		AND function=:function';
+		AND `function`=:function';
 		if ($_option != '') {
 			$_option = json_encode($_option, JSON_UNESCAPED_UNICODE);
 			$value['option'] = $_option;
@@ -102,7 +102,7 @@ class cron {
 		$sql = 'SELECT ' . DB::buildField(__CLASS__) . '
 		FROM cron
 		WHERE class=:class
-		AND function=:function';
+		AND `function`=:function';
 		if ($_option != '') {
 			$value['option'] = '%' . $_option . '%';
 			$sql .= ' AND `option` LIKE :option';

--- a/core/class/listener.class.php
+++ b/core/class/listener.class.php
@@ -86,7 +86,7 @@ class listener {
 		$sql = 'SELECT ' . DB::buildField(__CLASS__) . '
 		FROM listener
 		WHERE class=:class
-		AND function=:function';
+		AND `function`=:function';
 		if ($_option != '') {
 			$_option = json_encode($_option, JSON_UNESCAPED_UNICODE);
 			$value['option'] = $_option;
@@ -104,7 +104,7 @@ class listener {
 		$sql = 'SELECT ' . DB::buildField(__CLASS__) . '
 		FROM listener
 		WHERE class=:class
-		AND function=:function
+		AND `function`=:function
 		AND `option` LIKE :option';
 		return DB::Prepare($sql, $value, DB::FETCH_TYPE_ALL, PDO::FETCH_CLASS, __CLASS__);
 	}
@@ -118,7 +118,7 @@ class listener {
 		$sql = 'SELECT ' . DB::buildField(__CLASS__) . '
 		FROM listener
 		WHERE class=:class
-		AND function=:function
+		AND `function`=:function
 		AND event=:event';
 		return DB::Prepare($sql, $value, DB::FETCH_TYPE_ALL, PDO::FETCH_CLASS, __CLASS__);
 	}
@@ -131,7 +131,7 @@ class listener {
 		);
 		$sql = 'DELETE FROM listener
 		WHERE class=:class
-		AND function=:function
+		AND `function`=:function
 		AND event=:event';
 		if ($_option != '') {
 			$_option = json_encode($_option, JSON_UNESCAPED_UNICODE);


### PR DESCRIPTION
"function" est réservé depuis MySQL 8.0.1 et doit être échappé afin de représenter un nom de champs