### PR TITLE
Sort data after merging history and historyArch

### DIFF
--- a/core/class/history.class.php
+++ b/core/class/history.class.php
@@ -414,8 +414,11 @@ class history {
 		}
 		$sql .= ' ORDER BY `datetime` ASC';
 		$result2 = DB::Prepare($sql, $values, DB::FETCH_TYPE_ALL, PDO::FETCH_CLASS, 'historyArch');
-
-		return array_merge($result2, $result1);
+		// $t0 = -microtime(true);
+		$resu = array_merge($result2, $result1);
+    		uasort($resu,function($a,$b) { return strcmp($a->datetime, $b->datetime); });
+		// message::add(__CLASS__, "Merge history Nb: ".count($resu) ." Total time: " .round($t0 +microtime(true),3) ."s");
+		return $resu;
 	}
 
 	public static function getOldestValue($_cmd_id, $_limit = 1) {


### PR DESCRIPTION
<!--
  Thanks for your contribution to make Jeedom better!
-->


## Proposed change
<!--
  Explain you PR here and why Core maintainers should accept it.
  You can link to Community subject if discussed there.
-->
There is many subjects on community for this PR.
I.e. : https://community.jeedom.com/t/data-non-coherentes/94276?u=jpty
History data are not sorted after merging history and historyArch tables.
If the table 'history' contains old datas, it creates stray lines in highchart graphics

## Type of change
<!--
  What type of change your PR is
-->

- [ ] 3rd party lib update
- [x] Bugfix (non breaking change)
- [ ] Core new feature
- [ ] UI new functionnality
- [ ] Code quality improvements
- [ ] Core documentation


## Test check
<!--
  Describe here on which hardware, OS, Core version and eventually plugins you have tested your PR against.
  Give a maximum of details on what you did test, under which circumstances, and which side effect you did tried to handle.
-->
Tested on a Smart with version 4.2.21.
Uncomment lines in the PR. With my largest history of 131200 rows, it took 1.9s to sort.
Post processing of datas in javascript for highcharts display tooks about 16s.
<html><body>
<!--StartFragment-->

Date et heure | Source | Description | Action | Occurrences
-- | -- | -- | -- | --
  | 2022-11-12 17:42:06 | history | Merge history Nb: 4 Total time: 0s |   | 12
  | 2022-11-12 17:42:04 | history | Merge history Nb: 6497 Total time: 0.062s |   |  
  | 2022-11-12 17:41:47 | history | Merge history Nb: 2210 Total time: 0.014s |   | 3
  | 2022-11-12 17:39:05 | history | Merge history Nb: 21 Total time: 0s |   | 23
  | 2022-11-12 17:34:38 | history | Merge history Nb: 131218 Total time: 1.873s |   |  
  | 2022-11-12 17:30:14 | history | Merge history Nb: 18 Total time: 0s |   | 13
  | 2022-11-12 17:26:46 | history | Merge history Nb: 131210 Total time: 1.882s |   |  
  | 2022-11-12 17:16:48 | history | Merge history Nb: 131200 Total time: 1.856s

<!--EndFragment-->
</body>
</html>
With smaller data sets, it's immediate. 6500 rows in 0.062s

## Documentation
<!--
  Some useful links for contributors
-->


[beta-testing](https://doc.jeedom.com/en_US/beta/)
[contribute](https://doc.jeedom.com/en_US/contribute/)
[community](https://community.jeedom.com/)
[plugins](https://doc.jeedom.com/en_US/dev/)

