### PR TITLE
Update translate.class.php

### DIFF
--- a/core/class/translate.class.php
+++ b/core/class/translate.class.php
@@ -190,7 +190,7 @@ class translate {
 					$content = file_get_contents($filename);
 					return is_json($content, array())[self::getLanguage()];
 				} else {
-					return array([self::getLanguage()] => array());
+					return array(self::getLanguage() => array());
 				}
 			} else {
 				return array_merge($return, plugin::getTranslation($_plugin, self::getLanguage()));


### PR DESCRIPTION
Petite erreur dans la création du array() qui génère des erreurs : 
PHP Warning:  Illegal offset type in /var/www/html/core/class/translate.class.php on line 193

<!--
  Thanks for your contribution to make Jeedom better!
-->


## Proposed change
<!--
  Explain you PR here and why Core maintainers should accept it.
  You can link to Community subject if discussed there.
-->


## Type of change
<!--
  What type of change your PR is
-->

- [ ] 3rd party lib update
- [X] Bugfix (non breaking change)
- [ ] Core new feature
- [ ] UI new functionnality
- [ ] Code quality improvements
- [ ] Core documentation


## Test check
<!--
  Describe here on which hardware, OS, Core version and eventually plugins you have tested your PR against.
  Give a maximum of details on what you did test, under which circumstances, and which side effect you did tried to handle.
-->


## Documentation
<!--
  Some useful links for contributors
-->


[beta-testing](https://doc.jeedom.com/en_US/beta/)
[contribute](https://doc.jeedom.com/en_US/contribute/)
[community](https://community.jeedom.com/)
[plugins](https://doc.jeedom.com/en_US/dev/)

