### PR TITLE
Fix JS issue with CSP violatedDirective

### DIFF
--- a/desktop/common/js/utils.js
+++ b/desktop/common/js/utils.js
@@ -47,14 +47,15 @@ window.addEventListener('error', function(event) {
 if ('SecurityPolicyViolationEvent' in window) { // Check browser support of SecurityPolicyViolationEnevt interface
   window.addEventListener("securitypolicyviolation", function(event) {
     var uri = event.blockedURI
+    var msg = `{{Erreur de directive Content Security Policy sur la ressource "${uri}"}}`
     if (event.originalPolicy && event.violatedDirective) {
-      var violation = event.originalPolicy.trim().split(';').find(e => e.trim().startsWith(event.violatedDirective)).trim()
-      if (event.disposition == 'enforce')
-        var msg = `{{Impossible de charger la ressource "${uri}", car elle va contre la directive de Content Security Policy :<br /> "${violation}"}}`
-      else
-        var msg = `{{La ressource "${uri}" a été chargée, mais elle va contre la directive de Content Security Policy :<br /> "${violation}"}}`
-    }else {
-      var msg = `{{Erreur de directive Content Security Policy sur la ressource "${uri}"}}`
+      var violation = event.originalPolicy.trim().split(';').find(e => e.trim().startsWith(event.violatedDirective))
+      if (typeof violation === 'string') {
+        if (event.disposition == 'enforce')
+          var msg = `{{Impossible de charger la ressource "${uri}", car elle va contre la directive de Content Security Policy :<br /> "${violation.trim()}"}}`
+        else
+          var msg = `{{La ressource "${uri}" a été chargée, mais elle va contre la directive de Content Security Policy :<br /> "${violation.trim()}"}}`
+      }
     }
     jeedomUtils.JS_ERROR.push({"filename": event.documentURI, "lineno": "0", "message": msg})
     $('#bt_jsErrorModal').show()


### PR DESCRIPTION
## Proposed change
Fix JS issue with CSP violatedDirective:

If `violatedDirective` cannot be found in the `originalPolicy`, then .find return `undefined`
Resulting in error: `Uncaught TypeError: Cannot read properties of undefined (reading 'trim')`

Reported on Community:
- https://community.jeedom.com/t/erreur-javascript-uncaught-typerror-reading-trim/93334/
- https://community.jeedom.com/t/erreur-recurrente-suite-a-lupgrade-en-4-3/92916

## Type of change
- [ ] 3rd party lib update
- [x] Bugfix (non breaking change)
- [ ] Core new feature
- [ ] UI new functionnality
- [ ] Code quality improvements
- [ ] Core documentation

## Test check
Using new `Apache sécurisé` or `Apache non sécurisé` configuration.
Works with regular CSP violation
Also works (now) with this test:
```
event = new Event('securitypolicyviolation')
event.violatedDirective = ';'
event.originalPolicy = ';'
window.dispatchEvent(event)
```
