### PR TITLE
Core v4.3: Remove " le " when no value in cmd.configure.php

### DIFF
--- a/desktop/modal/cmd.configure.php
+++ b/desktop/modal/cmd.configure.php
@@ -127,7 +127,11 @@ $configEqDisplayType = jeedom::getConfiguration('eqLogic:displayType');
                 <div class="form-group">
                   <label class="col-xs-4 control-label">{{Etat}}</label>
                   <div class="col-xs-8">
+                    <?php
+                      if ($value != '') {
+                    ?>
                     <span class="label label-primary" style="max-width: 100%;"><?php echo '<span class="cmdConfigure_cmdValue" data-cmd_id="' . $cmd->getid() . '" title="{{Date de collecte}} : ' .  $cmd->getCollectDate() . '">' . $value . ' ' . $cmd->getUnite() . ' {{le}} ' . $cmd->getValueDate() . '<span>'; ?></span>
+                    <?php } ?>
                   </div>
                 </div>
               <?php } ?>


### PR DESCRIPTION
Just a suggestion.

Because when there is no value, " le " was printed:
![Capture d’écran 2022-08-30 à 11 59 41](https://user-images.githubusercontent.com/46993341/187409611-4f277967-5737-4518-9ba1-ca41919a8eec.png)
