### PR TITLE
:bug: Fix switch from card view to list view

### DIFF
--- a/core/js/plugin.template.js
+++ b/core/js/plugin.template.js
@@ -39,7 +39,7 @@ if (!jeeFrontEnd.pluginTemplate) {
       if (butDisp != null) {
         butDisp.removeClass('hidden') //Not shown on previous core versions
         if (getCookie('jeedom_displayAsTable') == 'true' || jeedom.theme.theme_displayAsTable == 1) {
-          butDisp.addClass('active').dataset.sate = '1'
+          butDisp.addClass('active').dataset.state = '1'
           if (coreSupport) {
             document.querySelectorAll('.eqLogicDisplayCard')?.addClass('displayAsTable')
             document.querySelectorAll('.eqLogicDisplayCard .hiddenAsCard')?.removeClass('hidden')
@@ -49,14 +49,14 @@ if (!jeeFrontEnd.pluginTemplate) {
         //core event:
         if (coreSupport) {
           butDisp.unRegisterEvent('click').registerEvent('click', function(event) {
-            if (butDisp.dataset.sate == '0') {
-              butDisp.addClass('active').dataset.sate = '1'
+            if (butDisp.dataset.state != '1') {
+              butDisp.addClass('active').dataset.state = '1'
               setCookie('jeedom_displayAsTable', 'true', 2)
               document.querySelectorAll('.eqLogicDisplayCard')?.addClass('displayAsTable')
               document.querySelectorAll('.eqLogicDisplayCard .hiddenAsCard')?.removeClass('hidden')
               document.querySelector('.eqLogicThumbnailContainer').addClass('containerAsTable')
             } else {
-              butDisp.removeClass('active').dataset.sate = '0'
+              butDisp.removeClass('active').dataset.state = '0'
               setCookie('jeedom_displayAsTable', 'false', 2)
               document.querySelectorAll('.eqLogicDisplayCard')?.removeClass('displayAsTable')
               document.querySelectorAll('.eqLogicDisplayCard .hiddenAsCard')?.addClass('hidden')


### PR DESCRIPTION
## Proposed change

Fix a minor bug on the main main page of a plugin:
To switch from card view to list view, 2 clicks on the sandwich menu are needed:
![image](https://github.com/jeedom/core/assets/8396512/4bbc89cc-364f-4cc1-a89f-134b28a47044)
No issue to switch from list view to card view.

Problem is a typo in `plugin.template.js`, `dataset.sate` should certainly be `dataset.state`.
When clicking the first time `data-sate` attribut is created and set to `0`, then finally set to `1` on the second click:
0: ![image](https://github.com/jeedom/core/assets/8396512/f2a43858-38ad-44e1-ae5c-48df021df0b5)
1: ![image](https://github.com/jeedom/core/assets/8396512/205fd4fd-36a3-4e71-b930-9a506c3bd667)
2: ![image](https://github.com/jeedom/core/assets/8396512/e99c6de4-9fff-4827-9500-246f222b4fda)

## Type of change
- [ ] 3rd party lib update
- [x] Bugfix (non breaking change)
- [ ] Core new feature
- [ ] UI new functionnality
- [ ] Code quality improvements
- [ ] Core documentation

## Test check
No CI/CD or automated test for this bug.
Fix checked on Jeedom v4.4.0 (commit https://github.com/jeedom/core/commit/2b0723744d6ad1caf4eaf67b8089906a2c3b199c) with plugins Virtual and jMQTT.

## Documentation
N/A
