### PR TITLE
fix(core): Run npm list as sudo to check dependencies status

### DIFF
--- a/core/class/system.class.php
+++ b/core/class/system.class.php
@@ -414,7 +414,7 @@ class system {
 					if (file_exists(__DIR__ . '/../../' . $package . '/package.json')) {
 						$version = json_decode(file_get_contents(__DIR__ . '/../../' . $package . '/package.json'), true)['version'];
 						if ($type == 'npm') {
-							exec('cd ' . __DIR__ . '/../../' . $package . ';npm list', $output, $return_var);
+							exec('cd ' . __DIR__ . '/../../' . $package . ';' . self::getCmdSudo() . ' npm list', $output, $return_var);
 							if ($return_var == 0) {
 								$found = 1;
 							}


### PR DESCRIPTION


<!--
  Thanks for your contribution to make Jeedom better!
-->


## Proposed change
<!--
  Explain you PR here and why Core maintainers should accept it.
  You can link to Community subject if discussed there.
-->
During the installation of dependencies, a call to `npm list` is done, and if the return code is different than 0, it considers that dependencies needs to be installed again. If the user has insufficient rights in case of npm, the commands return 243. The fix simply uses sudo to avoid error code 243 return by `npm list` if the user doesn't have sufficient rights.

## Type of change
<!--
  What type of change your PR is
-->

- [ ] 3rd party lib update
- [x] Bugfix (non breaking change)
- [ ] Core new feature
- [ ] UI new functionnality
- [ ] Code quality improvements
- [ ] Core documentation


## Test check
<!--
  Describe here on which hardware, OS, Core version and eventually plugins you have tested your PR against.
  Give a maximum of details on what you did test, under which circumstances, and which side effect you did tried to handle.
-->
Tested on v4.2.18 running in Docker.

## Documentation
<!--
  Some useful links for contributors
-->


[beta-testing](https://doc.jeedom.com/en_US/beta/)
[contribute](https://doc.jeedom.com/en_US/contribute/)
[community](https://community.jeedom.com/)
[plugins](https://doc.jeedom.com/en_US/dev/)

