### PR TITLE
Core/TLS checks: remove all occurences of --no-check-certificate

### DIFF
--- a/core/class/migrate.class.php
+++ b/core/class/migrate.class.php
@@ -121,11 +121,11 @@ class migrate {
 				exec('sudo mv '.$fileExiste.' '.$mediaLink.'/backupJeedom.tar.gz');
 				return 'fileExist';
 			}else{
-				exec('sudo wget --no-check-certificate --progress=dot --dot=mega '.$url.' -a '.log::getPathToLog('migrate').' -O '.$mediaLink.'/backupJeedomDownload.tar.gz >> ' . log::getPathToLog('migrate').' 2&>1');
+				exec('sudo wget --progress=dot --dot=mega '.$url.' -a '.log::getPathToLog('migrate').' -O '.$mediaLink.'/backupJeedomDownload.tar.gz >> ' . log::getPathToLog('migrate').' 2&>1');
 				return 'telechargement';
 			}
 		}else{
-			exec('sudo wget --no-check-certificate --progress=dot --dot=mega '.$url.' -a '.log::getPathToLog('migrate').' -O '.$mediaLink.'/backupJeedomDownload.tar.gz >> ' . log::getPathToLog('migrate').' 2&>1');
+			exec('sudo wget --progress=dot --dot=mega '.$url.' -a '.log::getPathToLog('migrate').' -O '.$mediaLink.'/backupJeedomDownload.tar.gz >> ' . log::getPathToLog('migrate').' 2&>1');
 			return 'telechargement';
 		}
 	}

--- a/core/repo/market.repo.php
+++ b/core/repo/market.repo.php
@@ -306,7 +306,6 @@ class repo_market {
 			$cmd .= ' --exclude "' . $exclude . '"';
 		}
 		$cmd .= ' --num-retries 2';
-		$cmd .= ' --ssl-no-check-certificate';
 		$cmd .= ' --tempdir '.$base_dir . '/tmp';
 		$cmd .= ' ' . $base_dir . '  "webdavs://' . config::byKey('market::username') . ':' . config::byKey('market::backupPassword');
 		$cmd .= '@' . config::byKey('market::backupServer') . '/remote.php/webdav/' . config::byKey('market::cloud::backup::name').'"';
