### PR TITLE
Core V4.3: Quote escape on htmlstate + new line

### DIFF
--- a/core/js/plugin.template.js
+++ b/core/js/plugin.template.js
@@ -253,7 +253,7 @@ $(".eqLogicDisplayCard").on('click', function(event) {
             data.cmd[i]['htmlstate'] += 'data-cmd_id="' + data.cmd[i].id+ '"';
             data.cmd[i]['htmlstate'] += 'title="{{Date de valeur}} : ' + data.cmd[i].valueDate + '<br/>{{Date de collecte}} : ' + data.cmd[i].collectDate;
             if(data.cmd[i].state.length > 50){
-              data.cmd[i]['htmlstate'] += ' - '+data.cmd[i].state.replaceAll('"','\"');
+              data.cmd[i]['htmlstate'] += '<br/>'+data.cmd[i].state.replaceAll('"','&quot;');
             }
             data.cmd[i]['htmlstate'] += '" >';
             data.cmd[i]['htmlstate'] += data.cmd[i].state.substring(0, 50) +  ' ' + data.cmd[i].unite;


### PR DESCRIPTION
When the state value in a json (with quote), the value is not shown in tooltip because of quote escape:
![Capture d’écran 2022-08-30 à 12 43 05](https://user-images.githubusercontent.com/46993341/187417410-1c2acf78-c1f2-442c-b42c-3a06108cf80b.png)

Better use HTML escape character to fix it.
And arrange it on a new line.