### PR TITLE
Add unset($component['type']);

### DIFF
--- a/core/ajax/view.ajax.php
+++ b/core/ajax/view.ajax.php
@@ -137,6 +137,7 @@ try {
 				if (!is_object($eqLogic)) {
 					continue;
 				}
+				unset($component['type']);
 				utils::a2o($eqLogic, $component);
 				$eqLogic->save(true);
 			}elseif($component['type'] == 'scenario'){
@@ -144,6 +145,7 @@ try {
 				if (!is_object($scenario)) {
 					continue;
 				}
+				unset($component['type']);
 				utils::a2o($scenario, $component);
 				$scenario->save(true);
 			}


### PR DESCRIPTION
Add unset($component['type']); before a2o
the 'type' is not used in a2o, but get trouble if a function is called "settype" in a plugin. (get 'true' with method_exists gettype)
For example, the jMQTT plugin uses the setType() setter, when a user change a view (with the pencil), it changes the type by eqLogic in the plugin.

This modification is a prevention in case another plugin uses the same settler.