### PR TITLE
do not read html tags in logs

### DIFF
--- a/core/js/log.class.js
+++ b/core/js/log.class.js
@@ -305,6 +305,7 @@ jeedom.log.colorReplacement = {
 
 }
 jeedom.log.stringColorReplace = function(_str) {
+  _str= _str.replaceAll('<', '&lt;');
   for (var re in jeedom.log.colorReplacement) {
     _str = _str.split(re).join(jeedom.log.colorReplacement[re])
   }


### PR DESCRIPTION
if the log msg contains html tags, then they are not displayed anymore in the "colorful" display

before : 
![image](https://user-images.githubusercontent.com/12429858/156208672-12b66b7d-e9e1-41d7-848e-1d4679de4105.png)


after : 
![image](https://user-images.githubusercontent.com/12429858/156208577-4ec00ec6-8625-4d1b-b532-d680e45078df.png)


https://community.jeedom.com/t/logs-colorees-ne-pas-afficher-les-tags-html/80130