### PR TITLE
Don't display cmd.configure modal on textarea dblclick

### DIFF
--- a/core/js/plugin.template.js
+++ b/core/js/plugin.template.js
@@ -490,7 +490,7 @@ $('#div_pageContainer').on('click', '.cmd .cmdAction[data-action=test]', functio
   }
 })
 
-$('#div_pageContainer').on('dblclick', '.cmd input,select,span,a', function(event) {
+$('#div_pageContainer').on('dblclick', '.cmd input,textarea,select,span,a', function(event) {
   event.stopPropagation()
 })
 


### PR DESCRIPTION
In jMQTT plugin, We are using some textarea instead of input field to allow multiline values.
Double-click on a cmd displays a modal named "Configuration commande".
Exception exists for input,textarea,select,span,a fields type but not for textarea.
This one needs to be added.
