### PR TITLE
Fix log::removeAll() and add Empty All Log

### DIFF
--- a/core/ajax/log.ajax.php
+++ b/core/ajax/log.ajax.php
@@ -36,6 +36,12 @@ try {
 		ajax::success();
 	}
 
+	if (init('action') == 'clearAll') {
+		unautorizedInDemo();
+		log::clearAll();
+		ajax::success();
+	}
+
 	if (init('action') == 'remove') {
 		unautorizedInDemo();
 		log::remove(init('log'));

--- a/core/class/log.class.php
+++ b/core/class/log.class.php
@@ -194,6 +194,16 @@ class log {
 		}
 		return;
 	}
+	public static function clearAll() {
+		foreach (array('', 'scenarioLog/') as $logPath) {
+			$logs = ls(self::getPathToLog($logPath), '*');
+			foreach ($logs as $log) {
+				self::clear($logPath.$log);
+			}
+		}
+		return true;
+	}
+
 
 	/**
 	 * Vide le fichier de log
@@ -218,7 +228,7 @@ class log {
 		foreach (array('', 'scenarioLog/') as $logPath) {
 			$logs = ls(self::getPathToLog($logPath), '*');
 			foreach ($logs as $log) {
-				self::remove($log, $logPath);
+				self::remove($logPath.$log);
 			}
 		}
 		return true;

--- a/core/class/log.class.php
+++ b/core/class/log.class.php
@@ -196,12 +196,8 @@ class log {
 	}
 
 	public static function clearAll() {
-		foreach (array('', 'scenarioLog/') as $logPath) {
-			$logs = ls(self::getPathToLog($logPath), '*');
-			foreach ($logs as $log) {
-				self::clear($logPath.$log);
-			}
-		}
+		foreach (ls(self::getPathToLog(''), '*', false, array('files')) as $log)
+			self::clear($log);
 		return true;
 	}
 
@@ -225,12 +221,8 @@ class log {
 	}
 
 	public static function removeAll() {
-		foreach (array('', 'scenarioLog/') as $logPath) {
-			$logs = ls(self::getPathToLog($logPath), '*');
-			foreach ($logs as $log) {
-				self::remove($logPath.$log);
-			}
-		}
+		foreach (ls(self::getPathToLog(''), '*', false, array('files')) as $log)
+			self::remove($log);
 		return true;
 	}
 

--- a/core/class/log.class.php
+++ b/core/class/log.class.php
@@ -194,6 +194,7 @@ class log {
 		}
 		return;
 	}
+
 	public static function clearAll() {
 		foreach (array('', 'scenarioLog/') as $logPath) {
 			$logs = ls(self::getPathToLog($logPath), '*');
@@ -203,7 +204,6 @@ class log {
 		}
 		return true;
 	}
-
 
 	/**
 	 * Vide le fichier de log

--- a/core/js/log.class.js
+++ b/core/js/log.class.js
@@ -112,6 +112,26 @@ jeedom.log.remove = function(_params) {
   $.ajax(paramsAJAX);
 }
 
+jeedom.log.clearAll = function(_params) {
+  var paramsRequired = [];
+  var paramsSpecifics = {
+    global: _params.global || true,
+  };
+  try {
+    jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
+  } catch (e) {
+    (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
+    return;
+  }
+  var params = $.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  paramsAJAX.url = 'core/ajax/log.ajax.php';
+  paramsAJAX.data = {
+    action: 'clearAll',
+  };
+  $.ajax(paramsAJAX);
+}
+
 jeedom.log.clear = function(_params) {
   var paramsRequired = ['log'];
   var paramsSpecifics = {

--- a/desktop/js/log.js
+++ b/desktop/js/log.js
@@ -103,6 +103,24 @@ $("#bt_clearLog").on('click', function(event) {
   })
 })
 
+$("#bt_clearAllLog").on('click', function(event) {
+  bootbox.confirm("{{Êtes-vous sûr de vouloir vider tous les logs ?}}", function(result) {
+    if (result) {
+      jeedom.log.clearAll({
+        error: function(error) {
+          $('#div_alertError').showAlert({
+            message: error.message,
+            level: 'danger'
+          })
+        },
+        success: function(data) {
+          jeedomUtils.loadPage('index.php?v=d&p=log')
+        }
+      })
+    }
+  })
+})
+
 $("#bt_removeLog").on('click', function(event) {
   jeedom.log.remove({
     log: $('.li_log.active').attr('data-log'),

--- a/desktop/php/log.php
+++ b/desktop/php/log.php
@@ -66,6 +66,7 @@ natcasesort($list_logfile);
 				<a class="btn btn-warning btn-sm" data-state="1" id="bt_globalLogStopStart"><i class="fas fa-pause"></i> {{Pause}}
 				</a><a class="btn btn-success btn-sm" id="bt_downloadLog"><i class="fas fa-cloud-download-alt"></i> {{Télécharger}}
 				</a><a class="btn btn-warning btn-sm" id="bt_clearLog"><i class="fas fa-times"></i> {{Vider}}
+				</a><a class="btn btn-warning btn-sm" id="bt_clearAllLog"><i class="fas fa-times"></i> {{Vider tous}}
 				</a><a class="btn btn-danger btn-sm" id="bt_removeLog"><i class="far fa-trash-alt"></i> {{Supprimer}}
 				</a><a class="btn btn-danger btn-sm roundedRight" id="bt_removeAllLog"><i class="far fa-trash-alt"></i> {{Supprimer tous}}</a>
 			</span>


### PR DESCRIPTION
1) log::removeAll() did not remove Scenario files

2) As some daemon does not re-create files and continues to write to a phantom file descriptor, it would be nice to be able to empty all log file at once.