### PR TITLE
Relative path for icon and Font-Awesome

### DIFF
--- a/desktop/modal/icon.selector.php
+++ b/desktop/modal/icon.selector.php
@@ -66,7 +66,7 @@ sendVarToJS([
         <div id="treeFolder-icon" class="div_treeFolder">
           <ul id="ul_Folder-bg">
             <?php
-            $scanPaths = array('/var/www/html/core/css/icon', '/var/www/html/data/fonts');
+            $scanPaths = array(__DIR__ . '/../../core/css/icon', __DIR__ . '/../../data/fonts');
             foreach ($scanPaths as $root) {
               $ls = ls($root, '*', false, array('folders'));
               foreach ($ls as $dir) {
@@ -76,7 +76,7 @@ sendVarToJS([
                 echo '<li><a data-path="' . $root . '/' . $dir . '">' . ucfirst(str_replace(array('/', '_'), array('', ' '), $dir)) . '</a></li>';
               }
             }
-            echo '<li><a data-path="/var/www/html/3rdparty/font-awesome5/">Font-Awesome</a></li>';
+            echo '<li><a data-path="'.__DIR__ . '/../../data/3rdparty/font-awesome5/">Font-Awesome</a></li>';
             ?>
           </ul>
         </div>


### PR DESCRIPTION
<!--
  Thanks for your contribution to make Jeedom better!
-->


## Proposed change
If Jeedom is not installed in the default repo /var/www/html/, we can't select any icons neither any Fonts Awesome. 

Change for a relative path


## Type of change

-  Bugfix (non breaking change)


## Test check
Install Jeedom in a custom path
Create a new widget and click on the button 'Choisir' in the first part (General). 
Without the fix, we get an error 401, and no icons were displayed
With the fix, we have now a list of icons




[beta-testing](https://doc.jeedom.com/en_US/beta/)
[contribute](https://doc.jeedom.com/en_US/contribute/)
[community](https://community.jeedom.com/)
[plugins](https://doc.jeedom.com/en_US/dev/)

