### PR TITLE
Update scenarioExpression.class.php

### DIFF
--- a/core/class/scenarioExpression.class.php
+++ b/core/class/scenarioExpression.class.php
@@ -713,7 +713,7 @@ class scenarioExpression {
 
 		$histories = $cmd->getHistory();
 		if (count($histories) == 0) {
-			return '0';
+			return 0;
 		}
 		
 		$duration = 0;

--- a/core/class/scenarioExpression.class.php
+++ b/core/class/scenarioExpression.class.php
@@ -712,7 +712,10 @@ class scenarioExpression {
 		$_decimal = strlen(substr(strrchr($_value, "."), 1));
 
 		$histories = $cmd->getHistory();
-
+		if (count($histories) == 0) {
+			return '0';
+		}
+		
 		$duration = 0;
 		$lastDuration = strtotime($histories[0]->getDatetime());
 		$lastValue = $histories[0]->getValue();


### PR DESCRIPTION
Lorsque la fonction est appelée avec une commande historisée mais sans donnée en BDD, elle renvoie une erreur "Undefined offset: 0" et ne permet pas de sauvegarder un virtuel, car celui-ci déclenche une "erreur 500".

<!--
  Thanks for your contribution to make Jeedom better!
-->


## Proposed change
<!--
  Explain you PR here and why Core maintainers should accept it.
  You can link to Community subject if discussed there.
-->


## Type of change
<!--
  What type of change your PR is
-->

- [ ] 3rd party lib update
- [X ] Bugfix (non breaking change)
- [ ] Core new feature
- [ ] UI new functionnality
- [ ] Code quality improvements
- [ ] Core documentation


## Test check
<!--
  Describe here on which hardware, OS, Core version and eventually plugins you have tested your PR against.
  Give a maximum of details on what you did test, under which circumstances, and which side effect you did tried to handle.
-->


## Documentation
<!--
  Some useful links for contributors
-->


[beta-testing](https://doc.jeedom.com/en_US/beta/)
[contribute](https://doc.jeedom.com/en_US/contribute/)
[community](https://community.jeedom.com/)
[plugins](https://doc.jeedom.com/en_US/dev/)

