### PR TITLE
Update scenarioExpression.class.php

### DIFF
--- a/core/class/scenarioExpression.class.php
+++ b/core/class/scenarioExpression.class.php
@@ -1555,7 +1555,7 @@ class scenarioExpression {
 							if ($cmd->getType() == 'info') {
 								$cmd->event(jeedom::evaluateExpression($options['value']));
 								$this->setLog($scenario, $GLOBALS['JEEDOM_SCLOG_TEXT']['event']['txt'] . $cmd->getHumanName() . ' ' . __('à', __FILE__) . ' ' . $options['value']);
-							} else if ($cmd->getType() == 'action') {
+							} else if ($cmd->getType() == 'action' && $cmd->getEqLogic()->getIsEnable() == 1) {
 								if ($cmd->getSubtype() == 'slider') {
 									$options['slider'] = evaluate($options['value']);
 								}


### PR DESCRIPTION
Lors de l'utilisation de genericType, celui-ci extrait toutes les cmd même celles qui sont dans des équipements désactivés, pour ensuite faire un "$cmd->execCmd" sur cette cmd. Se qui a pour effet de bloquer la suite du foreach car le scénario tombe dans un "throw new Exception"  (cmd.class.php#L1099).
Ce PR est simpliste mais il fonctionne, le mieux serai, il me semble, de traiter directement dans la fonction : 
byGenericTypeObjectId($_generic_type, $_object_id = null, $_type = null) en rajoutant par exemple une variable $_onlyEnable = false, mais il faut ensuite conditionner la requête sql, et c'est là que s'arrête mes compétences ;-)

https://community.jeedom.com/t/probleme-de-recursivite-dans-les-scenarios-avec-les-generictype/86925

<!--
  Thanks for your contribution to make Jeedom better!
-->


## Proposed change
<!--
  Explain you PR here and why Core maintainers should accept it.
  You can link to Community subject if discussed there.
-->


## Type of change
<!--
  What type of change your PR is
-->

- [ ] 3rd party lib update
- [x] Bugfix (non breaking change)
- [ ] Core new feature
- [ ] UI new functionnality
- [ ] Code quality improvements
- [ ] Core documentation


## Test check
<!--
  Describe here on which hardware, OS, Core version and eventually plugins you have tested your PR against.
  Give a maximum of details on what you did test, under which circumstances, and which side effect you did tried to handle.
-->


## Documentation
<!--
  Some useful links for contributors
-->


[beta-testing](https://doc.jeedom.com/en_US/beta/)
[contribute](https://doc.jeedom.com/en_US/contribute/)
[community](https://community.jeedom.com/)
[plugins](https://doc.jeedom.com/en_US/dev/)

