### PR TITLE
Fix humanReadableToCmd which breaks int

### DIFF
--- a/core/class/cmd.class.php
+++ b/core/class/cmd.class.php
@@ -545,7 +545,7 @@ class cmd {
 			}
 			return $_input;
 		}
-		if (is_bool($_input) || is_null($_input)) {
+		if (is_int($_input) || is_bool($_input) || is_null($_input)) {
 			return $_input;
 		}
 		$replace = array();


### PR DESCRIPTION
Next to PR #1825 , the problem also occurs with integers too.

in cmd::humanReadableToCmd()
If $_input contains an integer (from a parsed json), it doesn't match any case and go to the end of this function which is an str_replace().
And Bam!, 55 becomes "55"
:-(