### PR TITLE
add "try-it-now" button

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://github.com/jeedom/core/graphs/commit-activity)
 [![GitHub contributors](https://img.shields.io/github/contributors/jeedom/core.svg)](https://github.com/jeedom/core/graphs/contributors/)
 [![Website www.jeedom.com](https://img.shields.io/website-up-down-green-red/http/shields.io.svg)](https://www.jeedom.com/)
+[![Try it now!](https://img.shields.io/badge/PWD-Try%20it%20now-blue?logo=docker)](https://labs.play-with-docker.com/?stack=https://raw.githubusercontent.com/pifou25/jeedom-core/alpha/docker-compose.yml)
 
 # Jeedom - La domotique innovante | *Innovative Home Automation*
 <p align="center">

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.8'
+
+services:
+
+  jeedom:
+    # fix jeedom version to avoid unwanted upgrade
+    image: jeedom/jeedom:4.4
+    restart: unless-stopped
+    # map host directories into container volumes
+    # volumes:
+    #  - ./volumes/jeedom:/var/www/html
+    #  - ./volumes/backup:/tmp/backup
+    healthcheck:
+      test: ["CMD-SHELL", "curl -so /tmp/status http://localhost/here.html || exit 1"]
+      interval: 1m30s
+      retries: 3
+      start_period: 40s
+      timeout: 20s
+    ports:
+      # host port mapped to the container port 80
+      - "80:80"
+    logging:
+      # limit log file and size
+      options:
+        max-size: "10m"
+        max-file: "1"


### PR DESCRIPTION
use the online docker feature play-with-docker

<!--
  Thanks for your contribution to make Jeedom better!
-->


## Proposed change
<!--
  Explain you PR here and why Core maintainers should accept it.
  You can link to Community subject if discussed there.
-->


## Type of change
<!--
  What type of change your PR is
-->

- [ ] 3rd party lib update
- [ ] Bugfix (non breaking change)
- [ ] Core new feature
- [ ] UI new functionnality
- [ ] Code quality improvements
- [ ] Core documentation
- [x] **docker-compose as an example, and the "try-it-now" button on readme, allowing everyone to test onlive the docker image**

## Test check
<!--
  Describe here on which hardware, OS, Core version and eventually plugins you have tested your PR against.
  Give a maximum of details on what you did test, under which circumstances, and which side effect you did tried to handle.
-->


## Documentation

This is just a link on README to try the docker image online with the default "docker-compose"

[beta-testing](https://doc.jeedom.com/en_US/beta/)
[contribute](https://doc.jeedom.com/en_US/contribute/)
[community](https://community.jeedom.com/)
[plugins](https://doc.jeedom.com/en_US/dev/)

