### PR TITLE
Update scenarioExpression.class.php

### DIFF
--- a/core/class/scenarioExpression.class.php
+++ b/core/class/scenarioExpression.class.php
@@ -1647,6 +1647,8 @@ class scenarioExpression {
 					$answer = explode(';', $options['answer']);
 					if (($key = array_search('*', $answer)) !== false) {
 						unset($answer[$key]);
+						if (count($answer) >= 1) $answer = array_values($answer);
+						else $answer = array("");
 					}
 					$options_cmd = array('title' => $options['question'], 'message' => $options['question'], 'answer' => $answer, 'timeout' => $limit, 'variable' => $options['variable']);
 
@@ -1665,7 +1667,7 @@ class scenarioExpression {
 					$this->setLog($scenario, __('Demande', __FILE__) . ' ' . json_encode($options_cmd));
 					$cmd->setCache('ask::variable', $options['variable']);
 					$cmd->setCache('ask::endtime', strtotime('now') + $limit);
-					$cmd->setCache('ask::answer', $options_cmd['answer']);
+					$cmd->setCache('ask::answer', explode(';', $options['answer']));
 					$cmd->execCmd($options_cmd);
 					$occurence = 0;
 					$value = '';


### PR DESCRIPTION
<!--
  Thanks for your contribution to make Jeedom better!
-->


## Proposed change
- cache if value contains *

during my test with telegram:
- if $answer contains "*;yes":
scenario_execution -> "PHP Notice: Undefined offset: 0 in /var/www/html/plugins/telegram/core/class/telegram.class.php on line 224"
telegram -> "Error sending telegram: {"ok":false,"error_code":400,"description":"Bad Request: field \"keyboard\" of the ReplyKeyboardMarkup must be an Array of Arrays"} "

- if $answer contains only "*":
scenario_execution -> "PHP Notice: Undefined offset: 0 in /var/www/html/plugins/telegram/core/class/telegram.class.php on line 224"


## Type of change
<!--
  What type of change your PR is
-->

- [ ] 3rd party lib update
- [X] Bugfix (non breaking change)
- [ ] Core new feature
- [ ] UI new functionnality
- [ ] Code quality improvements
- [ ] Core documentation


## Test check
<!--
  Describe here on which hardware, OS, Core version and eventually plugins you have tested your PR against.
  Give a maximum of details on what you did test, under which circumstances, and which side effect you did tried to handle.
-->


## Documentation
<!--
  Some useful links for contributors
-->


[beta-testing](https://doc.jeedom.com/en_US/beta/)
[contribute](https://doc.jeedom.com/en_US/contribute/)
[community](https://community.jeedom.com/)
[plugins](https://doc.jeedom.com/en_US/dev/)

