### PR TITLE
Update types.php

### DIFF
--- a/desktop/php/types.php
+++ b/desktop/php/types.php
@@ -90,7 +90,7 @@ function jeedom_displayGenFamily($_family, $_familyId='') {
 
 			if ($cmdGenericType != '') {
 				try {
-              		$cmdGeneric = $GENRICSTYPES[$cmdGenericType]['family'] . ' -> ' . $GENRICSTYPES[$cmdGenericType]['name'];
+              		array_key_exists($cmdGenericType, $GENRICSTYPES) ? $cmdGeneric = $GENRICSTYPES[$cmdGenericType]['family'] . ' -> ' . $GENRICSTYPES[$cmdGenericType]['name'] : $cmdGeneric = '('.$cmdGenericType.')';
               	} catch (Exception $e) {
               		$cmdGeneric = ' -> ';
               	}


### PR DESCRIPTION
Résous les messages PHP Notice:  Undefined index dans http.error, lorsqu'une "commande" à un Generic_type qui n'est pas référencé dans INTERNAL_CONFIG.
Exemple : plugin weather --> cmdGenericType = WEATHER_RAIN
plugin googlecast --> cmdGenericType = GENERIC