### PR TITLE
fix value position for info>numeric>default

### DIFF
--- a/desktop/css/coreWidgets.css
+++ b/desktop/css/coreWidgets.css
@@ -464,6 +464,9 @@ Desktop
   div.cmd-widget[data-type="info"][data-subtype="numeric"][data-template="default"] {
     text-align: center;
   }
+  div.cmd-widget[data-type="info"][data-subtype="numeric"][data-template="default"] .state {
+    width: 90px;
+  }
   .cmd-widget.widget-hygrothermographe {
     width: 220px;
     height: 220px;


### PR DESCRIPTION
When cmdName is too long, the value is not center in the middle of the gauge :
![Capture d’écran 2021-05-05 à 12 42 37](https://user-images.githubusercontent.com/46993341/117132082-9de0e180-ada2-11eb-9bc6-587b8834c68b.png)

Gauge size is fixed to 90px :
![Capture d’écran 2021-05-05 à 12 45 06](https://user-images.githubusercontent.com/46993341/117132243-d8e31500-ada2-11eb-886c-75cf036b5d27.png)

So state value should be as well :
![Capture d’écran 2021-05-05 à 12 43 02](https://user-images.githubusercontent.com/46993341/117132290-f0220280-ada2-11eb-9eb3-795c5f620a79.png)
