### PR TITLE
proposal to fix converted value display in command list

### DIFF
--- a/core/js/plugin.template.js
+++ b/core/js/plugin.template.js
@@ -269,14 +269,14 @@ $(".eqLogicDisplayCard").on('click', function(event) {
         }
         $('.cmdTableState').each(function() {
           jeedom.cmd.addUpdateFunction($(this).attr('data-cmd_id'), function(_options) {
-            _options.value = String(_options.value).replace(/<[^>]*>?/gm, '');
+            _options.display_value = String(_options.display_value).replace(/<[^>]*>?/gm, '');
             let cmd = $('.cmdTableState[data-cmd_id=' + _options.cmd_id + ']')
             let title = '{{Date de collecte}} : ' + _options.collectDate+' - {{Date de valeur}} ' + _options.valueDate;
-            if(_options.value.length > 50){
-              title += ' - '+_options.value;
+            if(_options.display_value.length > 50){
+              title += ' - '+_options.display_value;
             }
             cmd.attr('title', title)
-            cmd.empty().append(_options.value.substring(0, 50) + ' ' + _options.unit);
+              cmd.empty().append(_options.display_value.substring(0, 50) + ' ' + _options.unit);
             cmd.css('color','var(--logo-primary-color)');
             setTimeout(function(){
               cmd.css('color','');


### PR DESCRIPTION
<!--
  Thanks for your contribution to make Jeedom better!
-->


## Proposed change
Values in commands list does not match unit if the value has been converted by the core, see topic https://community.jeedom.com/t/incoherence-dunites-sur-la-colonne-valeur-pour-uptime/92799

So proposal is to use "display_value" like in widget

The remaining issue is that the value displayed initially just after the refresh of the page will not be converted (but the value will be correct and match the unit), and after first cmd event the value will be in the converted unit (and still correct thanks this change)


## Type of change
<!--
  What type of change your PR is
-->

- [ ] 3rd party lib update
- [ X ] Bugfix (non breaking change)
- [ ] Core new feature
- [ ] UI new functionnality
- [ ] Code quality improvements
- [ ] Core documentation


## Test check
<!--
  Describe here on which hardware, OS, Core version and eventually plugins you have tested your PR against.
  Give a maximum of details on what you did test, under which circumstances, and which side effect you did tried to handle.
-->
Manual test

## Documentation
<!--
  Some useful links for contributors
-->


[beta-testing](https://doc.jeedom.com/en_US/beta/)
[contribute](https://doc.jeedom.com/en_US/contribute/)
[community](https://community.jeedom.com/)
[plugins](https://doc.jeedom.com/en_US/dev/)

