### PR TITLE
Correction approximation fonction duration()

### DIFF
--- a/core/class/scenarioExpression.class.php
+++ b/core/class/scenarioExpression.class.php
@@ -653,7 +653,7 @@ class scenarioExpression {
 		}
 		$duration = 0;
 		$lastDatetime = strtotime($_startTime);
-		$lastValue = round($histories[0]->getValue(), $_decimal);
+		$lastValue = round($cmd->getTemporalAvg($_startTime, $_endTime), 1);
 		foreach ($histories as $history) {
 			if ($history->getDatetime() < $_startTime) {
 				$lastValue = round($history->getValue(), $_decimal);


### PR DESCRIPTION
Prenons l’exemple d’une commande binaire qui a été à 1 une fois durant 10 minutes pendant les 24 dernières heures et était préalablement à 0 les 6 jours précédents.
Si je demande duration(#maCommande#, 1, 24 hour) le résultat va être complètement faux car le code prend comme valeur de départ de la période la moyenne arithmétique de la valeur de cette periode (1 seul changement, 0.5).
Par exemple, on va obtenir 1010 minutes au lieu de 10 minutes…

Solution :
A la ligne 656 du fichier ScenarioExpresssion.class.php au lieu de faire une moyenne arithmétique
$lastValue = round($histories[0]->getValue(), $_decimal);
il faudrait faire une moyenne temporelle
$lastValue = round($cmd->getTemporalAvg($_startTime, $_endTime), 1);

Commentaire :
Cette correction donne toujours une approximation, mais une approximation très proche de la réalité contrairement à l’implémentation actuelle

<!--
  Thanks for your contribution to make Jeedom better!
-->


## Proposed change
<!--
  Explain you PR here and why Core maintainers should accept it.
  You can link to Community subject if discussed there.
-->


## Type of change
<!--
  What type of change your PR is
-->

- [ ] 3rd party lib update
- [x] Bugfix (non breaking change)
- [ ] Core new feature
- [ ] UI new functionnality
- [ ] Code quality improvements
- [ ] Core documentation


## Test check
<!--
  Describe here on which hardware, OS, Core version and eventually plugins you have tested your PR against.
  Give a maximum of details on what you did test, under which circumstances, and which side effect you did tried to handle.
-->


## Documentation
<!--
  Some useful links for contributors
-->


[beta-testing](https://doc.jeedom.com/en_US/beta/)
[contribute](https://doc.jeedom.com/en_US/contribute/)
[community](https://community.jeedom.com/)
[plugins](https://doc.jeedom.com/en_US/dev/)

