### PR TITLE
Fix Apache/core crashes related to 4.3.0 migration script

### DIFF
--- a/install/update/4.3.0.php
+++ b/install/update/4.3.0.php
@@ -1,7 +1,11 @@
 <?php
-require_once __DIR__ . '/../../core/php/core.inc.php';
+//
+// EMPTY TO PREVENT FUTUR ISSUES, UNTIL ROOT CAUSE IS IDENTIFIED
+// cf: https://community.jeedom.com/t/crash-install-4-3/89719
+//
 
-echo 'Ensure Content-Security-Policy (Report-Only) is enabled in apache';
-shell_exec('sudo a2enmod headers');
-shell_exec('grep -c "Content-Security-Policy" /etc/apache2/conf-available/security.conf > /dev/null 2>&1 || sudo cp /var/www/html/install/apache_security_unsecure /etc/apache2/conf-available/security.conf');
-shell_exec('echo "systemctl restart apache2" | sudo at now');
+//require_once __DIR__ . '/../../core/php/core.inc.php';
+
+//echo 'Ensure Content-Security-Policy (Report-Only) is enabled in apache';
+//shell_exec('sudo a2enmod headers');
+//shell_exec('grep -c "Content-Security-Policy" /etc/apache2/conf-available/security.conf > /dev/null 2>&1 || sudo cp /var/www/html/install/apache_security_unsecure /etc/apache2/conf-available/security.conf');


### PR DESCRIPTION
## Proposed change
Temporary fix related to https://community.jeedom.com/t/crash-install-4-3/89719

2 issues here:
- Apache MUST NOT be restarted in update script as update.php is not completely detached from Apache,
- Apache cannot start on some systems, because this script enables `mod_headers` in apache and some users have a very old `security.conf` file containing `Content-Security-Policy` (preventing `security.conf` update).

## Type of change
HOT FIX

@zoic21 could you please merge in alpha and beta quickly to avoid this issue to spread further more?

- [ ] 3rd party lib update
- [x] Bugfix (non breaking change)
- [ ] Core new feature
- [ ] UI new functionnality
- [ ] Code quality improvements
- [ ] Core documentation
