### PR TITLE
better restart of docker jeedom installation

### DIFF
--- a/install/OS_specific/Docker/init.sh
+++ b/install/OS_specific/Docker/init.sh
@@ -59,7 +59,17 @@ chmod 777 -R /tmp
 chmod 755 -R /var/www/html
 chown -R www-data:www-data /var/www/html
 
+echo 'Verify .dockerinit to recognize docker installation for jeedom'
+if ! [ -f /.dockerinit ]; then
+        touch /.dockerinit
+        chmod 755 /.dockerinit
+fi
+
+echo 'Remove /tmp/jeedom/started file'
+rm -f /tmp/jeedom/started
+
 echo 'Start apache2'
 service apache2 start
 
+echo 'Start cron'
 cron -f


### PR DESCRIPTION
* Installation will be recognize as a docker installation by Jeedom thanks to /.dockerinit
* Correct restart (plugins immediately reload and scenarios with trigger #start# thanks to removal of /tmp/jeedom/started