### PR TITLE
Viewing a log file from a plugin configuration page

### DIFF
--- a/desktop/js/plugin.js
+++ b/desktop/js/plugin.js
@@ -572,9 +572,9 @@ $('#bt_savePluginLogConfig').off('click').on('click', function() {
 $('#div_configLog').on({
   'click': function(event) {
     if ($('#md_modal').is(':visible')) {
-      $('#md_modal2').dialog({title: "{{Log du plugin}}" + ' ' + $(this).attr('data-log')}).load('index.php?v=d&modal=log.display&log='+$(this).attr('data-log')).dialog('open')
+      $('#md_modal2').dialog({title: "{{Log du plugin}}" + ' ' + $(this).attr('data-log')}).load('index.php?v=d&modal=log.display&log='+escape($(this).attr('data-log'))).dialog('open')
     } else {
-      $('#md_modal').dialog({title: "{{Log du plugin}}" + ' ' + $(this).attr('data-log')}).load('index.php?v=d&modal=log.display&log='+$(this).attr('data-log')).dialog('open')
+      $('#md_modal').dialog({title: "{{Log du plugin}}" + ' ' + $(this).attr('data-log')}).load('index.php?v=d&modal=log.display&log='+escape($(this).attr('data-log'))).dialog('open')
     }
   }
 }, '.bt_plugin_conf_view_log')


### PR DESCRIPTION
Escaping characters in the filename allowing it to be viewed correctly from the plugin configuration page. For example, the filename cloudsyncpro.#123