### PR TITLE
Fix jeedom.cmd.save() when no id is provided

### DIFF
--- a/core/ajax/cmd.ajax.php
+++ b/core/ajax/cmd.ajax.php
@@ -270,7 +270,7 @@ try {
 		}
 		unautorizedInDemo();
 		$cmd_ajax = jeedom::fromHumanReadable(json_decode(init('cmd'), true));
-		$cmd = cmd::byId($cmd_ajax['id']);
+		$cmd = cmd::byId(init($cmd_ajax['id']));
 		if (!is_object($cmd)) {
 			$cmd = new cmd();
 		}

--- a/core/ajax/cmd.ajax.php
+++ b/core/ajax/cmd.ajax.php
@@ -270,7 +270,7 @@ try {
 		}
 		unautorizedInDemo();
 		$cmd_ajax = jeedom::fromHumanReadable(json_decode(init('cmd'), true));
-		$cmd = cmd::byId(init($cmd_ajax['id']));
+		$cmd = isset($cmd_ajax['id']) ? cmd::byId($cmd_ajax['id']) : null;
 		if (!is_object($cmd)) {
 			$cmd = new cmd();
 		}


### PR DESCRIPTION
## Proposed change
Fix error in ajax callback for JS function `jeedom.cmd.save()`, when `id` is not provided in `cmd` param.

## Type of change
- [ ] 3rd party lib update
- [x] Bugfix (non breaking change)
- [ ] Core new feature
- [ ] UI new functionnality
- [ ] Code quality improvements
- [ ] Core documentation

## Test check
This JS call:
```js
jeedom.cmd.save({
  cmd: {
    eqType: "jMQTT",
    eqLogic_id: "302",
    name: "NEW-CMD",
    type: "info",
    subType: "string",
    configuration: {topic: "test", jsonPath: ""}
  }
});
```
currently correctly creates the next cmd
but raises `PHP Notice:  Undefined index: id in /var/www/html/core/ajax/cmd.ajax.php on line 273` in apache.error.

After the fix, jeedom.cmd.save() works without notice.
