### PR TITLE
Use debian:stretch to create Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:latest
+FROM debian:stretch
 
 MAINTAINER info@jeedom.com
 


### PR DESCRIPTION
Jeedom needs Debian Stretch to run since 3.1.5.
https://jeedom.github.io/documentation/installation/fr_FR/index#tocAnchor-1-8