### PR TITLE
Add more readability to inputbox on scenario

### DIFF
--- a/core/template/scenario/equipement.default.html
+++ b/core/template/scenario/equipement.default.html
@@ -4,6 +4,8 @@
   <span class="input-group-btn">
     <a class="btn btn-default listEquipementInfo" data-cmd_id="#id#" data-uid="#uid#" tooltip="{{Sélectionner un équipement}}" ><i class="fas fa-list-alt"></i></a>
   </span>
+</div>
+<div class="input-group input-group-sm" style="width: 100%">
   <span class="input-group-addon">{{Action}}</span>
   <select class="expressionAttr form-control input-sm roundedRight" data-l1key="options" data-l2key="action" data-option_id="#id#" data-uid="#uid#">
     <option value="show">{{Visible}}</option>

--- a/core/template/scenario/event.default.html
+++ b/core/template/scenario/event.default.html
@@ -4,6 +4,8 @@
 	<span class="input-group-btn">
 		<a class="btn btn-default form-control listCmdInfo" data-cmd_id="#id#" data-uid="#uid#"><i class="fas fa-list-alt"></i></a>
 	</span>
+</div>
+<div class="input-group input-group-sm" style="width: 100%">
 	<span class="input-group-addon" style="width: 100px">{{Valeur}}</span>
 	<input class="expressionAttr form-control input-sm" data-l1key="options" data-l2key="value" placeholder="{{Valeur}}" value="#value#" data-cmd_id="#id#" data-uid="#uid#"/>
 	<span class="input-group-btn">

--- a/core/template/scenario/tag.default.html
+++ b/core/template/scenario/tag.default.html
@@ -1,6 +1,8 @@
 <div class="input-group input-group-sm" style="width: 100%">
   <span class="input-group-addon roundedLeft" style="width: 100px">{{Nom}}</span>
   <input class="expressionAttr form-control input-sm" data-l1key="options" data-l2key="name" placeholder="{{Nom}}" value="#name#" data-uid="#uid#"/>
+</div>
+<div class="input-group input-group-sm" style="width: 100%">
   <span class="input-group-addon" style="width: 100px">{{Valeur}}</span>
   <input class="expressionAttr form-control input-sm autoCompleteCondition" data-l1key="options" data-l2key="value" placeholder="{{Valeur}}" value="#value#" data-uid="#uid#"/>
   <span class="input-group-btn">

--- a/core/template/scenario/variable.default.html
+++ b/core/template/scenario/variable.default.html
@@ -1,6 +1,8 @@
 <div class="input-group input-group-sm" style="width: 100%">
   <span class="input-group-addon roundedLeft" style="width: 100px">{{Nom}}</span>
   <input class="expressionAttr form-control input-sm" data-l1key="options" data-l2key="name" placeholder="{{Nom}}" value="#name#" data-uid="#uid#"/>
+</div>
+<div class="input-group input-group-sm" style="width: 100%">
   <span class="input-group-addon" style="width: 100px">{{Valeur}}</span>
   <input class="expressionAttr form-control input-sm autoCompleteCondition" data-l1key="options" data-l2key="value" placeholder="{{Valeur}}" value="#value#" data-uid="#uid#"/>
   <span class="input-group-btn">


### PR DESCRIPTION
Very often the full name of the equipment does not fit in the input field.
So having `Name` and `Value` input on 2 lines helps with readability.