### PR TITLE
Update the documentation concerning available actions for the scenario HTTP API

### DIFF
--- a/docs/fr_FR/api_http.md
+++ b/docs/fr_FR/api_http.md
@@ -19,7 +19,7 @@ Cette API s’utilise très facilement par de simples requêtes HTTP via URL.
 Voici l’URL = [http://\#IP\_JEEDOM\#/core/api/jeeApi.php?apikey=\#APIKEY\#&type=scenario&id=\#ID\#&action=\#ACTION\#](http://#IP_JEEDOM#/core/api/jeeApi.php?apikey=#APIKEY#&type=scenario&id=#ID#&action=#ACTION#)
 
 - **id** : correspond à l’id de votre scénario. L’ID se trouve sur la page du scénario concerné, dans "Outils" → "Scénarios", une fois le scénario sélectionné, à côté du nom de l’onglet "Général". Autre moyen de le retrouver : dans "Outils" → "Scénarios", cliquez sur "Vue d’ensemble".
-- **action** : correspond à l’action que vous voulez appliquer. Les commandes disponibles sont : "start", "stop", "désactiver" et "activer" pour respectivement démarrer, arrêter, désactiver ou activer le scénario.
+- **action** : correspond à l’action que vous voulez appliquer. Les commandes disponibles sont : "start", "stop", "deactivate" et "activate" pour respectivement démarrer, arrêter, désactiver ou activer le scénario.
 - **tags** \[optionnel\] : si l’action est "start", vous pouvez passer des tags au scénario (voir la documentation sur les scénarios) sous la forme tags=toto%3D1%20tata%3D2 (à noter que %20 correspond à un espace et %3D à = ).
 
 ##  Info/Action commande


### PR DESCRIPTION
I can see in the [German](https://github.com/jeedom/core/blob/alpha/docs/de_DE/api_http.md#szenario), [Spanish](https://github.com/jeedom/core/blob/alpha/docs/es_ES/api_http.md#gui%C3%B3n) and [Portuguese](https://github.com/jeedom/core/blob/alpha/docs/pt_PT/api_http.md#cenas) documentation that the available actions have been also translated, but from what [I can see in the code](https://github.com/jeedom/core/blob/8c57bc2e62018e4448480feaf0bddda166813579/core/api/jeeApi.php#L142), the actions are hard-coded in English.

Should I also update the documentation for others languages ?