### PR TITLE
additional selector for initSpinners

### DIFF
--- a/desktop/common/js/utils.js
+++ b/desktop/common/js/utils.js
@@ -998,7 +998,7 @@ jeedomUtils.dateTimePickerInit = function(_step) {
 }
 
 jeedomUtils.initSpinners = function() {
-  $('input[type="number"]').spinner({
+  $('input[type="number"].ui-spinner').spinner({
     icons: {
       down: "ui-icon-triangle-1-s",
       up: "ui-icon-triangle-1-n"

--- a/desktop/modal/eqLogic.configure.php
+++ b/desktop/modal/eqLogic.configure.php
@@ -311,7 +311,7 @@ sendVarToJS([
                         $echo .= '<input class="eqLogicAttr pull-right advanceWidgetParameter form-control inline-block input-sm" data-l1key="display" data-l2key="advanceWidgetParameter' . $pKey . $key . '" style="width:50%;' . $display . '" value="' . $default . '" />';
                         break;
                       case 'number':
-                        $echo .= '<input type="number" class="eqLogicAttr pull-right advanceWidgetParameter form-control inline-block input-sm" data-l1key="display" data-l2key="advanceWidgetParameter' . $pKey . $key . '" style="width:50%;' . $display . '" value="' . $default . '" />';
+                        $echo .= '<input type="number" class="eqLogicAttr pull-right advanceWidgetParameter form-control inline-block input-sm ui-spinner" data-l1key="display" data-l2key="advanceWidgetParameter' . $pKey . $key . '" style="width:50%;' . $display . '" value="' . $default . '" />';
                         break;
                     }
                     $echo .= '</td>';
@@ -435,11 +435,11 @@ sendVarToJS([
             <div class="form-group">
               <label class="col-sm-2 control-label">{{Nombre de lignes}}</label>
               <div class="col-sm-2">
-                <input type="number" min="1" max="20" step="1" class="eqLogicAttr form-control input-sm" data-l1key="display" data-l2key="layout::dashboard::table::nbLine" />
+                <input type="number" min="1" max="20" step="1" class="eqLogicAttr form-control input-sm ui-spinner" data-l1key="display" data-l2key="layout::dashboard::table::nbLine" />
               </div>
               <label class="col-sm-2 control-label">{{Nombre de colonnes}}</label>
               <div class="col-sm-2">
-                <input type="number" min="1" max="20" step="1" class="eqLogicAttr form-control input-sm" data-l1key="display" data-l2key="layout::dashboard::table::nbColumn" />
+                <input type="number" min="1" max="20" step="1" class="eqLogicAttr form-control input-sm ui-spinner" data-l1key="display" data-l2key="layout::dashboard::table::nbColumn" />
               </div>
               <a class="btn btn-success btn-sm" id="bt_eqLogicLayoutApply"><i class="fas fa-hammer"></i></i> {{Appliquer}}</a>
             </div>

--- a/desktop/modal/eqLogic.dashboard.edit.php
+++ b/desktop/modal/eqLogic.dashboard.edit.php
@@ -193,11 +193,11 @@ $cmd_widgetMobile = cmd::availableWidget('mobile');
                 <div class="form-group">
                   <label class="col-sm-2 control-label">{{Lignes}}</label>
                   <div class="col-sm-2">
-                    <input type="number" min="1" max="20" step="1" class="eqLogicAttr form-control input-sm" data-l1key="display" data-l2key="layout::dashboard::table::nbLine" />
+                    <input type="number" min="1" max="20" step="1" class="eqLogicAttr form-control input-sm ui-spinner" data-l1key="display" data-l2key="layout::dashboard::table::nbLine" />
                   </div>
                   <label class="col-sm-2 control-label">{{Colonnes}}</label>
                   <div class="col-sm-2">
-                    <input type="number" min="1" max="20" step="1" class="eqLogicAttr form-control input-sm" data-l1key="display" data-l2key="layout::dashboard::table::nbColumn" />
+                    <input type="number" min="1" max="20" step="1" class="eqLogicAttr form-control input-sm ui-spinner" data-l1key="display" data-l2key="layout::dashboard::table::nbColumn" />
                   </div>
                   <a class="btn btn-success btn-sm" id="bt_eqLogicLayoutApply"><i class="fas fa-hammer"></i></i> {{Appliquer}}</a>
                 </div>

--- a/desktop/php/administration.php
+++ b/desktop/php/administration.php
@@ -413,13 +413,13 @@ user::isBan();
 								<sup><i class="fas fa-question-circle" tooltip="{{Contraint la hauteur des tuiles tous les x pixels}}"></i></sup>
 							</label>
 							<div class="col-lg-2 col-md-2 col-sm-3 col-xs-6">
-								<input type="number" min="1" class="configKey form-control" data-l1key="widget::step::height" data-reload="1" />
+								<input type="number" min="1" class="configKey form-control ui-spinner" data-l1key="widget::step::height" data-reload="1" />
 							</div>
 							<label class="col-lg-2 col-md-3 col-sm-3 col-xs-6 control-label">{{Pas horizontal}}
 								<sup><i class="fas fa-question-circle" tooltip="{{Contraint la largeur des tuiles tous les x pixels}}"></i></sup>
 							</label>
 							<div class="col-lg-2 col-md-2 col-sm-3 col-xs-6">
-								<input type="number" min="1" class="configKey form-control" data-l1key="widget::step::width" data-reload="1" />
+								<input type="number" min="1" class="configKey form-control ui-spinner" data-l1key="widget::step::width" data-reload="1" />
 							</div>
 						</div>
 						<div class="form-group">
@@ -427,7 +427,7 @@ user::isBan();
 								<sup><i class="fas fa-question-circle" tooltip="{{Espace vertical et horizontal entre les tuiles, en pixel}}"></i></sup>
 							</label>
 							<div class="col-lg-2 col-md-2 col-sm-3 col-xs-6">
-								<input type="number" min="0" class="configKey form-control" data-l1key="widget::margin" data-reload="1" />
+								<input type="number" min="0" class="configKey form-control ui-spinner" data-l1key="widget::margin" data-reload="1" />
 							</div>
 						</div>
 						<div class="form-group">
@@ -469,7 +469,7 @@ user::isBan();
 								<sup><i class="fas fa-question-circle" tooltip="{{Valeur de flou pour les images de fond sur les pages Dashboard.}}"></i></sup>
 							</label>
 							<div class="col-lg-2 col-md-2 col-sm-3 col-xs-6">
-								<input type="number" min="0" max="20" class="configKey form-control" data-l1key="css::objectBackgroundBlur" data-reload="1" />
+								<input type="number" min="0" max="20" class="configKey form-control ui-spinner" data-l1key="css::objectBackgroundBlur" data-reload="1" />
 							</div>
 						</div>
 						<div class="form-group">
@@ -510,13 +510,13 @@ user::isBan();
 								<sup><i class="fas fa-question-circle" tooltip="{{Opacité des images de fond en thème Light. Ajuster en fonction de la luminosité des images de fond.}}"></i></sup>
 							</label>
 							<div class="col-lg-2 col-md-2 col-sm-3 col-xs-6">
-								<input type="number" min="0.1" max="1" step="0.05" class="configKey form-control" data-l1key="interface::background::opacitylight" data-reload="1" />
+								<input type="number" min="0.1" max="1" step="0.05" class="configKey form-control ui-spinner" data-l1key="interface::background::opacitylight" data-reload="1" />
 							</div>
 							<label class="col-lg-2 col-md-3 col-sm-3 col-xs-6 control-label">{{Opacité thème Dark}}
 								<sup><i class="fas fa-question-circle" tooltip="{{Opacité des images de fond en thème Dark.  Ajuster en fonction de la luminosité des images de fond.}}"></i></sup>
 							</label>
 							<div class="col-lg-2 col-md-2 col-sm-3 col-xs-6">
-								<input type="number" min="0.1" max="1" step="0.05" class="configKey form-control" data-l1key="interface::background::opacitydark" data-reload="1" />
+								<input type="number" min="0.1" max="1" step="0.05" class="configKey form-control ui-spinner" data-l1key="interface::background::opacitydark" data-reload="1" />
 							</div>
 						</div>
 
@@ -544,7 +544,7 @@ user::isBan();
 								<sup><i class="fas fa-question-circle" tooltip="{{Durée d'affichage des notifications en seconde (0: infini)}}."></i></sup>
 							</label>
 							<div class="col-lg-2 col-md-2 col-sm-2 col-xs-6">
-								<input type="number" min="0" max="30" step="1" class="configKey form-control" data-l1key="interface::toast::duration" data-reload="1" />
+								<input type="number" min="0" max="30" step="1" class="configKey form-control ui-spinner" data-l1key="interface::toast::duration" data-reload="1" />
 							</div>
 						</div>
 
@@ -573,7 +573,7 @@ user::isBan();
 								<sup><i class="fas fa-question-circle" tooltip="{{Transparence (Opacité) des tuiles et de certains éléments d'interface.}}"></i></sup>
 							</label>
 							<div class="col-lg-2 col-md-2 col-sm-2 col-xs-6">
-								<input type="number" min="0" max="1" step="0.1" class="configKey form-control" data-l1key="css::background-opacity" data-reload="1" />
+								<input type="number" min="0" max="1" step="0.1" class="configKey form-control ui-spinner" data-l1key="css::background-opacity" data-reload="1" />
 							</div>
 						</div>
 						<div class="form-group">
@@ -581,7 +581,7 @@ user::isBan();
 								<sup><i class="fas fa-question-circle" tooltip="{{Arrondi des éléments de l'interface (Tuiles, boutons etc).<br>0 : pas d'arrondi}}"></i></sup>
 							</label>
 							<div class="col-lg-2 col-md-2 col-sm-2 col-xs-6">
-								<input type="number" min="0" max="1" step="0.1" class="configKey form-control" data-l1key="css::border-radius" data-reload="1" />
+								<input type="number" min="0" max="1" step="0.1" class="configKey form-control ui-spinner" data-l1key="css::border-radius" data-reload="1" />
 							</div>
 						</div>
 						<div class="form-group">
@@ -1788,7 +1788,7 @@ user::isBan();
 													$div .= '<input class="configKey form-control" data-l1key="' . $key . '::' . $pKey . '" value="' . $default . '" />';
 													break;
 												case 'number':
-													$div .= '<input type="number" class="configKey form-control" data-l1key="' . $key . '::' . $pKey . '" value="' . $default . '" />';
+													$div .= '<input type="number" class="configKey form-control ui-spinner" data-l1key="' . $key . '::' . $pKey . '" value="' . $default . '" />';
 													break;
 												case 'password':
 													$div .= '<div class="input-group">';


### PR DESCRIPTION
<!--
  Thanks for your contribution to make Jeedom better!
-->


## Proposed change
When opening the configuration of a device on the dashboard or in design, "jeedomUtils.initSpinners" is initialized,
all code widgets (input[type="number"]) present on the page are therefore impacted.


## Type of change
added an extra selector to impact core code only.


- [ ] 3rd party lib update
- [X] Bugfix (non breaking change)
- [ ] Core new feature
- [ ] UI new functionnality
- [ ] Code quality improvements
- [ ] Core documentation


## Test check
<!--
  Describe here on which hardware, OS, Core version and eventually plugins you have tested your PR against.
  Give a maximum of details on what you did test, under which circumstances, and which side effect you did tried to handle.
-->


## Documentation
<!--
  Some useful links for contributors
-->


[beta-testing](https://doc.jeedom.com/en_US/beta/)
[contribute](https://doc.jeedom.com/en_US/contribute/)
[community](https://community.jeedom.com/)
[plugins](https://doc.jeedom.com/en_US/dev/)

