### PR TITLE
🔨 Allow calculValueOffset/evaluateExpression ("Formule de calcul") on every info cmd

### DIFF
--- a/core/class/cmd.class.php
+++ b/core/class/cmd.class.php
@@ -901,29 +901,30 @@ class cmd {
 			return $_value;
 		}
 		if ($this->getType() == 'info') {
+			if ($this->getSubType() == 'numeric') { // Handle comma instead of period in a float value
+				$_value = floatval(str_replace(',', '.', $_value));
+			}
+			$calc = $this->getConfiguration('calculValueOffset');
+			if ($calc != '') {
+				try {
+					if (preg_match("/[a-zA-Z#]/", $_value)) { // Value is not just a number
+						$calc = str_replace('#value#', '"' . $_value . '"', str_replace('\'#value#\'', '#value#', str_replace('"#value#"', '#value#', $calc)));
+					} else { // Value is a number
+						$calc = str_replace('#value#', $_value, $calc);
+					}
+					$_value = jeedom::evaluateExpression($calc);
+				} catch (Exception $ex) {
+				} catch (Error $ex) {
+				}
+			}
 			switch ($this->getSubType()) {
 				case 'string':
-					if ($_quote) {
-						return '"' . $_value . '"';
-					}
-					return $_value;
 				case 'other':
 					if ($_quote) {
 						return '"' . $_value . '"';
 					}
 					return $_value;
 				case 'binary':
-					if ($this->getConfiguration('calculValueOffset') != '') {
-						try {
-							if (preg_match("/[a-zA-Z#]/", $_value)) {
-								$_value = jeedom::evaluateExpression(str_replace('#value#', '"' . $_value . '"', str_replace('\'#value#\'', '#value#', str_replace('"#value#"', '#value#', $this->getConfiguration('calculValueOffset')))));
-							} else {
-								$_value = jeedom::evaluateExpression(str_replace('#value#', $_value, $this->getConfiguration('calculValueOffset')));
-							}
-						} catch (Exception $ex) {
-						} catch (Error $ex) {
-						}
-					}
 					if ($_value === true || $_value === 1) { // Handle literal values
 						$binary = true;
 					} elseif ((is_numeric(intval($_value)) && intval($_value) >= 1)) { // Handle number and numeric string
@@ -936,18 +937,6 @@ class cmd {
 					// Return int value negated according to invertBinary configuration
 					return intval($binary xor boolval($this->getConfiguration('invertBinary', false)));
 				case 'numeric':
-					$_value = floatval(str_replace(',', '.', $_value));
-					if ($this->getConfiguration('calculValueOffset') != '') {
-						try {
-							if (preg_match("/[a-zA-Z#]/", $_value)) {
-								$_value = jeedom::evaluateExpression(str_replace('#value#', '"' . $_value . '"', str_replace('\'#value#\'', '#value#', str_replace('"#value#"', '#value#', $this->getConfiguration('calculValueOffset')))));
-							} else {
-								$_value = jeedom::evaluateExpression(str_replace('#value#', $_value, $this->getConfiguration('calculValueOffset')));
-							}
-						} catch (Exception $ex) {
-						} catch (Error $ex) {
-						}
-					}
 					if ($this->getConfiguration('historizeRound') !== '' && is_numeric($this->getConfiguration('historizeRound')) && $this->getConfiguration('historizeRound') >= 0) {
 						$_value = round($_value, $this->getConfiguration('historizeRound'));
 					}

--- a/desktop/modal/cmd.configure.php
+++ b/desktop/modal/cmd.configure.php
@@ -341,7 +341,7 @@ $configEqDisplayType = jeedom::getConfiguration('eqLogic:displayType');
       <br />
       <form class="form-horizontal">
         <fieldset>
-          <?php if (($cmd->getType() == 'info' && ($cmd->getSubType() == 'numeric' || $cmd->getSubType() == 'binary')) || ($cmd->getType() == 'action' && ($cmd->getSubType() == 'slider'))) {
+          <?php if (($cmd->getType() == 'info') || ($cmd->getType() == 'action' && ($cmd->getSubType() == 'slider'))) {
           ?>
             <legend><i class="fas fa-table"></i> {{Calcul et arrondi}}</legend>
             <div class="form-group">


### PR DESCRIPTION
## Proposed change
This is a cherry pick of PR #2146 on branch V4-stable, as requested by [Jeandhom on community](https://community.jeedom.com/t/github-appliquer-un-pr-en-alpha-sur-sa-prod-en-stable/105139)

Purpose: Always display "Formule de calcul" on info cmd advanced configuration modal (in Core v4.3)

## Type of change
- [ ] 3rd party lib update
- [ ] Bugfix (non breaking change)
- [ ] Core new feature
- [x] UI new functionnality
- [ ] Code quality improvements
- [ ] Core documentation

## Test check
Tested in dev env, but no CI/CD check included.

## Documentation
https://community.jeedom.com/t/formule-de-calcul-dans-une-commande-info-autre/93564