### PR TITLE
Correct typo in function cleanFileSystemRight() name

### DIFF
--- a/core/ajax/jeedom.ajax.php
+++ b/core/ajax/jeedom.ajax.php
@@ -409,7 +409,7 @@ try {
 
 	if (init('action') == 'cleanFileSystemRight') {
 		unautorizedInDemo();
-		ajax::success(jeedom::cleanFileSytemRight());
+		ajax::success(jeedom::cleanFileSystemRight());
 	}
 
 	if (init('action') == 'consistency') {

--- a/core/class/jeedom.class.php
+++ b/core/class/jeedom.class.php
@@ -1394,7 +1394,7 @@ class jeedom {
 		system::php($cmd, true);
 	}
 
-	public static function cleanFileSytemRight() {
+	public static function cleanFileSystemRight() {
 		$cmd = system::getCmdSudo() . 'chown -R ' . system::get('www-uid') . ':' . system::get('www-gid') . ' ' . __DIR__ . '/../../*;';
 		$cmd .= system::getCmdSudo() . 'chmod 775 -R ' . __DIR__ . '/../../*;';
 		$cmd .= system::getCmdSudo() . 'find ' . __DIR__ . '/../../log -type f -exec chmod 665 {} +;';

--- a/install/backup.php
+++ b/install/backup.php
@@ -38,7 +38,7 @@ try {
 	
 	try {
 		echo 'Vérification des droits sur les fichiers...';
-		jeedom::cleanFileSytemRight();
+		jeedom::cleanFileSystemRight();
 		echo "OK\n";
 	} catch (Exception $e) {
 		echo "NOK\n";
@@ -228,7 +228,7 @@ try {
 	
 	try {
 		echo 'Vérification des droits sur les fichiers...';
-		jeedom::cleanFileSytemRight();
+		jeedom::cleanFileSystemRight();
 		echo "OK\n";
 	} catch (Exception $e) {
 		echo "NOK\n";

--- a/install/consistency.php
+++ b/install/consistency.php
@@ -368,7 +368,7 @@ if(method_exists('utils','attrChanged')){
 	}
 	try {
 		echo "\nCheck filesystem right...";
-		jeedom::cleanFileSytemRight();
+		jeedom::cleanFileSystemRight();
 		echo "OK\n";
 	} catch (Exception $e) {
 		echo "NOK\n";

--- a/install/restore.php
+++ b/install/restore.php
@@ -78,7 +78,7 @@ try {
 	
 	try {
 		echo "Vérification des droits...";
-		jeedom::cleanFileSytemRight();
+		jeedom::cleanFileSystemRight();
 		echo "OK\n";
 	} catch (Exception $e) {
 		echo '***ERREUR*** ' . $e->getMessage();

--- a/install/update.php
+++ b/install/update.php
@@ -75,7 +75,7 @@ try {
 	echo "[PROGRESS][5]\n";
 	try {
 		echo "Check rights...";
-		jeedom::cleanFileSytemRight();
+		jeedom::cleanFileSystemRight();
 		echo "OK\n";
 	} catch (Exception $e) {
 		echo '***ERROR***' . $e->getMessage();


### PR DESCRIPTION
While working on another topic, I realized there was a typo in this function name.
I searched all calls to the function and propose to fix ti.