### PR TITLE
Process html special character for tooltips and command's value

### DIFF
--- a/desktop/modal/eqLogic.configure.php
+++ b/desktop/modal/eqLogic.configure.php
@@ -143,7 +143,7 @@ sendVarToJS([
                 $display .= '<td><span class="label label-sm label-' . (($cmd->getType() == 'action') ? 'warning' : 'primary') . '">' . $cmd->getType() . '</span> <span class="label label-sm label-info">' . $cmd->getSubtype() . '</span></td>';
                 $display .= '<td>';
                 if ($cmd->getType() == 'info') {
-                  $value = $cmd->execCmd();
+                  $value = htmlspecialchars($cmd->execCmd());
                   $title = '{{Date de valeur}} : ' . $cmd->getValueDate() . '<br>{{Date de collecte}} : ' .  $cmd->getCollectDate();
                   if (strlen($value) > 50) {
                     $title .= '<br>{{Valeur}} : ' . $value;


### PR DESCRIPTION
<!--
  Thanks for your contribution to make Jeedom better!
-->


## Proposed change
<!--
  Explain you PR here and why Core maintainers should accept it.
  You can link to Community subject if discussed there.
-->


## Type of change
<!--
  What type of change your PR is
-->

- [ ] 3rd party lib update
- [x] Bugfix (non breaking change)
- [ ] Core new feature
- [ ] UI new functionnality
- [ ] Code quality improvements
- [ ] Core documentation


## Test check
<!--
  Describe here on which hardware, OS, Core version and eventually plugins you have tested your PR against.
  Give a maximum of details on what you did test, under which circumstances, and which side effect you did tried to handle.
-->
When the value of a command is displayed in the command list of an equipment(tooltip and status column), the value is processed in plugin.template.js
with:
`data.cmd[i].state = String(data.cmd[i].state).replace(/<[^>]*>?/gm, '');`
In the Advanced configuration of the equipment, the value was not processed in modal/eqLogic.configure.php.
`$value = $cmd->execCmd();`
Description of this issue can be found here:
[Community](https://community.jeedom.com/t/livebox-configuration-avancee-disposition-plus-accessible/104161/7?u=jpty)

## Documentation
<!--
  Some useful links for contributors
-->


[beta-testing](https://doc.jeedom.com/en_US/beta/)
[contribute](https://doc.jeedom.com/en_US/contribute/)
[community](https://community.jeedom.com/)
[plugins](https://doc.jeedom.com/en_US/dev/)

