### PR TITLE
Exclude all node_modules folders (from NodeJS) for plugins etc

### DIFF
--- a/install/backup.php
+++ b/install/backup.php
@@ -127,6 +127,7 @@ try {
 		'support',
 		'backup',
 		'script/tunnel',
+		'node_modules',
 		'.git',
 		'.log',
 		'core/config/common.config.php',


### PR DESCRIPTION
reduce the backup size significantly for some plugins !