### PR TITLE
Gauges no longer work with energies.

### DIFF
--- a/core/template/dashboard/cmd.info.numeric.default.html
+++ b/core/template/dashboard/cmd.info.numeric.default.html
@@ -19,14 +19,14 @@
       let minValue = ('#minValue#' == '') ? 0 : parseInt('#minValue#')
       let maxValue = ('#maxValue#' == '') ? 100 : parseInt('#maxValue#')
       cmd.attr('title','{{Date de valeur}} : '+_options.valueDate+'<br/>{{Date de collecte}} : '+_options.collectDate)
-      if (_options.display_value >= maxValue) {
-        maxValue = _options.display_value
+      if (_options.value >= maxValue) {
+        maxValue = _options.value
         var angle = 0
-      } else if (_options.display_value <= minValue) {
-        minValue = _options.display_value
+      } else if (_options.value <= minValue) {
+        minValue = _options.value
         var angle = -180
       } else {
-        var angle = (((_options.display_value - minValue) * 180) / (maxValue - minValue)) - 180
+        var angle = (((_options.value - minValue) * 180) / (maxValue - minValue)) - 180
       }
       cmd.find('.gaugeValue').css('transform', 'scale(0.94) rotate('+angle+'deg)')
       cmd.find('.state strong').first().text(_options.display_value+' '+_options.unit)


### PR DESCRIPTION
<!--
  Thanks for your contribution to make Jeedom better!
-->


## Proposed change
The problem is that Jeedom formats the data.
For energy, when the data exceeds 1000 watts, Jeedom does not display 1000W, but 1.00kW. This poses a problem in the calculation of the angle. Fortunately, Jeedom also sends the unformatted data in "value"


## Type of change


- [ ] 3rd party lib update
- [x] Bugfix (non breaking change)
- [ ] Core new feature
- [ ] UI new functionnality
- [ ] Code quality improvements
- [ ] Core documentation


## Test check
<!--
  Describe here on which hardware, OS, Core version and eventually plugins you have tested your PR against.
  Give a maximum of details on what you did test, under which circumstances, and which side effect you did tried to handle.
-->


## Documentation
<!--
  Some useful links for contributors
-->


[beta-testing](https://doc.jeedom.com/en_US/beta/)
[contribute](https://doc.jeedom.com/en_US/contribute/)
[community](https://community.jeedom.com/)
[plugins](https://doc.jeedom.com/en_US/dev/)

