### PR TITLE
replace deprecated create_function by anonymous fn

### DIFF
--- a/core/class/jeeObject.class.php
+++ b/core/class/jeeObject.class.php
@@ -667,12 +667,12 @@ class jeeObject {
 				'usage' => config::byKey('autoreorder::weight_automation_action') * $usage['automation'] + config::byKey('autoreorder::weight_human_actio') * $usage['ui'] + config::byKey('autoreorder::weight_history') * $usage['history'],
 			);
 		}
-		usort($eqLogics, create_function('$a, $b', '
-        if ($a["usage"] == $b["usage"]){
-            return 0;
-        }
-        return ($a["usage"] >  $b["usage"]) ? -1 : 1;
-    '));
+		usort($eqLogics, function ($a, $b) {
+			if ($a["usage"] == $b["usage"]) {
+				return 0;
+			}
+			return ($a["usage"] >  $b["usage"]) ? -1 : 1;
+		});
 		$order = 0;
 		foreach ($eqLogics as $eqLogic) {
 			$eqLogic['eqLogic']->setOrder($order);


### PR DESCRIPTION
<!--
  Thanks for your contribution to make Jeedom better!
-->


## Proposed change
Usage of create_function has been DEPRECATED as of PHP 7.2.0, and will be REMOVED as of PHP 8.0.0: https://www.php.net/manual/en/function.create-function.php

So this change is necessary for compatibility with PHP 8.0


## Type of change
<!--
  What type of change your PR is
-->

- [ ] 3rd party lib update
- [ ] Bugfix (non breaking change)
- [ ] Core new feature
- [ ] UI new functionnality
- [X] Code quality improvements
- [ ] Core documentation


## Test check
<!--
  Describe here on which hardware, OS, Core version and eventually plugins you have tested your PR against.
  Give a maximum of details on what you did test, under which circumstances, and which side effect you did tried to handle.
-->


## Documentation
<!--
  Some useful links for contributors
-->


[beta-testing](https://doc.jeedom.com/en_US/beta/)
[contribute](https://doc.jeedom.com/en_US/contribute/)
[community](https://community.jeedom.com/)
[plugins](https://doc.jeedom.com/en_US/dev/)

