### PR TITLE
Update cmd.class.php

### DIFF
--- a/core/class/cmd.class.php
+++ b/core/class/cmd.class.php
@@ -1446,6 +1446,7 @@ class cmd {
 				if (config::byKey('active', 'widget') == 1) {
 					$template = getTemplate('core', $_version, $template_name, 'widget');
 				}
+				$template = getTemplate('core', $_version, $template_name, $this->getEqType());
 				if ($template == '') {
 					foreach (plugin::listPlugin(true) as $plugin) {
 						$template = getTemplate('core', $_version, $template_name, $plugin->getId());


### PR DESCRIPTION
priority to the calling plugin before searching in the other plugins, 
because if two plugins use the same name, it is the widget in alphabetical order of the plugin name that is used