### PR TITLE
Fix Dockerfile mysql-client install for Debian buster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV APACHE_PORT 80
 ENV SSH_PORT 22
 ENV MODE_HOST 0
 
-RUN apt-get update && apt-get install -y wget openssh-server supervisor mysql-client
+RUN apt-get update && apt-get install -y wget openssh-server supervisor default-mysql-client
 
 RUN echo "root:${SHELL_ROOT_PASSWORD}" | chpasswd && \
 sed -i 's/PermitRootLogin without-password/PermitRootLogin yes/' /etc/ssh/sshd_config && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV APACHE_PORT 80
 ENV SSH_PORT 22
 ENV MODE_HOST 0
 
-RUN apt-get update && apt-get install -y wget openssh-server supervisor
+RUN apt-get update && apt-get install -y wget openssh-server supervisor mysql-client
 
 RUN echo "root:${SHELL_ROOT_PASSWORD}" | chpasswd && \
 sed -i 's/PermitRootLogin without-password/PermitRootLogin yes/' /etc/ssh/sshd_config && \
@@ -27,7 +27,9 @@ RUN /root/install_docker.sh -s 2;exit 0
 RUN /root/install_docker.sh -s 4;exit 0
 RUN /root/install_docker.sh -s 5;exit 0
 RUN /root/install_docker.sh -s 8;exit 0
+RUN /root/install_docker.sh -s 9;exit 0
 RUN /root/install_docker.sh -s 11;exit 0
+RUN /root/install_docker.sh -s 12;exit 0
 RUN systemctl disable apache2;exit 0
 RUN systemctl disable sshd;exit 0
 

--- a/install/install.sh
+++ b/install/install.sh
@@ -446,7 +446,9 @@ case ${STEP} in
   ;;
   10) step_10_jeedom_installation
   ;;
-  11) step_11_jeedom_check
+  11) step_11_jeedom_post
+  ;;
+  12) step_12_jeedom_check
   ;;
   *) echo "${ROUGE}Désolé, Je ne peux sélectionner une ${STEP} étape pour vous !${NORMAL}"
   ;;


### PR DESCRIPTION
This PR fixes the creation of the docker image for Debian buster.

[a6a7a31](https://github.com/jeedom/core/commit/a6a7a310e366db0469bd050ca1d3bf3c9553ceca) comes from a [PR that was directly merged on beta](https://github.com/jeedom/core/pull/1620) by mistake.