### PR TITLE
improve variable détection when multiple(( used

### DIFF
--- a/core/class/scenarioExpression.class.php
+++ b/core/class/scenarioExpression.class.php
@@ -1210,7 +1210,7 @@ class scenarioExpression {
 		if (!is_string($_expression)) {
 			return $_expression;
 		}
-		preg_match_all("/([a-zA-Z][a-zA-Z1-9_]*?)\(((([^\()]*\(.*\)[^\()]*))|([^\(]*))\)/", $_expression, $matches, PREG_SET_ORDER);
+		preg_match_all("/([a-zA-Z][a-zA-Z1-9_]*?)\(((([^\()]*\(.*\)[^\()]*[^\)]))|([^\(]*[^\)]))\)/", $_expression, $matches, PREG_SET_ORDER);
 		if (is_array($matches)) {
 			foreach ($matches as $match) {
 				$function = $match[1];


### PR DESCRIPTION
## Proposed change

improve tags detection when multiple "(" are used



## Type of change
<!--
  What type of change your PR is
-->

- [ ] 3rd party lib update
- [x ] Bugfix (non breaking change)
- [ ] Core new feature
- [ ] UI new functionnality
- [ ] Code quality improvements
- [ ] Core documentation


## Test check
when in scenario/action/variable you set the value to for exemple :
`(((maxBetween(#[Garage][Consomation][total cumul hier €]#, now - 1 days -1 hour , now )- maxBetween(#[Garage][Consomation][total cumul hier €]#, now - 2 days  -1 hour ,  now - 1 days ))/ maxBetween(#[Garage][Consomation][total cumul hier €]#, now - 1 days  -1 hour , now )*100))` the double "))" where not correctly detected


[beta-testing](https://doc.jeedom.com/en_US/beta/)
[contribute](https://doc.jeedom.com/en_US/contribute/)
[community](https://community.jeedom.com/)
[plugins](https://doc.jeedom.com/en_US/dev/)

