### PR TITLE
DB connection never reinit

### DIFF
--- a/core/class/DB.class.php
+++ b/core/class/DB.class.php
@@ -48,6 +48,7 @@ class DB {
 	public static function getConnection() {
 		if(self::$connection == null){
 			self::initConnection();
+			self::$lastConnection = strtotime('now');
 		}else if (self::$lastConnection + 120 < strtotime('now')) {
 			try {
 				$result = @self::$connection->query('select 1;');
@@ -57,8 +58,8 @@ class DB {
 			} catch (Exception $e) {
 				self::initConnection();
 			}
+			self::$lastConnection = strtotime('now');
 		}
-		self::$lastConnection = strtotime('now');
 		return self::$connection;
 	}
 


### PR DESCRIPTION
`self::$lastConnection = strtotime('now')` should be done only if `self::initConnection()` is called or connection is checked.

### Case is the following:
- PHP Daemon is maintaining a DB connection,
- Daily backup occurs, DB is partially locked,
- Daemon requests DB using eqLogic::byId(xxx) when locked and request fails:
```
PHP Warning:  Error while sending QUERY packet. PID=11072 in /var/www/html/core/class/DB.class.php on line 118
[...]
PHP  21. eqLogic::byId() /var/www/html/plugins/jMQTT/core/class/jMQTT.class.php:1678
PHP  22. DB::Prepare() /var/www/html/core/class/eqLogic.class.php:78
PHP  23. PDOStatement->execute() /var/www/html/core/class/DB.class.php:118
```
- DB connection is no longer usable after that,
- **BUT**, next DB request is arriving a few seconds later (or at least <120s),
- Call to `DB::getConnection()`, `self::$connection` is not `null`, as it is the same connection and `DB::Prepare()` does not reset it,
- `self::$lastConnection + 120 < strtotime('now')` is obviously `false`,
- `self::$lastConnection` is set to `strtotime('now')`, the same connection is returned without checking it,
- And so on, for each new call to `DB::getConnection()`, as long as the Daemon is not restarted.
