### PR TITLE
calcul exact de scenarioExpression.duration()

### DIFF
--- a/core/class/history.class.php
+++ b/core/class/history.class.php
@@ -147,6 +147,36 @@ class history {
 	}
 
 	/**
+	 * Value of a command on a given date
+	 */
+	public static function byCmdIdAtDatetime($_cmd_id, $_time) {
+		$values = array(
+			'cmd_id' => $_cmd_id,
+			'time' => $_time,
+		);
+		$sql = 'SELECT ' . DB::buildField(__CLASS__) . '
+		FROM history
+		WHERE cmd_id=:cmd_id
+		AND `datetime`<=:time
+		ORDER BY `datetime` DESC LIMIT 1';
+		$result = DB::Prepare($sql, $values, DB::FETCH_TYPE_ROW, PDO::FETCH_CLASS, __CLASS__);
+		if (!is_object($result)) {
+			$sql = 'SELECT ' . DB::buildField(__CLASS__) . '
+			FROM historyArch
+			WHERE cmd_id=:cmd_id
+			AND `datetime`<=:time
+			ORDER BY `datetime` DESC LIMIT 1';
+			$result = DB::Prepare($sql, $values, DB::FETCH_TYPE_ROW, PDO::FETCH_CLASS, 'historyArch');
+			if (is_object($result)) {
+				$result->setTableName('historyArch');
+			}
+		} else {
+			$result->setTableName('history');
+		}
+		return $result;
+	}
+
+	/**
 	 * Archive data from history into historyArch
 	 */
 	public static function archive() {

--- a/core/class/scenarioExpression.class.php
+++ b/core/class/scenarioExpression.class.php
@@ -647,13 +647,13 @@ class scenarioExpression {
 		$_value = str_replace(',', '.', $_value);
 		$_decimal = strlen(substr(strrchr($_value, "."), 1));
 
-		$histories = $cmd->getHistory(date('Y-m-d H:i:s', strtotime($_startTime . ' - 2 hours')), $_endTime);
+		$histories = $cmd->getHistory($_startTime, $_endTime);
 		if (count($histories) == 0) {
 			return '';
 		}
 		$duration = 0;
 		$lastDatetime = strtotime($_startTime);
-		$lastValue = round($cmd->getTemporalAvg($_startTime, $_endTime), 1);
+		$lastValue = round(history::byCmdIdAtDatetime($_cmd_id, $_startTime), $_decimal);
 		foreach ($histories as $history) {
 			if ($history->getDatetime() < $_startTime) {
 				$lastValue = round($history->getValue(), $_decimal);


### PR DESCRIPTION
<!--
  Thanks for your contribution to make Jeedom better!
-->


## Proposed change
<!--
  Explain you PR here and why Core maintainers should accept it.
  You can link to Community subject if discussed there.
-->
Ajout d'une méthode dans la classe history permettant de connaitre le dernière valeur connue d'une commande à une date donnée afin de pouvoir l'utiliser dans la méthode duration de la classe scenarioExpression afin d'en finir avec les approximation et obtenir une valeur réelle.

## Type of change
<!--
  What type of change your PR is
-->

- [ ] 3rd party lib update
- [X] Bugfix (non breaking change)
- [x] Core new feature
- [ ] UI new functionnality
- [x] Code quality improvements
- [ ] Core documentation


## Test check
<!--
  Describe here on which hardware, OS, Core version and eventually plugins you have tested your PR against.
  Give a maximum of details on what you did test, under which circumstances, and which side effect you did tried to handle.
-->


## Documentation
<!--
  Some useful links for contributors
-->


[beta-testing](https://doc.jeedom.com/en_US/beta/)
[contribute](https://doc.jeedom.com/en_US/contribute/)
[community](https://community.jeedom.com/)
[plugins](https://doc.jeedom.com/en_US/dev/)

