### PR TITLE
Update scenarioExpression.class.php

### DIFF
--- a/core/class/scenarioExpression.class.php
+++ b/core/class/scenarioExpression.class.php
@@ -692,6 +692,7 @@ class scenarioExpression {
 				} else {
 					if ($lastValue == $_value) {
 						$duration = $duration + (strtotime($_endTime) - $lastDuration);
+						$lastValue = round($history->getValue(), $_decimal);
 					}
 					break;
 				}
@@ -702,6 +703,7 @@ class scenarioExpression {
 			$lastValue = round($history->getValue(), $_decimal);
 		}
 		if ($lastValue == $_value && $lastDuration <= strtotime($_endTime)) {
+			if (time() < strtotime($_endTime)) $_endTime = date('Y-m-d H:i:s');
 			$duration = $duration + (strtotime($_endTime) - $lastDuration);
 		}
 		return floor($duration / $_unit);


### PR DESCRIPTION
Modification de durationBetween() :
Fixe l'ajout en doublon de $duration constaté lors du break qui réinitialise pas le $lastValue.
Fixe si  $_endTime > time() ce qui permet de n'envoyer que le $duration entre $_startDate et time().