### PR TITLE
Clean Docker's init.sh

### DIFF
--- a/install/OS_specific/Docker/init.sh
+++ b/install/OS_specific/Docker/init.sh
@@ -2,10 +2,10 @@
 echo 'Start init'
 
 echo 'Start atd'
-service atd restart
+service atd start
 
 echo 'Starting mysql'
-service mysql restart
+service mysql start
 
 if ! [ -f /.jeedom_backup_restore ]; then
 	if [ ! -z "${RESTOREBACKUP}" ] && [ "${RESTOREBACKUP}" != 'NO' ]; then

--- a/install/OS_specific/Docker/init.sh
+++ b/install/OS_specific/Docker/init.sh
@@ -1,35 +1,6 @@
 #!/bin/bash
 echo 'Start init'
 
-if [ -f /var/www/html/core/config/common.config.php ]; then
-	echo 'Jeedom is already install'
-else
-	echo 'Start jeedom installation'
-	rm -rf /root/install.sh
-	wget https://raw.githubusercontent.com/jeedom/core/alpha/install/install.sh -O /root/install.sh
-	chmod +x /root/install.sh
-	/root/install.sh -s 6
-	if [ $(which mysqld | wc -l) -ne 0 ]; then
-		chown -R mysql:mysql /var/lib/mysql
-		mysql_install_db --user=mysql --basedir=/usr/ --ldata=/var/lib/mysql/
-		service mysql restart
-		MYSQL_JEEDOM_PASSWD=$(cat /dev/urandom | tr -cd 'a-f0-9' | head -c 15)
-		echo "DROP USER 'jeedom'@'localhost';" | mysql > /dev/null 2>&1
-		echo  "CREATE USER 'jeedom'@'localhost' IDENTIFIED BY '${MYSQL_JEEDOM_PASSWD}';" | mysql
-		echo  "DROP DATABASE IF EXISTS jeedom;" | mysql
-		echo  "CREATE DATABASE jeedom;" | mysql
-		echo  "GRANT ALL PRIVILEGES ON jeedom.* TO 'jeedom'@'localhost';" | mysql
-		cp /var/www/html/core/config/common.config.sample.php /var/www/html/core/config/common.config.php
-		sed -i "s/#PASSWORD#/${MYSQL_JEEDOM_PASSWD}/g" /var/www/html/core/config/common.config.php
-		sed -i "s/#DBNAME#/jeedom/g" /var/www/html/core/config/common.config.php
-		sed -i "s/#USERNAME#/jeedom/g" /var/www/html/core/config/common.config.php
-		sed -i "s/#PORT#/3306/g" /var/www/html/core/config/common.config.php
-		sed -i "s/#HOST#/localhost/g" /var/www/html/core/config/common.config.php
-		/root/install.sh -s 10
-		/root/install.sh -s 11
-	fi
-fi
-
 echo 'Start atd'
 service atd restart
 

--- a/install/OS_specific/Docker/init.sh
+++ b/install/OS_specific/Docker/init.sh
@@ -4,10 +4,8 @@ echo 'Start init'
 echo 'Start atd'
 service atd restart
 
-if [ $(which mysqld | wc -l) -ne 0 ]; then
-	echo 'Starting mysql'
-	service mysql restart
-fi
+echo 'Starting mysql'
+service mysql restart
 
 if ! [ -f /.jeedom_backup_restore ]; then
 	if [ ! -z "${RESTOREBACKUP}" ] && [ "${RESTOREBACKUP}" != 'NO' ]; then


### PR DESCRIPTION
With the recent changes...

- Jeedom is already installed (```step_6```), so ```[ -f /var/www/html/core/config/common.config.php ]``` is always ```true```.
- mariadb is installed inside the container, so ```[ $(which mysqld | wc -l) -ne 0 ]``` is also always ```true```.

I'm also throwing in a cosmetic change... no need to restart services that are not started.