### PR TITLE
History export broken due to file not properly passed in parameter

### DIFF
--- a/core/class/scenarioExpression.class.php
+++ b/core/class/scenarioExpression.class.php
@@ -1748,7 +1748,7 @@ class scenarioExpression {
 					}
 					$options['name'] = str_replace(array('/'), array(''), $options['name']);
 					$tmp_file = jeedom::getTmpFolder('history_export') . '/' . $options['name'] . '.csv';
-					$cmd_parameters = array('files' => $tmp_file, 'title' => $options['name'], 'message' => $options['name']);
+					$cmd_parameters = array('files' => [$tmp_file], 'title' => $options['name'], 'message' => $options['name']);
 
 					$start = date('Y-m-d H:i:s', strtotime($options['start']));
 					$end = date('Y-m-d H:i:s', strtotime($options['end']));


### PR DESCRIPTION
<!--
  Thanks for your contribution to make Jeedom better!
-->


## Proposed change
<!--
  Explain you PR here and why Core maintainers should accept it.
  You can link to Community subject if discussed there.
-->
Correct a bug where the export of the history from a scenario is broken as it doesn't embeds the history attachment properly


## Type of change
<!--
  What type of change your PR is
-->

- [ ] 3rd party lib update
- [X] Bugfix (non breaking change)
- [ ] Core new feature
- [ ] UI new functionnality
- [ ] Code quality improvements
- [ ] Core documentation


## Test check
<!--
  Describe here on which hardware, OS, Core version and eventually plugins you have tested your PR against.
  Give a maximum of details on what you did test, under which circumstances, and which side effect you did tried to handle.
-->
Before the fix: running a history export scenario doesn't work (nothing exported)
After the fix: running the same scenario does export the history properly


## Documentation
<!--
  Some useful links for contributors
-->


[beta-testing](https://doc.jeedom.com/en_US/beta/)
[contribute](https://doc.jeedom.com/en_US/contribute/)
[community](https://community.jeedom.com/)
[plugins](https://doc.jeedom.com/en_US/dev/)

