### PR TITLE
Update jeeApi.php

### DIFF
--- a/core/api/jeeApi.php
+++ b/core/api/jeeApi.php
@@ -120,7 +120,7 @@ if (init('type') != '') {
 		if ($type != init('plugin', 'core') && init('plugin', 'core') != 'core') {
 			throw new Exception(__('Vous n\'êtes pas autorisé à effectuer cette action 4, IP : ', __FILE__) . getClientIp());
 		}
-		if (class_exists($type) && method_exists($type, 'event')) {
+		if ($type != 'object' && class_exists($type) && method_exists($type, 'event')) {
 			log::add('api', 'info', __('Appels de ', __FILE__) . secureXSS($type) . '::event()');
 			$type::event();
 			die();


### PR DESCRIPTION
L'api de base 'object' ne marche plus :
http://jeedomIP/core/api/jeeApi.php?apikey=xxx&type=object
Voici un correctif possible (l'autre serait de descendre le test `if (class_exists($type) && method_exists($type, 'event'))` plus bas dans le code