### PR TITLE
Add an event after a ask reply (from user or after timeout)

### DIFF
--- a/core/class/scenarioExpression.class.php
+++ b/core/class/scenarioExpression.class.php
@@ -1691,6 +1691,7 @@ class scenarioExpression {
 						$dataStore->setValue($value);
 						$dataStore->save();
 					}
+					event::add('scenario::ask', array('scenario_id' => $scenario->getId(), 'variable' => $options['variable'], 'value' => $value));
 					$this->setLog($scenario, __('Réponse', __FILE__) . ' ' . $value);
 					return;
 				} elseif ($this->getExpression() == 'jeedom_poweroff') {


### PR DESCRIPTION
- Send an event after the ask variable is set (from user with the specified command in the ask command or after the ask timeout)
- Very useful and simple for the application used to respond (until now, after a ask timeout, there is no simple way for the application used to reply to know when timeout has expired) => testing the value 'Aucune réponse' is not optimal and need to be added in all scenarios using a ask command (and have to be specific for each application : not really friendly)

<!--
  Thanks for your contribution to make Jeedom better!
-->


## Proposed change
<!--
  Explain you PR here and why Core maintainers should accept it.
  You can link to Community subject if discussed there.
-->


## Type of change
<!--
  What type of change your PR is
-->

- [ ] 3rd party lib update
- [ ] Bugfix (non breaking change)
- [ ] Core new feature
- [ ] UI new functionnality
- [x] Code quality improvements
- [ ] Core documentation


## Test check
<!--
  Describe here on which hardware, OS, Core version and eventually plugins you have tested your PR against.
  Give a maximum of details on what you did test, under which circumstances, and which side effect you did tried to handle.
-->


## Documentation
<!--
  Some useful links for contributors
-->


[beta-testing](https://doc.jeedom.com/en_US/beta/)
[contribute](https://doc.jeedom.com/en_US/contribute/)
[community](https://community.jeedom.com/)
[plugins](https://doc.jeedom.com/en_US/dev/)

