### PR TITLE
override the Dockerhub repository name

### DIFF
--- a/.github/workflows/docker-image-latest.yml
+++ b/.github/workflows/docker-image-latest.yml
@@ -24,8 +24,9 @@ jobs:
 
       - name: BRANCH name
         # adding infos in the $GITHUB_ENV file and summary
+        # secret DOCKER_HUB_REPO is optional (default=jeedom)
         run: |
-          export DOCKER_HUB_USERNAME=${{ secrets.DOCKER_HUB_USERNAME }}
+          export DOCKER_HUB_USERNAME=${{ secrets.DOCKER_HUB_REPO }}
           bash install/OS_specific/Docker/init_workflow.sh
 
       - name: Set up QEMU
@@ -88,7 +89,7 @@ jobs:
             "VERSION=${{ env.GITHUB_BRANCH }}"
             "DEBIAN=buster"
           tags: |
-            "${{ secrets.DOCKER_HUB_USERNAME }}/jeedom:${{ env.JEEDOM_SHORT_VERSION}}-buster"
+            "${{ env.JEEDOM_REPO }}/jeedom:${{ env.JEEDOM_SHORT_VERSION}}-buster"
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/install/OS_specific/Docker/init_workflow.sh
+++ b/install/OS_specific/Docker/init_workflow.sh
@@ -3,15 +3,17 @@
 # this script is used by CI/CD Github Workflow
 JEEDOM_VERSION=$(cat core/config/version)
 JEEDOM_SHORT_VERSION="$(echo "$JEEDOM_VERSION" | awk -F. '{print $1"."$2}')"
+# Docker hub repository may be overriden
+REPO=${DOCKER_HUB_REPO:-"jeedom"}
 
 if [[ "${GITHUB_REF_NAME}" == "V4-Stable" ]]; then
-  JEEDOM_TAGS="${DOCKER_HUB_USERNAME}/jeedom:latest,${DOCKER_HUB_USERNAME}/jeedom:$JEEDOM_SHORT_VERSION";
+  JEEDOM_TAGS="${REPO}/jeedom:latest,${REPO}/jeedom:$JEEDOM_SHORT_VERSION";
   GITHUB_BRANCH=${GITHUB_REF_NAME};
 elif [[ "${GITHUB_REF_NAME}" == "beta" ]]; then
-  JEEDOM_TAGS="${DOCKER_HUB_USERNAME}/jeedom:beta,${DOCKER_HUB_USERNAME}/jeedom:$JEEDOM_SHORT_VERSION";
+  JEEDOM_TAGS="${REPO}/jeedom:beta,${REPO}/jeedom:$JEEDOM_SHORT_VERSION";
   GITHUB_BRANCH=${GITHUB_REF_NAME};
 else
-  JEEDOM_TAGS="${DOCKER_HUB_USERNAME}/jeedom:$JEEDOM_SHORT_VERSION";
+  JEEDOM_TAGS="${REPO}/jeedom:$JEEDOM_SHORT_VERSION";
   GITHUB_BRANCH=alpha;
 fi
 
@@ -21,6 +23,7 @@ echo "JEEDOM_VERSION=$JEEDOM_VERSION" >> $GITHUB_ENV
 echo "JEEDOM_SHORT_VERSION=$JEEDOM_SHORT_VERSION" >> $GITHUB_ENV
 echo "JEEDOM_TAGS=$JEEDOM_TAGS" >> $GITHUB_ENV
 echo "GITHUB_BRANCH=$GITHUB_BRANCH" >> $GITHUB_ENV
+echo "JEEDOM_REPO=$REPO" >> $GITHUB_ENV
 
 # GITHUB_STEP_SUMMARY is the workflow summary
 # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary


### PR DESCRIPTION

## Proposed change

Fix the repository name for the github workflow : 
default is `jeedom` and the optional secret DOCKER_HUB_REPO may allow to override it.