### PR TITLE
Update icon.selector.php

### DIFF
--- a/desktop/modal/icon.selector.php
+++ b/desktop/modal/icon.selector.php
@@ -76,7 +76,7 @@ sendVarToJS([
                 echo '<li><a data-path="' . $root . '/' . $dir . '">' . ucfirst(str_replace(array('/', '_'), array('', ' '), $dir)) . '</a></li>';
               }
             }
-            echo '<li><a data-path="'.__DIR__ . '/../../data/3rdparty/font-awesome5/">Font-Awesome</a></li>';
+            echo '<li><a data-path="'.__DIR__ . '/../../3rdparty/font-awesome5/">Font-Awesome</a></li>';
             ?>
           </ul>
         </div>


### PR DESCRIPTION
Correction d'une petite coquille qui c'est glissé lors du dernier PR , qui ne permettait plus d'afficher les icones font-awesome5.
http.error -> [ PHP Warning:  file_get_contents(/var/www/html/core/php/../../data/3rdparty/font-awesome5/icons.json) ]...

<!--
  Thanks for your contribution to make Jeedom better!
-->


## Proposed change
<!--
  Explain you PR here and why Core maintainers should accept it.
  You can link to Community subject if discussed there.
-->


## Type of change
<!--
  What type of change your PR is
-->

- [ ] 3rd party lib update
- [X] Bugfix (non breaking change)
- [ ] Core new feature
- [ ] UI new functionnality
- [ ] Code quality improvements
- [ ] Core documentation


## Test check
<!--
  Describe here on which hardware, OS, Core version and eventually plugins you have tested your PR against.
  Give a maximum of details on what you did test, under which circumstances, and which side effect you did tried to handle.
-->


## Documentation
<!--
  Some useful links for contributors
-->


[beta-testing](https://doc.jeedom.com/en_US/beta/)
[contribute](https://doc.jeedom.com/en_US/contribute/)
[community](https://community.jeedom.com/)
[plugins](https://doc.jeedom.com/en_US/dev/)

