### PR TITLE
Bugfix: can’t delete any admin user if only one is active

### DIFF
--- a/core/class/user.class.php
+++ b/core/class/user.class.php
@@ -475,7 +475,7 @@ class user {
 	}
 	
 	public function preRemove() {
-		if (count(user::byProfils('admin', true)) == 1 && $this->getProfils() == 'admin') {
+		if (count(user::byProfils('admin', true)) == 1 && ($this->getProfils() == 'admin' && $this->getEnable() == 1)) {
 			throw new Exception(__('Vous ne pouvez supprimer le dernier administrateur', __FILE__));
 		}
 	}


### PR DESCRIPTION
Only the active one should be locked