### PR TITLE
Optimize replacement of '=' by '==' in function evaluate()

### DIFF
--- a/core/php/utils.inc.php
+++ b/core/php/utils.inc.php
@@ -1003,13 +1003,7 @@ function evaluate($_string) {
 	} else {
 		$c = 0;
 	}
-	$expr = str_replace('==', '=', $string);
-	$expr = str_replace('=', '==', $expr);
-	$expr = str_replace('<==', '<=', $expr);
-	$expr = str_replace('>==', '>=', $expr);
-	$expr = str_replace('!==', '!=', $expr);
-	$expr = str_replace('!===', '!==', $expr);
-	$expr = str_replace('====', '===', $expr);
+	$expr = preg_replace("/([^=<>!])=([^=])/", "$1==$2", $string); // Replace all '=' by '==' and avoid '==' '===' '>=' '<=' '!=' '!==' 
 	if ($c > 0) {
 		for ($i = 0; $i < $c; $i++) {
 			$expr = str_replace('--preparsed' . $i . '--', $matches[0][$i], $expr);


### PR DESCRIPTION
Replace all '=' by '==' in 1 pass instead of 7
Avoid messing with '==' '===' '>=' '<=' '!=' '!==' as expected