### PR TITLE
Fix gif as valid

### DIFF
--- a/core/ajax/object.ajax.php
+++ b/core/ajax/object.ajax.php
@@ -289,7 +289,7 @@ try {
 			}
 			$extension = strtolower(strrchr($_FILES['file']['name'], '.'));
 			if (!in_array($extension, array('.jpg', '.png', '.gif'))) {
-				throw new Exception(__('Extension du fichier non valide (autorisé .jpg .png) : ', __FILE__) . $extension);
+				throw new Exception(__('Extension du fichier non valide (autorisé .jpg .png .gif) : ', __FILE__) . $extension);
 			}
 			if (filesize($_FILES['file']['tmp_name']) > 5000000) {
 				throw new Exception(__('Le fichier est trop gros (maximum 5Mo)', __FILE__));

--- a/core/ajax/plan.ajax.php
+++ b/core/ajax/plan.ajax.php
@@ -202,7 +202,7 @@ try {
 			throw new Exception(__('Aucun fichier trouvé. Vérifiez le paramètre PHP (post size limit)', __FILE__));
 		}
 		$extension = strtolower(strrchr($_FILES['file']['name'], '.'));
-		if (!in_array($extension, array('.jpg', '.png'))) {
+		if (!in_array($extension, array('.jpg', '.png', '.gif'))) {
 			throw new Exception(__('Extension du fichier non valide (autorisé .jpg .png .gif) : ', __FILE__) . $extension);
 		}
 		if (filesize($_FILES['file']['tmp_name']) > 5000000) {


### PR DESCRIPTION
.gif was added in commit https://github.com/jeedom/core/commit/5fb296f42f76c1b42d43a90fdbe569ef9c0a4b1b but Exception was not updated:
https://github.com/jeedom/core/blob/4e13839aad1fbce5fd9a793d92182025dbe0cdca/core/ajax/object.ajax.php#L291-L292

Exception does not match array here: https://github.com/jeedom/core/blob/4e13839aad1fbce5fd9a793d92182025dbe0cdca/core/ajax/plan.ajax.php#L205-L206 

Also, consider adding .gif in:
- https://github.com/jeedom/core/tree/alpha/core/ajax/config.ajax.php#L117
- https://github.com/jeedom/core/tree/alpha/core/ajax/plan.ajax.php#L247
- https://github.com/jeedom/core/tree/alpha/core/ajax/view.ajax.php#L202

I can update this PR in that way if you wish ;)