### PR TITLE
Passage à l'heure d'hiver

### DIFF
--- a/core/class/cron.class.php
+++ b/core/class/cron.class.php
@@ -360,7 +360,7 @@ class cron {
 	* @return boolean
 	*/
 	public function isDue() {
-		if(((new DateTime('today midnight +1 day'))->format('I') - (new DateTime('today midnight'))->format('I')) == -1 && date('G') > 0 && date('G') < 4){
+		if(((new DateTime('today midnight +1 day'))->format('I') - (new DateTime('today midnight'))->format('I')) == -1 && date('Gi') > 155 && date('Gi') < 305){
 			return false;
 		}
 		//check if already sent on that minute


### PR DESCRIPTION
Réduction de la plage d'inactivité du cron lors du changement d'heure en octobre.
Avant modif, pas de cron entre 0h59 à 4h00 soit 4h sans cron
Avec modif: 1h55 à 3h05 soit 2h10 sans cron