@@ -345,7 +344,6 @@ class repo_market {
 		
 		$cmd = system::getCmdSudo() . ' PASSPHRASE="' . config::byKey('market::cloud::backup::password') . '"';
 		$cmd .= ' duplicity cleanup --force ';
-		$cmd .= ' --ssl-no-check-certificate';
 		$cmd .= ' --num-retries 3';
 		$cmd .= ' "webdavs://' . config::byKey('market::username') . ':' . config::byKey('market::backupPassword');
 		$cmd .= '@' . config::byKey('market::backupServer') . '/remote.php/webdav/' . config::byKey('market::cloud::backup::name').'"';
@@ -367,7 +365,6 @@ class repo_market {
 		}
 		$cmd = system::getCmdSudo() . ' PASSPHRASE="' . config::byKey('market::cloud::backup::password') . '"';
 		$cmd .= ' duplicity remove-all-but-n-full ' . $_nb . ' --force ';
-		$cmd .= ' --ssl-no-check-certificate';
 		$cmd .= ' --num-retries 3';
 		$cmd .= ' "webdavs://' . config::byKey('market::username') . ':' . config::byKey('market::backupPassword');
 		$cmd .= '@' . config::byKey('market::backupServer') . '/remote.php/webdav/' . config::byKey('market::cloud::backup::name').'"';
@@ -395,7 +392,6 @@ class repo_market {
 		$return = array();
 		$cmd = system::getCmdSudo();
 		$cmd .= ' duplicity collection-status';
-		$cmd .= ' --ssl-no-check-certificate';
 		$cmd .= ' --num-retries 2';
 		$cmd .= ' --timeout 60';
 		$cmd .= ' "webdavs://' . config::byKey('market::username') . ':' . config::byKey('market::backupPassword');
@@ -439,7 +435,6 @@ class repo_market {
 		$cmd = system::getCmdSudo() . ' PASSPHRASE="' . config::byKey('market::cloud::backup::password') . '"';
 		$cmd .= ' duplicity --file-to-restore /';
 		$cmd .= ' --time ' . $timestamp;
-		$cmd .= ' --ssl-no-check-certificate';
 		$cmd .= ' --num-retries 3';
 		$cmd .= ' --tempdir '.$base_dir;
 		$cmd .= ' "webdavs://' . config::byKey('market::username') . ':' . config::byKey('market::backupPassword');
@@ -1114,7 +1109,7 @@ class repo_market {
 		$url = config::byKey('market::address') . "/core/php/downloadFile.php?id=" . $this->getId() . '&version=' . $_version . '&jeedomversion=' . jeedom::version() . '&hwkey=' . jeedom::getHardwareKey() . '&username=' . urlencode(config::byKey('market::username')) . '&password=' . self::getPassword() . '&password_type=sha1';
 		log::add('update', 'alert', __('Téléchargement de ', __FILE__) . $this->getLogicalId() . '...');
 		log::add('update', 'alert', __('URL ', __FILE__) . $url);
-		exec('wget --no-check-certificate "' . $url . '" -O ' . $tmp . ' >> ' . log::getPathToLog('update').' 2>&1');
+		exec('wget "' . $url . '" -O ' . $tmp . ' >> ' . log::getPathToLog('update').' 2>&1');
 		switch ($this->getType()) {
 			case 'plugin':
 			return $tmp;

--- a/core/repo/url.repo.php
+++ b/core/repo/url.repo.php
@@ -69,7 +69,7 @@ class repo_url {
 		if (!is_writable($tmp_dir)) {
 			throw new Exception(__('Impossible d\'écrire dans le répertoire : ', __FILE__) . $tmp . __('. Exécuter la commande suivante en SSH : sudo chmod 777 -R ', __FILE__) . $tmp_dir);
 		}
-		exec('wget --no-check-certificate --progress=dot --dot=mega ' . $_update->getConfiguration('url') . ' -O ' . $tmp);
+		exec('wget --progress=dot --dot=mega ' . $_update->getConfiguration('url') . ' -O ' . $tmp);
 		log::add('update', 'alert', $result);
 		return array('path' => $tmp, 'localVersion' => date('Y-m-d H:i:s'));
 	}
@@ -86,7 +86,7 @@ class repo_url {
 	}
 
 	public static function downloadCore($_path) {
-		exec('wget --no-check-certificate --progress=dot --dot=mega ' . config::byKey('url::core::url') . ' -O ' . $_path);
+		exec('wget --progress=dot --dot=mega ' . config::byKey('url::core::url') . ' -O ' . $_path);
 		return;
 	}
 
@@ -98,7 +98,7 @@ class repo_url {
 			if (file_exists(jeedom::getTmpFolder('url') . '/version')) {
 				com_shell::execute(system::getCmdSudo() . 'rm /tmp/jeedom_version');
 			}
-			exec('wget --no-check-certificate --progress=dot --dot=mega ' . config::byKey('url::core::version') . ' -O /tmp/jeedom_version');
+			exec('wget --progress=dot --dot=mega ' . config::byKey('url::core::version') . ' -O /tmp/jeedom_version');
 			if (!file_exists(jeedom::getTmpFolder('url') . '/version')) {
 				return null;
 			}

--- a/install/install.sh
+++ b/install/install.sh
@@ -126,7 +126,7 @@ step_5_php() {
 step_6_jeedom_download() {
   echo "---------------------------------------------------------------------"
   echo "${JAUNE}Commence l'étape 6 téléchargement de jeedom${NORMAL}"
-  wget --no-check-certificate https://github.com/jeedom/core/archive/${VERSION}.zip -O /tmp/jeedom.zip
+  wget https://github.com/jeedom/core/archive/${VERSION}.zip -O /tmp/jeedom.zip
   if [ $? -ne 0 ]; then
     echo "${JAUNE}Ne peut télécharger Jeedom depuis github. Utilisez la version de déploiement si elle existe${NORMAL}"
     if [ -f /root/jeedom.zip ]; then

--- a/install/update.php
+++ b/install/update.php
@@ -116,7 +116,7 @@ try {
 					if (file_exists($tmp)) {
 						unlink($tmp);
 					}
-					exec('wget --no-check-certificate --progress=dot --dot=mega ' . $url . ' -O ' . $tmp);
+					exec('wget --progress=dot --dot=mega ' . $url . ' -O ' . $tmp);
 				} else {
 					$class = 'repo_' . config::byKey('core::repo::provider');
 					if (!class_exists($class)) {


### PR DESCRIPTION
Because it is just insane to disable TLS checks everywhere in this project.

People should fix their setup, working in dev environments should either imply
to store a new CA in the cacert store or to access using a plain HTTP URI.