### PR TITLE
 management of nested functions

### DIFF
--- a/core/class/scenarioExpression.class.php
+++ b/core/class/scenarioExpression.class.php
@@ -1210,32 +1210,38 @@ class scenarioExpression {
 		if (!is_string($_expression)) {
 			return $_expression;
 		}
-		preg_match_all("/([a-zA-Z][a-zA-Z1-9_]*?)\((.*?)\)/", $_expression, $matches, PREG_SET_ORDER);
+		preg_match_all("/([a-zA-Z][a-zA-Z1-9_]*?)\(((([^\()]*\(.*\)[^\()]*))|([^\(]*))\)/", $_expression, $matches, PREG_SET_ORDER);
 		if (is_array($matches)) {
 			foreach ($matches as $match) {
 				$function = $match[1];
+			        if (isset($match[4])and strlen($match[4])>=1 ){
+					$matchUsed=$match[4];
+			      	}
+			     	else{
+					$matchUsed=$match[5];
+			      	}
 				$replace_string = $match[0];
-				if (substr_count($match[2], '(') != substr_count($match[2], ')')) {
-					$pos = strpos($_expression, $match[2]) + strlen($match[2]);
-					while (substr_count($match[2], '(') > substr_count($match[2], ')')) {
-						$match[2] .= $_expression[$pos];
+				if (substr_count($matchUsed, '(') != substr_count($matchUsed, ')')) {
+					$pos = strpos($_expression, $matchUsed) + strlen($matchUsed);
+					while (substr_count($matchUsed, '(') > substr_count($matchUsed, ')')) {
+						$matchUsed .= $_expression[$pos];
 						$pos++;
 						if ($pos > strlen($_expression)) {
 							break;
 						}
 					}
-					$arguments = self::setTags($match[2], $_scenario, $_quote, $_nbCall++);
+					$arguments = self::setTags($matchUsed, $_scenario, $_quote, $_nbCall++);
 					while ($arguments[0] == '(' && $arguments[strlen($arguments) - 1] == ')') {
 						$arguments = substr($arguments, 1, -1);
 					}
-					$result = str_replace($match[2], $arguments, $_expression);
+					$result = str_replace($matchUsed, $arguments, $_expression);
 					while (substr_count($result, '(') > substr_count($result, ')')) {
 						$result .= ')';
 					}
 					$result = self::setTags($result, $_scenario, $_quote, $_nbCall++);
 					return cmd::cmdToValue(str_replace(array_keys($replace1), array_values($replace1), $result), $_quote);
 				} else {
-					$arguments = explode(',', $match[2]);
+					$arguments = explode(',', $matchUsed);
 				}
 				if (method_exists(__CLASS__, $function)) {
 					if ($function == 'trigger') {


### PR DESCRIPTION
Modify regex to manage multi and nested function like :
*variable(dateRemplissage)+variable(dateRemplissage)+variable(dateRemplissage)
ou
*durationbetween(#[Salle][Poele][Status]#,0,variable(dateRemplissage),now)*60

## Type of change
modification de la regex


- [ ] 3rd party lib update
- [X ] Bugfix (non breaking change)
- [ ] Core new feature
- [ ] UI new functionnality
- [ ] Code quality improvements
- [ ] Core documentation


## Test check

Dans un scenario, créer une action de type variable, affecter à n'importe qu'elle variable et pour la valeur, imbriquer deux fonctions. Dans mon test "durationbetween" et "variable".
EX :  dans scenario  action/ variable/ value = durationbetween(#[Salle][Poele][Status]#,0,variable(dateRemplissage),now)*60

Sans la modif de la regex, le resultat de la premiere itération se porte sur 
> durationbetween(#[Salle][Poele][Status]#,0,variable(dateRemplissage)
au lieu de 
> durationbetween(#[Salle][Poele][Status]#,0,variable(dateRemplissage),now)
Le resultat en devient donc inexploitable.
