### PR TITLE
Allow refreshValue when no HTML element is available

### DIFF
--- a/core/js/cmd.class.js
+++ b/core/js/cmd.class.js
@@ -341,7 +341,7 @@ jeedom.cmd.refreshValue = function(_params) {
   var cmd = null;
   for(var i in _params){
     cmd = $('.cmd[data-cmd_id=' + _params[i].cmd_id + ']');
-    if (cmd.html() != undefined && cmd.hasClass('noRefresh')) {
+    if (cmd.hasClass('noRefresh')) {
       continue;
     }
     if (!isset(jeedom.cmd.update) || !isset(jeedom.cmd.update[_params[i].cmd_id])) {

--- a/core/js/cmd.class.js
+++ b/core/js/cmd.class.js
@@ -341,7 +341,7 @@ jeedom.cmd.refreshValue = function(_params) {
   var cmd = null;
   for(var i in _params){
     cmd = $('.cmd[data-cmd_id=' + _params[i].cmd_id + ']');
-    if (cmd.html() == undefined || cmd.hasClass('noRefresh')) {
+    if (cmd.html() != undefined && cmd.hasClass('noRefresh')) {
       continue;
     }
     if (!isset(jeedom.cmd.update) || !isset(jeedom.cmd.update[_params[i].cmd_id])) {


### PR DESCRIPTION
This check block the use of jeedom refresh mecanism in advanced custom designs (for exemple, if I want to trigger hide/show of elements depending the refresh of a value, I need to add a dummy html element with correct class and field to not block the trigger of `jeedom.cmd.update[_params[i].cmd_id](_params[i]);`.