### PR TITLE
Update eqLogic.configure.php

### DIFF
--- a/desktop/modal/eqLogic.configure.php
+++ b/desktop/modal/eqLogic.configure.php
@@ -171,11 +171,12 @@ sendVarToJS([
                 $display .= '<td>';
                 if ($cmd->getType() == 'info') {
                   $value = $cmd->execCmd();
-                  $title = '{{Date de collecte}} : ' .  $cmd->getCollectDate();
+                  $title = '{{Date de valeur}} : ' . $cmd->getValueDate() . ' - {{Date de collecte}} : ' .  $cmd->getCollectDate();
                   if (strlen($value) > 50) {
-                    $title .= ' - ' . $value;
+                    $title .= '<br/>{{Valeur}} : ' . $value;
+                    $value = trim(substr($value, 0, 50)) . '...';
                   }
-                  $display .= '<span class="eqLogicConfigure_cmdValue" data-cmd_id="' . $cmd->getid() . '" title=" ' . $title . '">' . substr($value, 0, 50) . ' ' . $cmd->getUnite() . ' {{le}} ' . $cmd->getValueDate() . '<span>';
+                  $display .= '<span class="eqLogicConfigure_cmdValue" data-cmd_id="' . $cmd->getid() . '" title=" ' . htmlspecialchars($title) . '">' . $value . ' ' . $cmd->getUnite() . '<span>';
                 }
                 $display .= '</td>';
                 $display .= '<td>';
@@ -834,13 +835,14 @@ sendVarToJS([
   $('.eqLogicConfigure_cmdValue').each(function() {
     jeedom.cmd.addUpdateFunction($(this).attr('data-cmd_id'), function(_options) {
       _options.value = String(_options.value).replace(/<[^>]*>?/gm, '');
-      let cmd = $('.cmdTableState[data-cmd_id=' + _options.cmd_id + ']')
-      let title = '{{Date de collecte}} : ' + _options.collectDate + ' - {{Date de valeur}} ' + _options.valueDate;
+      let cmd = $('.eqLogicConfigure_cmdValue[data-cmd_id=' + _options.cmd_id + ']')
+      let title = '{{Date de valeur}} : ' + _options.valueDate + ' - {{Date de collecte}} : ' + _options.collectDate;
       if (_options.value.length > 50) {
-        title += ' - ' + _options.value;
+        title += '<br/>{{Valeur}} : ' + _options.value;
+         _options.value = _options.value.trim().substring(0, 50) + '...';
       }
       cmd.attr('title', title)
-      cmd.empty().append(_options.value.substring(0, 50) + ' ' + _options.unit + ' {{le}} ' + _options.valueDate);
+      cmd.empty().append(_options.value + ' ' + _options.unit);
       cmd.css('color', 'var(--logo-primary-color)');
       setTimeout(function() {
         cmd.css('color', '');


### PR DESCRIPTION
Je propose ce PR car il y avait un soucis avec 
let cmd = $('.cmdTableState[data-cmd_id=' + _options.cmd_id + ']') qui ne mettait pas a jour eqLogicConfigure_cmdValue
j'en ai profité pour ajouter/modifier certaines petites choses (a prendre ou a laisser :-) et certainement pas au top niveau code ... Mais c'était pour moi la meilleur méthode pour expliquer ce que j'ai constaté.
j'ai juste remarqué une chose que je ne peut debugger par manque de connaissance :
Lorsque le Core met à jour la valeur, le tooltips semble mal se comporter, je me retrouve avec l'info-bulle bien formater a l'initialisation et lorsque intervient une MaJ de la valeur, je me retrouve avec l'info-bulle d'origine non MaJ, mais aussi une nouvelle info-bulle (bien MaJ) mais non formaté (en Brut) celle-ci est directement visible dans le code (title="...").

<!--
  Thanks for your contribution to make Jeedom better!
-->


## Proposed change
<!--
  Explain you PR here and why Core maintainers should accept it.
  You can link to Community subject if discussed there.
-->


## Type of change
<!--
  What type of change your PR is
-->

- [ ] 3rd party lib update
- [X] Bugfix (non breaking change)
- [ ] Core new feature
- [ ] UI new functionnality
- [ ] Code quality improvements
- [ ] Core documentation


## Test check
<!--
  Describe here on which hardware, OS, Core version and eventually plugins you have tested your PR against.
  Give a maximum of details on what you did test, under which circumstances, and which side effect you did tried to handle.
-->


## Documentation
<!--
  Some useful links for contributors
-->


[beta-testing](https://doc.jeedom.com/en_US/beta/)
[contribute](https://doc.jeedom.com/en_US/contribute/)
[community](https://community.jeedom.com/)
[plugins](https://doc.jeedom.com/en_US/dev/)

