### PR TITLE
Suppr classe cursor widgets info

### DIFF
--- a/core/template/dashboard/cmd.info.binary.shutter.html
+++ b/core/template/dashboard/cmd.info.binary.shutter.html
@@ -1,4 +1,4 @@
-<div class="cmd cmd-widget shuttergauge cursor #history#" data-type="info" data-subtype="binary" data-template="shutter" data-cmd_id="#id#" data-cmd_uid="#uid#" data-version="#version#" data-eqLogic_id="#eqLogic_id#">
+<div class="cmd cmd-widget shuttergauge #history#" data-type="info" data-subtype="binary" data-template="shutter" data-cmd_id="#id#" data-cmd_uid="#uid#" data-version="#version#" data-eqLogic_id="#eqLogic_id#">
   <div class="title #hide_name#">
     <div class="cmdName">#name_display#</div>
   </div>

--- a/core/template/dashboard/cmd.info.binary.tmplicon.html
+++ b/core/template/dashboard/cmd.info.binary.tmplicon.html
@@ -1,4 +1,4 @@
-<div class="cmd cmd-widget cursor #history#" data-type="info" data-subtype="binary" data-template="tmplicon" data-cmd_id="#id#" data-cmd_uid="#uid#" data-version="#version#">
+<div class="cmd cmd-widget #history#" data-type="info" data-subtype="binary" data-template="tmplicon" data-cmd_id="#id#" data-cmd_uid="#uid#" data-version="#version#">
   <div class="title #hide_name#">
     <div class="cmdName">#name_display#</div>
   </div>

--- a/core/template/dashboard/cmd.info.binary.tmplimg.html
+++ b/core/template/dashboard/cmd.info.binary.tmplimg.html
@@ -1,4 +1,4 @@
-<div class="cmd cmd-widget cursor #history#" data-type="info" data-subtype="binary" data-template="tmplimg" data-cmd_id="#id#" data-cmd_uid="#uid#" data-version="#version#">
+<div class="cmd cmd-widget #history#" data-type="info" data-subtype="binary" data-template="tmplimg" data-cmd_id="#id#" data-cmd_uid="#uid#" data-version="#version#">
   <div class="title #hide_name#">
     <div class="cmdName">#name_display#</div>
   </div>


### PR DESCRIPTION
Suppression des classes cursor sur les widgets d'info pour éviter que le curseur ne passe en main au survol alors qu'aucune action n'est possible.