### PR TITLE
Fix in jeedom.eqLogic.byId() [beta]

### DIFF
--- a/core/js/eqLogic.class.js
+++ b/core/js/eqLogic.class.js
@@ -299,9 +299,9 @@ jeedom.eqLogic.getCmd = function(_params) {
 jeedom.eqLogic.byId = function(_params) {
   var paramsRequired = ['id'];
   var paramsSpecifics = {
-    pre_success: function(result) {
-      jeedom.eqLogic.cache.byId[_params.id] = result;
-      return result;
+    pre_success: function(data) {
+      jeedom.eqLogic.cache.byId[data.result.id] = data.result;
+      return data;
     }
   };
   try {


### PR DESCRIPTION
## Proposed change
Fix `jeedom.eqLogic.byId()` when return browser cached value.

Using twice this code:
```
jeedom.eqLogic.byId({
	id: EqId,
	success: function (result){
		console.log(result);
	}
});
```
Does not give the same result as the complete ajax payload is put in cache and not only the result:
```
jeedom.eqLogic.byId({
	id: '44',
	success: function (result){
		console.log(result);
	}
});
-> {id: '44', name: 'dummy42', logicalId: '', generic_type: null, object_id: '-1', …}

jeedom.eqLogic.byId({
	id: '44',
	success: function (result){
		console.log(result);
	}
});
-> {state: 'ok', result: {…}}
```
First call is ok, second is not.

With the fix, it is always ok:
```
jeedom.eqLogic.byId({
	id: '44',
	success: function (result){
		console.log(result);
	}
});
-> {id: '44', name: 'dummy42', logicalId: '', generic_type: null, object_id: '-1', …}

jeedom.eqLogic.byId({
	id: '44',
	success: function (result){
		console.log(result);
	}
});
-> {id: '44', name: 'dummy42', logicalId: '', generic_type: null, object_id: '-1', …}
```

For reference, this PR mimics the way it is done in `core/js/cmd.class.js` in beta or alpha:
https://github.com/jeedom/core/blob/b8422d93177916e86f4dbab06d6db3fa64047e34/core/js/cmd.class.js#L538-L540
https://github.com/jeedom/core/blob/a3d8cd3dc149b6446647392275bdc02beea9bf99/core/js/cmd.class.js#L539-L541
**Alpha MUST also be PR-ed:**
https://github.com/jeedom/core/blob/a3d8cd3dc149b6446647392275bdc02beea9bf99/core/js/eqLogic.class.js#L302-L304

## Type of change
- [ ] 3rd party lib update
- [x] Bugfix (non breaking change)
- [ ] Core new feature
- [ ] UI new functionnality
- [ ] Code quality improvements
- [ ] Core documentation


## Test check
See bellow to reproduce.