### PR TITLE
[Docker] Realign Dockerfile_full with Dockerfile

### DIFF
--- a/Dockerfile_full
+++ b/Dockerfile_full
@@ -1,17 +1,10 @@
-FROM debian:latest
+FROM debian:stretch
 
 MAINTAINER info@jeedom.com
 
-RUN apt-get update
+COPY install/install.sh /tmp/
+RUN sh /tmp/install.sh
 
-ADD install/install.sh /root/install_docker.sh
-RUN chmod +x /root/install_docker.sh
-RUN /root/install_docker.sh
-
-VOLUME /var/lib/mysql
-VOLUME /var/www/html
-EXPOSE 80
-
-ADD install/OS_specific/Docker/init.sh /root/init.sh
+COPY install/OS_specific/Docker/init.sh /root/
 RUN chmod +x /root/init.sh
 CMD ["/root/init.sh"]


### PR DESCRIPTION
(I did not test it)

$ diff -u Dockerfile Dockerfile_full
--- Dockerfile	2020-03-31 10:47:36.564738042 +0200
+++ Dockerfile_full	2020-03-31 12:28:53.787640813 +0200
@@ -3,12 +3,7 @@
 MAINTAINER info@jeedom.com

 COPY install/install.sh /tmp/
-RUN sh /tmp/install.sh -s 1
-RUN sh /tmp/install.sh -s 2
-RUN sh /tmp/install.sh -s 4
-RUN sh /tmp/install.sh -s 5
-RUN sh /tmp/install.sh -s 8
-RUN sh /tmp/install.sh -s 11
+RUN sh /tmp/install.sh

 COPY install/OS_specific/Docker/init.sh /root/
 RUN chmod +x /root/init.sh