### PR TITLE
allow access to others UART on pi4

### DIFF
--- a/core/class/jeedom.class.php
+++ b/core/class/jeedom.class.php
@@ -572,6 +572,9 @@ class jeedom {
 				if (file_exists('/dev/ttyAMA0')) {
 					$usbMapping['Raspberry pi'] = '/dev/ttyAMA0';
 				}
+				foreach (ls('/dev/', 'ttyAMA*') as $value) {
+					$usbMapping['/dev/' . $value] = '/dev/' . $value;
+				}
 				if (file_exists('/dev/ttymxc0')) {
 					$usbMapping['Jeedom board'] = '/dev/ttymxc0';
 				}


### PR DESCRIPTION
I let the existing "Raspberry pi" mapping for backward compatibility with existing config

see discussion here: https://community.jeedom.com/t/resolu-plugin-zwave-sur-rpi4-utiliser-un-autre-uart-que-dev-ttyama0/51171/8