### PR TITLE
Passage de la regex en ungreedy

### DIFF
--- a/core/class/scenarioExpression.class.php
+++ b/core/class/scenarioExpression.class.php
@@ -1210,7 +1210,7 @@ class scenarioExpression {
 		if (!is_string($_expression)) {
 			return $_expression;
 		}
-		preg_match_all("/([a-zA-Z][a-zA-Z1-9_]*?)\((.*?)\)/", $_expression, $matches, PREG_SET_ORDER);
+		preg_match_all("/([a-zA-Z][a-zA-Z1-9_]*?)\((.*?)\)/U", $_expression, $matches, PREG_SET_ORDER);
 		if (is_array($matches)) {
 			foreach ($matches as $match) {
 				$function = $match[1];


### PR DESCRIPTION
## Proposed change
Probleme de "décryptage" lors de plusieurs fonctions imbriquées
EX :  dans scenario  action/ variable/ value = **durationbetween(**#[Salle][Poele][Status]#,0,**variable(**dateRemplissage),now)*60



## Type of change
Passage de la regex en Ungreedy


- [ ] 3rd party lib update
- [X ] Bugfix (non breaking change)
- [ ] Core new feature
- [ ] UI new functionnality
- [ ] Code quality improvements
- [ ] Core documentation


## Test check

Dans un scenario, créer une action de type variable, affecter à n'importe qu'elle variable et pour la valeur, imbriquer deux fonctions. Dans mon test "durationbetween" et "variable".
EX :  dans scenario  action/ variable/ value = durationbetween(#[Salle][Poele][Status]#,0,variable(dateRemplissage),now)*60

Sans passer en ungreedy la regex, le resultat de la premiere itération se porte sur 
> durationbetween(#[Salle][Poele][Status]#,0,variable(dateRemplissage)
au lieu de 
> durationbetween(#[Salle][Poele][Status]#,0,variable(dateRemplissage),now)
Le resultat en devient donc inexploitable.



[beta-testing](https://doc.jeedom.com/en_US/beta/)
[contribute](https://doc.jeedom.com/en_US/contribute/)
[community](https://community.jeedom.com/)
[plugins](https://doc.jeedom.com/en_US/dev/)

