### PR TITLE
Test context of sudo to identify of -s option is required

### DIFF
--- a/core/class/system.class.php
+++ b/core/class/system.class.php
@@ -89,7 +89,12 @@ class system {
 		if (!jeedom::isCapable('sudo')) {
 			return '';
 		}
-		return 'sudo ';
+		// Test context of sudo
+		if (strlen(shell_exec('sudo which chown 2>/dev/null'))) {
+			return 'sudo ';
+		} else {
+			return 'sudo -s ';
+		}
 	}
 	
 	public static function fuserk($_port, $_protocol = 'tcp') {


### PR DESCRIPTION
I still face the issue which made me propose the pull request #1770. On my system, sudo requires the -s option to operate with the appropriate path.
Since my first proposal seems to cause issue, I come with this alternative.