### PR TITLE
Fix humanReadableToCmd which breaks bool and null

### DIFF
--- a/core/class/cmd.class.php
+++ b/core/class/cmd.class.php
@@ -545,6 +545,9 @@ class cmd {
 			}
 			return $_input;
 		}
+		if (is_bool($_input) || is_null($_input)) {
+			return $_input;
+		}
 		$replace = array();
 		preg_match_all("/#\[(.*?)\]\[(.*?)\]\[(.*?)\]#/", $_input, $matches);
 		if (count($matches) == 4) {


### PR DESCRIPTION
If someone fill in a cmd input with a JSON containing a boolean or null and save the equipement. (like {"bidule":true})
This JSON string is converted as object and sent to eqLogic.ajax.php for 'save' action.
During the save, the cmd part of the equipment is passed through cmd::humanReadableToCmd() recusive function.
This one go through the filled in JSON structure which finally end on a boolean or null.
boolean or null value doesn't match any case and go to the end of this function which is an str_replace().
And Bam!, true becomes '1', false -> '0' and null -> ''
:-(

ref : https://community.jeedom.com/t/json-interprete-dans-champs-des-commandes-bug-core/57935
