### PR TITLE
Fix V4-stable branch name case

### DIFF
--- a/install/OS_specific/Docker/init_workflow.sh
+++ b/install/OS_specific/Docker/init_workflow.sh
@@ -6,7 +6,7 @@ JEEDOM_SHORT_VERSION="$(echo "$JEEDOM_VERSION" | awk -F. '{print $1"."$2}')"
 # Docker hub repository may be overriden
 REPO=${DOCKER_HUB_REPO:-"jeedom"}
 
-if [[ "${GITHUB_REF_NAME}" == "V4-Stable" ]]; then
+if [[ "${GITHUB_REF_NAME}" == "V4-stable" ]]; then
   JEEDOM_TAGS="${REPO}/jeedom:latest,${REPO}/jeedom:$JEEDOM_SHORT_VERSION";
   GITHUB_BRANCH=${GITHUB_REF_NAME};
 elif [[ "${GITHUB_REF_NAME}" == "beta" ]]; then


### PR DESCRIPTION

## Proposed change

Fix the V4-stable branch name, this is for the workflow to update the Docker `latest` tag with the same image as the current 4.3 tag.

## Type of change
<!--
  What type of change your PR is
-->

- [ ] 3rd party lib update
- [ ] Bugfix (non breaking change)
- [ ] Core new feature
- [ ] UI new functionnality
- [ ] Code quality improvements
- [ ] Core documentation
- [x] Github Workflow 


## Test check
<!--
  Describe here on which hardware, OS, Core version and eventually plugins you have tested your PR against.
  Give a maximum of details on what you did test, under which circumstances, and which side effect you did tried to handle.
-->


## Documentation
<!--
  Some useful links for contributors
-->


[beta-testing](https://doc.jeedom.com/en_US/beta/)
[contribute](https://doc.jeedom.com/en_US/contribute/)
[community](https://community.jeedom.com/)
[plugins](https://doc.jeedom.com/en_US/dev/)

