### PR TITLE
Fix Docker init step

### DIFF
--- a/install/OS_specific/Docker/init.sh
+++ b/install/OS_specific/Docker/init.sh
@@ -27,7 +27,7 @@ else
 		sed -i "s/#USERNAME#/jeedom/g" /var/www/html/core/config/common.config.php
 		sed -i "s/#PORT#/3306/g" /var/www/html/core/config/common.config.php
 		sed -i "s/#HOST#/localhost/g" /var/www/html/core/config/common.config.php
-		/root/install.sh -s 10mariadb
+		/root/install.sh -s 10
 		/root/install.sh -s 11
 	fi
 fi


### PR DESCRIPTION
J'ai cette erreur au lancement du container jeedom  "Désolé, Je ne peux sélectionner une 10mariadb étape pour vous !"

<!--
  Thanks for your contribution to make Jeedom better!
-->


## Proposed change

This error occurs when I launch the official Jeedom container with mouting paths for /var/www/html and db /var/lib/mysql

`docker run -p 80:80 -v $PWD/jeedom:/var/www/html -v $PWD/mysql:/var/lib/mysql --hostname jeedom --name jeedom1 jeedom/jeedom
  `

This command make the script install/OS_specific/Docker/init.sh goes to the second part (Start jeedom installation), whereas, without these volume being mouted, we just see "Jeedom is already install"



## Type of change
<!--
  What type of change your PR is
-->

- [ ] 3rd party lib update
- [ x] Bugfix (non breaking change)
- [ ] Core new feature
- [ ] UI new functionnality
- [ ] Code quality improvements
- [ ] Core documentation


## Test check
I can't check with the official image until it is re-build again.

## Documentation
<!--
  Some useful links for contributors
-->


[beta-testing](https://doc.jeedom.com/en_US/beta/)
[contribute](https://doc.jeedom.com/en_US/contribute/)
[community](https://community.jeedom.com/)
[plugins](https://doc.jeedom.com/en_US/dev/)

