### PR TITLE
continue check on next plugin instead of return

### DIFF
--- a/core/class/plugin.class.php
+++ b/core/class/plugin.class.php
@@ -305,7 +305,7 @@ class plugin {
 					}
 				}
 				if ($enable == 0) {
-					return;
+					continue;
 				}
 				if (!$ok) {
 					$message = __('Attention le plugin', __FILE__) . ' ' . ' ' . $plugin->getName();


### PR DESCRIPTION
<!--
  Thanks for your contribution to make Jeedom better!
-->


## Proposed change
 We should continue check on next plugin instead of return function
see https://community.jeedom.com/t/bug-du-hearthbeat/82062


## Type of change
<!--
  What type of change your PR is
-->

- [ ] 3rd party lib update
- [X] Bugfix (non breaking change)
- [ ] Core new feature
- [ ] UI new functionnality
- [ ] Code quality improvements
- [ ] Core documentation


## Test check
Activating heartbeat on at least 2 plugins, first one with no equipment enabled and the second one with equipment not updated since heartbeat delay should generate a message.


## Documentation
<!--
  Some useful links for contributors
-->


[beta-testing](https://doc.jeedom.com/en_US/beta/)
[contribute](https://doc.jeedom.com/en_US/contribute/)
[community](https://community.jeedom.com/)
[plugins](https://doc.jeedom.com/en_US/dev/)

