### PR TITLE
Add -s option to sudo command

### DIFF
--- a/core/class/system.class.php
+++ b/core/class/system.class.php
@@ -84,12 +84,12 @@ class system {
 	
 	public static function getCmdSudo() {
 		if(!class_exists('jeedom')){
-			return 'sudo ';
+			return 'sudo -s ';
 		}
 		if (!jeedom::isCapable('sudo')) {
 			return '';
 		}
-		return 'sudo ';
+		return 'sudo -s ';
 	}
 	
 	public static function fuserk($_port, $_protocol = 'tcp') {


### PR DESCRIPTION
Since v10 of Debian (Buster), the behavior of the sudo command has changed (see https://wiki.debian.org/NewInBuster for details).
The result is that the upgrade of Jeedom is broken on such system because all commands requested with sudo are not foudn in $PATH.

A solution is to add the -s option to the sudo command.
From my research, adding -s solve this issue and does not impact negatively other systems.