### PR TITLE
Update history.class.js

### DIFF
--- a/core/js/history.class.js
+++ b/core/js/history.class.js
@@ -564,16 +564,6 @@ jeedom.history.drawChart = function(_params) {
                   dateFormat: '%Y-%m-%d'
               },
             },
-            lang: {
-					    downloadCSV: '{{Téléchargement CSV}}',
-					    downloadJPEG: '{{Téléchargement JPEG}}',
-					    downloadPDF: '{{Téléchargement PDF}}',
-					    downloadPNG: '{{Téléchargement PNG}}',
-					    downloadSVG: '{{Téléchargement SVG}}',
-					    downloadXLS: '{{Téléchargement XLS}}',
-					    printChart: '{{Imprimer}}',
-					    viewFullscreen: '{{Plein écran}}',
-				    },
             tooltip: {
               pointFormat: '{point.y} {series.userOptions.unite}<br/>{series.userOptions.shortName}',
               valueDecimals: _params.round,
@@ -830,16 +820,6 @@ jeedom.history.drawChart = function(_params) {
                   dateFormat: '%Y-%m-%d'
               },
             },
-            lang: {
-					    downloadCSV: '{{Téléchargement CSV}}',
-					    downloadJPEG: '{{Téléchargement JPEG}}',
-					    downloadPDF: '{{Téléchargement PDF}}',
-					    downloadPNG: '{{Téléchargement PNG}}',
-					    downloadSVG: '{{Téléchargement SVG}}',
-					    downloadXLS: '{{Téléchargement XLS}}',
-					    printChart: '{{Imprimer}}',
-					    viewFullscreen: '{{Plein écran}}',
-				    },
             rangeSelector: {
               allButtonsEnabled: true,
               buttonTheme: { // styles for the buttons

--- a/core/js/history.class.js
+++ b/core/js/history.class.js
@@ -559,10 +559,21 @@ jeedom.history.drawChart = function(_params) {
             credits: { enabled: false },
             exporting: {
               enabled: _params.enableExport || (jeedom.display.version == 'mobile') ? false : true,
+              libURL: '/3rdparty/highstock/lib/',
               csv: {
                   dateFormat: '%Y-%m-%d'
               },
             },
+            lang: {
+					    downloadCSV: '{{Téléchargement CSV}}',
+					    downloadJPEG: '{{Téléchargement JPEG}}',
+					    downloadPDF: '{{Téléchargement PDF}}',
+					    downloadPNG: '{{Téléchargement PNG}}',
+					    downloadSVG: '{{Téléchargement SVG}}',
+					    downloadXLS: '{{Téléchargement XLS}}',
+					    printChart: '{{Imprimer}}',
+					    viewFullscreen: '{{Plein écran}}',
+				    },
             tooltip: {
               pointFormat: '{point.y} {series.userOptions.unite}<br/>{series.userOptions.shortName}',
               valueDecimals: _params.round,
@@ -814,10 +825,21 @@ jeedom.history.drawChart = function(_params) {
             },
             exporting: {
               enabled: _params.enableExport || (jeedom.display.version == 'mobile') ? false : true,
+              libURL: '/3rdparty/highstock/lib/',
               csv: {
                   dateFormat: '%Y-%m-%d'
               },
             },
+            lang: {
+					    downloadCSV: '{{Téléchargement CSV}}',
+					    downloadJPEG: '{{Téléchargement JPEG}}',
+					    downloadPDF: '{{Téléchargement PDF}}',
+					    downloadPNG: '{{Téléchargement PNG}}',
+					    downloadSVG: '{{Téléchargement SVG}}',
+					    downloadXLS: '{{Téléchargement XLS}}',
+					    printChart: '{{Imprimer}}',
+					    viewFullscreen: '{{Plein écran}}',
+				    },
             rangeSelector: {
               allButtonsEnabled: true,
               buttonTheme: { // styles for the buttons

--- a/core/js/history.class.js
+++ b/core/js/history.class.js
@@ -559,7 +559,7 @@ jeedom.history.drawChart = function(_params) {
             credits: { enabled: false },
             exporting: {
               enabled: _params.enableExport || (jeedom.display.version == 'mobile') ? false : true,
-              libURL: '/3rdparty/highstock/lib/',
+              libURL: '3rdparty/highstock/lib/',
               csv: {
                   dateFormat: '%Y-%m-%d'
               },
@@ -815,7 +815,7 @@ jeedom.history.drawChart = function(_params) {
             },
             exporting: {
               enabled: _params.enableExport || (jeedom.display.version == 'mobile') ? false : true,
-              libURL: '/3rdparty/highstock/lib/',
+              libURL: '3rdparty/highstock/lib/',
               csv: {
                   dateFormat: '%Y-%m-%d'
               },

--- a/core/js/jeedom.class.js
+++ b/core/js/jeedom.class.js
@@ -147,7 +147,15 @@ jeedom.init = function() {
     lang: {
       months: ['{{Janvier}}', '{{Février}}', '{{Mars}}', '{{Avril}}', '{{Mai}}', '{{Juin}}', '{{Juillet}}', '{{Août}}', '{{Septembre}}', '{{Octobre}}', '{{Novembre}}', '{{Décembre}}'],
       shortMonths: ['{{Janvier}}', '{{Février}}', '{{Mars}}', '{{Avril}}', '{{Mai}}', '{{Juin}}', '{{Juillet}}', '{{Août}}', '{{Septembre}}', '{{Octobre}}', '{{Novembre}}', '{{Décembre}}'],
-      weekdays: ['{{Dimanche}}', '{{Lundi}}', '{{Mardi}}', '{{Mercredi}}', '{{Jeudi}}', '{{Vendredi}}', '{{Samedi}}']
+      weekdays: ['{{Dimanche}}', '{{Lundi}}', '{{Mardi}}', '{{Mercredi}}', '{{Jeudi}}', '{{Vendredi}}', '{{Samedi}}'],
+      downloadCSV: '{{Téléchargement CSV}}',
+      downloadJPEG: '{{Téléchargement JPEG}}',
+      downloadPDF: '{{Téléchargement PDF}}',
+      downloadPNG: '{{Téléchargement PNG}}',
+      downloadSVG: '{{Téléchargement SVG}}',
+      downloadXLS: '{{Téléchargement XLS}}',
+      printChart: '{{Imprimer}}',
+      viewFullscreen: '{{Plein écran}}',
     },
     colors: [
       cssComputedStyle.getPropertyValue('--al-info-color'),


### PR DESCRIPTION
<!--
  Thanks for your contribution to make Jeedom better!
-->


## Proposed change
La librairie `highcharts` peut, dans certains cas, tenter d'aller chercher la lib `jspdf.js` sur le site `code.highcharts.com`. Mais les accès aux sites tiers sont bloqués par sécurité  depuis quelques versions de Jeedom. L'option `libURL` permet d'indiquer à `highcharts` qu'il ne faut pas charger du code depuis `code.highcharts.com` mais utiliser ce qui est embarqué avec le core Jeedom.

J'en ai profité pour proposer une traduction du menu contextuelle des imports des graphique..

## Type of change
Export des graphiques:
+ Déclaration de l'option `['exporting][libURL]`pour utiliser les librairies (`jspdf.js` en particulier) locales pluto que de tenter d'aller les ceurcher sur `code.highcharts.com`
+ Traduction du menu contextuel pour les exports


- [ ] 3rd party lib update
- [ X] Bugfix (non breaking change)
- [ ] Core new feature
- [ ] UI new functionnality
- [ X] Code quality improvements
- [ ] Core documentation


## Test check
<!--
  Describe here on which hardware, OS, Core version and eventually plugins you have tested your PR against.
  Give a maximum of details on what you did test, under which circumstances, and which side effect you did tried to handle.
-->


## Documentation
<!--
  Some useful links for contributors
-->


[beta-testing](https://doc.jeedom.com/en_US/beta/)
[contribute](https://doc.jeedom.com/en_US/contribute/)
[community](https://community.jeedom.com/)
[plugins](https://doc.jeedom.com/en_US/dev/)

