### PR TITLE
cmd.action.other.tmplicon.html    utilisable pour cmd action standard sans retour d'etat

### DIFF
--- a/core/template/dashboard/cmd.action.other.tmplicon.html
+++ b/core/template/dashboard/cmd.action.other.tmplicon.html
@@ -17,8 +17,7 @@
       if ('#_time_widget_#' != '1') cmd.find('.timeCmd').parent().remove()
       
       if (_options.display_value == '') {
-        cmd.show();
-			  cmd.find('.iconCmd').empty().append((jeedom.cmd.normalizeName('#name#') == 'off') ? "#_icon_off_#" : "#_icon_on_#");
+	cmd.find('.iconCmd').empty().append((jeedom.cmd.normalizeName('#name#') == 'off') ? "#_icon_off_#" : "#_icon_on_#");
       } else if (['1', 1, '99', 99, 'on'].includes(_options.display_value)) {
         if (jeedom.cmd.normalizeName('#name#') == 'on') {
           cmd.hide()

--- a/core/template/dashboard/cmd.action.other.tmplicon.html
+++ b/core/template/dashboard/cmd.action.other.tmplicon.html
@@ -15,12 +15,15 @@
     jeedom.cmd.update['#id#'] = function(_options) {
       var cmd = $('.cmd[data-cmd_id=#id#]')
       if ('#_time_widget_#' != '1') cmd.find('.timeCmd').parent().remove()
-
-      if (['1', 1, '99', 99, 'on'].includes(_options.display_value)) {
+      
+      if (_options.display_value == '') {
+        cmd.show();
+			  cmd.find('.iconCmd').empty().append((jeedom.cmd.normalizeName('#name#') == 'off') ? "#_icon_off_#" : "#_icon_on_#");
+      } else if (['1', 1, '99', 99, 'on'].includes(_options.display_value)) {
         if (jeedom.cmd.normalizeName('#name#') == 'on') {
           cmd.hide()
         } else {
-          cmd.show()
+          cmd.show();
           cmd.find('.iconCmd').empty().append("#_icon_on_#")
           if ('#_time_widget_#' == '1') jeedom.cmd.displayDuration(_options.valueDate, cmd.find('.timeCmd'), '#time#')
         }


### PR DESCRIPTION
cmd.action.other.tmplicon.html    utilisable aussi pour cmd action standard sans retour d'etat. evite que l'icone ne soit cachee si la commande normalisee est off