### PR TITLE
Move preInstallUpdate in doUpdate after $zip->open

### DIFF
--- a/core/class/update.class.php
+++ b/core/class/update.class.php
@@ -291,7 +291,6 @@ class update {
 		} else {
 			$class = 'repo_' . $this->getSource();
 			if (class_exists($class) && method_exists($class, 'downloadObject') && config::byKey($this->getSource() . '::enable') == 1) {
-				$this->preInstallUpdate();
 				$cibDir = jeedom::getTmpFolder('market') . '/' . $this->getLogicalId();
 				if (file_exists($cibDir)) {
 					rrmdir($cibDir);
@@ -324,6 +323,7 @@ class update {
 					$zip = new ZipArchive;
 					$res = $zip->open($tmp);
 					if ($res === TRUE) {
+						$this->preInstallUpdate();
 						if (!$zip->extractTo($cibDir . '/')) {
 							$content = file_get_contents($tmp);
 							throw new Exception(__('Impossible d\'installer le plugin. Les fichiers n\'ont pas pu être décompressés : ', __FILE__) . substr($content, 255));


### PR DESCRIPTION
Le nettoyage du répertoire du plugin est fait trop tot.
En cas d'erreur de téléchargement du zip, le plugin est inopérationnel.
Le controle de consistance du zip est fait par $zip->open 
On en a parlé ici sans vous ;-)  : https://community.jeedom.com/t/fonction-du-core-qui-fait-le-menage-dans-les-plugins-preinstallupdate/28611/37?u=jpty