### PR TITLE
Ability for a plugin to exclude some of its subfolders from backups

### DIFF
--- a/install/backup.php
+++ b/install/backup.php
@@ -116,7 +116,7 @@ try {
 		echo $e->getMessage();
 	}
 	
-	echo 'Creating archive...';
+	echo "Creating archive...\n";
 	
 	$excludes = array(
 		'tmp',
@@ -139,6 +139,27 @@ try {
 		$excludes[] = config::byKey('recordDir', 'camera');
 	}
 	
+  	if (!isset($NO_PLUGIN_BACKUP) || $NO_PLUGIN_BACKUP === false) {
+		foreach (plugin::listPlugin(true) as $plugin) {
+			$plugin_id = $plugin->getId();
+			if (method_exists($plugin_id, 'backupExclude')) {
+				$plugin_excludes=$plugin_id::backupExclude();
+				if(isset($plugin_excludes) === true) {
+					foreach ($plugin_excludes as $plugin_exclude) {
+						$plugin_exclude=trim($plugin_exclude);
+     					if(isset($plugin_exclude) === true && $plugin_exclude !== '') {
+							if (strpos($plugin_exclude, '..') === false) {
+								$excludes[]="plugins/".$plugin_id."/".$plugin_exclude;
+								echo "Plugin " . $plugin_id . " - the following subfolder will be excluded from the backup: ".$plugin_exclude."\n";
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+  
+  
 	$exclude = '';
 	foreach ($excludes as $folder) {
 		$exclude .= ' --exclude="' . $folder . '"';


### PR DESCRIPTION
Added ability for a plugin to exclude one or more of its subfolders from backups.



<!--
  Thanks for your contribution to make Jeedom better!
-->


## Proposed change
<!--
  Explain you PR here and why Core maintainers should accept it.
  You can link to Community subject if discussed there.
-->
This is useful when the plugin stores a large amount of data that is not to be saved (like videos, images, etc.)
The plugin must implement the "backupExclude" method which must return an array containing the names of the subfolders to exclude.
Values ​​containing ".." are ignored in order to limit the action to the subfolders of the plugin.
https://community.jeedom.com/t/configuration-des-backups-des-plugins/82440?u=duke9

## Type of change
<!--
  What type of change your PR is
-->

- [ ] 3rd party lib update
- [ ] Bugfix (non breaking change)
- [X] Core new feature
- [ ] UI new functionnality
- [ ] Code quality improvements
- [ ] Core documentation


## Test check
<!--
  Describe here on which hardware, OS, Core version and eventually plugins you have tested your PR against.
  Give a maximum of details on what you did test, under which circumstances, and which side effect you did tried to handle.
-->
Tested on Jeedom 4.2.14 (on Raspberry Pi 4)
Test that exclusions are taken into account during backups : OK
Test that a plugin cannot exclude a folder which is not one of its subfolders : OK

## Documentation
<!--
  Some useful links for contributors
-->


[beta-testing](https://doc.jeedom.com/en_US/beta/)
[contribute](https://doc.jeedom.com/en_US/contribute/)
[community](https://community.jeedom.com/)
[plugins](https://doc.jeedom.com/en_US/dev/)

