### PR TITLE
Widget info/numérique Shutter

### DIFF
--- a/core/template/dashboard/cmd.info.numeric.shutter.html
+++ b/core/template/dashboard/cmd.info.numeric.shutter.html
@@ -1,4 +1,4 @@
-<div class="cmd cmd-widget shuttergauge cursor #history#" data-type="info" data-subtype="numeric" data-template="shutter" data-cmd_id="#id#" data-cmd_uid="#uid#" data-version="#version#" data-eqLogic_id="#eqLogic_id#">
+<div class="cmd cmd-widget shuttergauge #history#" data-type="info" data-subtype="numeric" data-template="shutter" data-cmd_id="#id#" data-cmd_uid="#uid#" data-version="#version#" data-eqLogic_id="#eqLogic_id#">
   <div class="title #hide_name#">
     <div class="cmdName">#name_display#</div>
   </div>


### PR DESCRIPTION
Suppression de la classe 'cursor' afin de supprimer le pointeur "main".
Le pointeur repasse bien en "main" si la commande est historisée.