### PR TITLE
:hammer: Faster and less bandwidth consuming logs display

### DIFF
--- a/core/ajax/log.ajax.php
+++ b/core/ajax/log.ajax.php
@@ -62,6 +62,19 @@ try {
 		ajax::success(log::get(init('log'), init('start', 0), init('nbLine', 99999)));
 	}
 
+	if (init('action') == 'getDelta') {
+		ajax::success(
+			log::getDelta(
+				init('log'),
+				intval(init('position', 0)),
+				init('search'),
+				intval(init('colored', 0)),
+				init('numbered', true),
+				intval(init('numberStart', 0))
+			)
+		);
+	}
+
 	throw new Exception(__('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));
 	/*     * *********Catch exeption*************** */
 } catch (Exception $e) {

--- a/core/class/log.class.php
+++ b/core/class/log.class.php
@@ -234,11 +234,11 @@ class log {
 	* @return boolean|array
 	*/
 	public static function get($_log = 'core', $_begin, $_nbLines) {
-		self::chunk($_log);
 		$path = (!file_exists($_log) || !is_file($_log)) ? self::getPathToLog($_log) : $_log;
 		if (!file_exists($path)) {
 			return false;
 		}
+		self::chunkLog($path);
 		$page = array();
 		$log = new SplFileObject($path);
 		if ($log) {

--- a/core/class/log.class.php
+++ b/core/class/log.class.php
@@ -260,6 +260,110 @@ class log {
 		return $page;
 	}
 
+	/*
+	* Get the log delta from $_position to the end of the file
+	* New position is stored in $_position when eof is reached
+	*
+	* @param string $_log Log filename (default 'core')
+	* @param int $_position Bytes representing position from the begining of the file (default 0)
+	* @param string $_search Text to find in log file (default '')
+	* @param int $_colored Should lines be colored (default 0) [0: no ; 1: global log colors ; 2: scenario colors]
+	* @param boolean $_numbered Should lines be numbered (default true)
+	* @param int $_numStart At what number should lines number start (default 0)
+	* @param int $_max Max number of returned lines (default 4000)
+	* @return array Array containing log to append to buffer and new position for next call
+	*/
+	public static function getDelta($_log = 'core', $_position = 0, $_search = '', $_colored = 0, $_numbered = true, $_numStart = 0, $_max = 4000) {
+		// Check if log file exists
+		$path = (file_exists($_log) && is_file($_log)) ? $_log : self::getPathToLog($_log);
+		if (!file_exists($path))
+			return false;
+		// Prepare file for reading
+		if (!$fp = fopen($path, 'r'))
+			return false;
+		// Set file pointer at requested position
+		fseek($fp, $_position);
+		// Iterate the file
+		$logs = array();
+		while (!feof($fp)) {
+			// Get a new line
+			$line = mb_convert_encoding(trim(fgets($fp)), 'UTF-8');
+			if ($line == '')
+				continue;
+			// Append line to array if not empty
+			if ($_search === '' || mb_stripos($line, $_search) !== false) {
+				if ($_numbered) {
+					array_push($logs, str_pad($_numStart, 4, '0', STR_PAD_LEFT) . '|' . trim($line) . "\n");
+				} else {
+					array_push($logs, trim($line) . "\n");
+				}
+			}
+			$_numStart++;
+		}
+		// Store new file position in $_position
+		$_position = ftell($fp);
+		fclose($fp);
+
+		// Display only the last jeedom.log.maxLines
+		$logText = '';
+		$nbLogs = count($logs);
+		// If logs are TRUNCATED, then add a message
+		if (count($logs) > $_max) {
+			$logText .= "-------------------- TRUNCATED LOG --------------------\n";
+			$logs = array_slice($logs, -$_max, $_max);
+		}
+		// Merge all lignes
+		$logText .= implode('', $logs);
+
+		// Apply color in system logs
+		if ($_colored == 1) {
+			$search = array(
+				'<',
+				'>',
+				'WARNING:',
+				'Erreur',
+				'OK',
+				'[INFO]',
+				'[DEBUG]',
+				'[WARNING]',
+				'[ALERT]',
+				'[ERROR]',
+				'-------------------- TRUNCATED LOG --------------------'
+			);
+			$replace = array(
+				'&lt;',
+				'&gt;',
+				'<span class="warning">WARNING</span>',
+				'<span class="danger">Erreur</span>',
+				'<strong>OK</strong>',
+				'<span class="label label-xs label-info">INFO</span>',
+				'<span class="label label-xs label-success">DEBUG</span>',
+				'<span class="label label-xs label-warning">WARNING</span>',
+				'<span class="label label-xs label-warning">ALERT</span>',
+				'<span class="label label-xs label-danger">ERROR</span>',
+				'<span class="label label-xl label-danger">-------------------- TRUNCATED LOG --------------------</span>'
+			);
+			$logText = str_replace($search, $replace, $logText);
+		}
+		// Apply color in scenario logs
+		elseif ($_colored == 2) {
+			$search = array();
+			$replace = array();
+			foreach($GLOBALS['JEEDOM_SCLOG_TEXT'] as $item) {
+				$search[] = $item['txt'];
+				$replace[] = str_replace('::', $item['txt'], $item['replace']);
+			}
+			$search[] = ' Start : ';
+			$replace[] = '<strong> -- Start : </strong>';
+			$search[] = 'Log :';
+			$replace[] = '<span class="success">&ensp;&ensp;&ensp;Log :</span>';
+			$logText = str_replace($search, $replace, $logText);
+		}
+
+		// Return the lines to the end of the file, the new position and line number
+		return array('position' => $_position, 'line' => $_numStart, 'logText' => $logText);
+	}
+
 	public static function liste($_filtre = null) {
 		$return = array();
 		foreach (ls(self::getPathToLog(''), '*') as $log) {

--- a/core/js/log.class.js
+++ b/core/js/log.class.js
@@ -91,6 +91,32 @@ jeedom.log.get = function(_params) {
   domUtils.ajax(paramsAJAX);
 }
 
+jeedom.log.getDelta = function(_params) {
+  var paramsRequired = ['log', 'position'];
+  var paramsSpecifics = {
+    global: _params.global || true,
+  };
+  try {
+    jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
+  } catch (e) {
+    (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
+    return;
+  }
+  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  paramsAJAX.url = 'core/ajax/log.ajax.php';
+  paramsAJAX.data = {
+    action: 'getDelta',
+    log: _params.log,
+    position: _params.position,
+    search: _params.search,
+    colored: _params.colored,
+    numbered: _params.numbered,
+    numberStart: _params.numberStart
+  };
+  domUtils.ajax(paramsAJAX);
+}
+
 jeedom.log.remove = function(_params) {
   var paramsRequired = ['log'];
   var paramsSpecifics = {

--- a/core/js/log.class.js
+++ b/core/js/log.class.js
@@ -18,6 +18,7 @@ jeedom.log = function() {};
 jeedom.log.timeout = null
 jeedom.log.currentAutoupdate = []
 jeedom.log.coloredThreshold = 300000
+jeedom.log.maxLines = 4000
 
 jeedom.log.list = function(_params) {
   var paramsRequired = [];
@@ -326,6 +327,155 @@ jeedom.log.autoupdate = function(_params) {
   });
 }
 
+jeedom.log.updateBtn = function(_control) {
+  if (_control.getAttribute('data-state') == 1) {
+    _control.removeClass('btn-success').addClass('btn-warning')
+    _control.innerHTML = '<i class="fa fa-pause"></i><span class="hidden-768"> {{Pause}}</span>'
+  } else {
+    _control.removeClass('btn-warning').addClass('btn-success')
+    _control.innerHTML = '<i class="fa fa-play"></i><span class="hidden-768"> {{Reprendre}}</span>'
+  }
+}
+
+jeedom.log.autoUpdateDelta = function(_params) {
+  // Normalize parameters
+  if (!isset(_params.callNumber)) _params.callNumber = 0
+  if (!isset(_params.position)) _params.position = 0;
+  if (!isset(_params.lineNum)) _params.lineNum = 0;
+  if (!isset(_params.log)) return
+  if (!isset(_params.display)) return
+
+  // Deprecated use with jQuery objects by plugins
+  if (_params.callNumber == 0) {
+    if (isElement_jQuery(_params.log)) _params.log = _params.log[0]
+    if (isElement_jQuery(_params.display)) _params.display = _params.display[0]
+    if (isElement_jQuery(_params.search)) _params.search = _params.search[0]
+    if (isElement_jQuery(_params.control)) _params.control = _params.control[0]
+  }
+
+  // Exit if invisible
+  if (!_params.display.isVisible()) return
+
+  // Exit if Paused
+  if (_params.callNumber > 0 && isset(_params.control) && _params.control.getAttribute('data-state') != 1) {
+    return
+  }
+  // Exit if a newer instance on another log is running
+  if (_params.callNumber > 0 && isset(jeedom.log.currentAutoupdate[_params.display.getAttribute('id')]) && jeedom.log.currentAutoupdate[_params.display.getAttribute('id')].log != _params.log) {
+    return
+  }
+
+  if (_params.callNumber == 0) {
+    // Empty space on first call
+    _params.position = 0;
+    _params.lineNum = 0;
+    _params.display.empty();
+
+    if (isset(_params.default_search)) {
+      _params.search.value = _params.default_search
+    }
+    _params.display.scrollTop = _params.display.offsetHeight + _params.display.scrollHeight + 1
+    if (_params.control.getAttribute('data-state') == 0) {
+      _params.control.setAttribute('data-state', 1)
+      jeedom.log.updateBtn(_params.control)
+    }
+
+    // Setup callback: On control button click
+    _params.control.unRegisterEvent('click').registerEvent('click', function (event) {
+      if (this.getAttribute('data-state') == 1) {
+        // On "Pause" requested
+        this.setAttribute('data-state', 0)
+        jeedom.log.updateBtn(this)
+      } else {
+        // On "Continue" requested
+        this.setAttribute('data-state', 1)
+        jeedom.log.updateBtn(this)
+        _params.display.scrollTop = _params.display.offsetHeight + _params.display.scrollHeight + 1
+        jeedom.log.autoUpdateDelta(_params)
+      }
+    })
+
+    // Setup callback: On search field update
+    _params.search.unRegisterEvent('keypress').registerEvent('keypress', function (event) {
+      // Reset log position and empty view
+      _params.position = 0;
+      _params.lineNum = 0;
+      _params.display.empty();
+      // Enable refresh/scrolling if disabled
+      if (_params.control.getAttribute('data-state') == 0) {
+        _params.control.click()
+      }
+    })
+  }
+  _params.callNumber++
+
+  jeedom.log.currentAutoupdate[_params.display.getAttribute('id')] = {
+    log: _params.log
+  }
+
+  // Disable auto update if log is scrolled
+  if (_params.callNumber > 1 && (_params.display.scrollTop + _params.display.offsetHeight + 10) < _params.display.scrollHeight) {
+    if (_params.control.getAttribute('data-state') == 1) {
+      _params.control.click()
+    }
+    return
+  }
+
+  var dom_brutlogcheck = document.getElementById('brutlogcheck')
+  // If first call AND element exists AND (enabled OR should be enabled), Then enable it
+  if (_params.callNumber == 1 && dom_brutlogcheck != null && dom_brutlogcheck.checked && dom_brutlogcheck.getAttribute('autoswitch') == 1) {
+    dom_brutlogcheck.checked = false
+  }
+
+  // If (element exists AND is disabled) OR (first call AND (element does not exists OR should be enabled)), Then colored
+  var colorMe = ((dom_brutlogcheck != null && !dom_brutlogcheck.checked) || (_params.callNumber == 1 && (dom_brutlogcheck == null || dom_brutlogcheck.getAttribute('autoswitch') == 1)))
+
+  jeedom.log.getDelta({
+    log: _params.log,
+    slaveId: _params.slaveId,
+    position: _params.position,
+    search: (!isset(_params.search)) ? '' : _params.search.value.toLowerCase(),
+    colored: (colorMe ? ((_params.display.id == 'pre_scenariolog') ? 2 : 1) : 0), // 0: no color ; 1: global log colors ; 2: Scenario colors
+    numbered: (_params.display.id == 'pre_globallog'),
+    numberStart: _params.lineNum,
+    global: (_params.callNumber == 1),
+    success: function(result) {
+      // Optimise search operation
+      var searchString = (!isset(_params.search)) ? '' : _params.search.value.toLowerCase()
+      // Store log file current position
+      _params.position = result.position;
+      // Store log file current line
+      _params.lineNum = result.line;
+
+      // Get logs as text from ajax
+      if (result.logText.length > 0) {
+        if (colorMe) {
+          // log = (_params.display.id == 'pre_scenariolog') ? jeedom.log.scenarioColorReplace(log) : jeedom.log.stringColorReplace(log);
+          _params.display.innerHTML += result.logText
+        } else {
+          _params.display.textContent += result.logText
+        }
+      }
+
+      _params.display.scrollTop = _params.display.offsetHeight + _params.display.scrollHeight + 1
+      if (jeedom.log.timeout !== null) {
+        clearTimeout(jeedom.log.timeout)
+      }
+      jeedom.log.timeout = setTimeout(function() {
+        jeedom.log.autoUpdateDelta(_params)
+      }, 1000)
+    },
+    error: function() {
+      if (jeedom.log.timeout !== null) {
+        clearTimeout(jeedom.log.timeout)
+      }
+      jeedom.log.timeout = setTimeout(function() {
+        jeedom.log.autoUpdateDelta(_params)
+      }, 1000)
+    },
+  });
+}
+
 //Standard log replacement:
 jeedom.log.colorReplacement = {
   'WARNING:': '--startTg--span class="warning"--endTg--WARNING--startTg--/span--endTg--:',
@@ -364,7 +514,7 @@ jeedom.log.getScTranslations({
     }
   },
   error: function() {
-    console.log('Unable to get jeedom scenario traductions')
+    console.log('Unable to get jeedom scenario translations')
   }
 })
 

--- a/desktop/js/log.js
+++ b/desktop/js/log.js
@@ -67,30 +67,36 @@ document.getElementById('in_searchLogFilter')?.addEventListener('keyup', functio
 //div_pageContainer events delegation:
 document.getElementById('div_pageContainer').addEventListener('click', function(event) {
   var _target = null
+
+  // "Raw log" button clicked
   if (_target = event.target.closest('#brutlogcheck')) {
+    // Disable switching automatically to "Rich Log"
     _target.setAttribute('autoswitch', 0)
-    let elPreGlobalLog = document.getElementById('pre_globallog')
-    var scroll = elPreGlobalLog.scrollTop
-    jeedom.log.autoupdate({
+    // Empty log view
+    document.getElementById('pre_globallog').empty()
+    // Display Pause button
+    jeedom.log.updateBtn(jeeP.btGlobalLogStopStart)
+    // Activate log auto update
+    jeedom.log.autoUpdateDelta({
       log: document.querySelector('li.li_log.active')?.getAttribute('data-log'),
       display: document.getElementById('pre_globallog'),
       search: document.getElementById('in_searchGlobalLog'),
-      control: jeeP.btGlobalLogStopStart,
-      once: 1
+      control: jeeP.btGlobalLogStopStart
     })
-    elPreGlobalLog.scrollTop = scroll
     return
   }
 
+  // Log selected in the list
   if (_target = event.target.closest('.li_log')) {
+    // Empty log view
     document.getElementById('pre_globallog').empty()
+    // Activate the corresponding item in the list
     document.querySelectorAll('.li_log').removeClass('active')
     _target.addClass('active')
-    jeeP.btGlobalLogStopStart.removeClass('btn-success')
-      .addClass('btn-warning')
-      .html('<i class="fas fa-pause"></i><span class="hidden-768"> {{Pause}}</span>')
-      .setAttribute('data-state', '1')
-    jeedom.log.autoupdate({
+    // Display Pause button
+    jeedom.log.updateBtn(jeeP.btGlobalLogStopStart)
+    // Activate log auto update
+    jeedom.log.autoUpdateDelta({
       log: _target.getAttribute('data-log'),
       display: document.getElementById('pre_globallog'),
       search: document.getElementById('in_searchGlobalLog'),
@@ -99,6 +105,7 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
     return
   }
 
+  // Log download button clicked
   if (_target = event.target.closest('#bt_downloadLog')) {
     window.open('core/php/downloadFile.php?pathfile=log/' + document.querySelector('.li_log.active').getAttribute('data-log'), "_blank", null)
     return
@@ -108,11 +115,7 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
     jeedom.log.clear({
       log: document.querySelector('.li_log.active').getAttribute('data-log'),
       success: function(data) {
-        document.querySelector('.li_log.active a').innerHTML = '<i class="fa fa-check"></i> ' + document.querySelector('.li_log.active').getAttribute('data-log')
-        document.querySelector('.li_log.active i').removeClass().addClass('fas', 'fa-check')
-        if (jeeP.btGlobalLogStopStart.getAttribute('data-state') == 0) {
-          jeeP.btGlobalLogStopStart.click()
-        }
+        document.querySelector('li.li_log.active').click()
       }
     })
     return

--- a/desktop/modal/log.display.php
+++ b/desktop/modal/log.display.php
@@ -55,18 +55,15 @@ if(init('log','event') == 'event'){
 (function() {// Self Isolation!
   document.getElementById('brutlogcheck').addEventListener('click', function(event) {
     event.target.setAttribute('autoswitch', 0)
-    var scroll = document.getElementById('pre_eventlog').scrollTop
-    jeedom.log.autoupdate({
+    jeedom.log.autoUpdateDelta({
       log: jeephp2js.md_logDislay_Name,
       display: document.getElementById('pre_eventlog'),
       search: document.getElementById('in_eventLogSearch'),
-      control: document.getElementById('bt_eventLogStopStart'),
-      once: 1
+      control: document.getElementById('bt_eventLogStopStart')
     })
-    document.getElementById('pre_eventlog').scrollTop = scroll
   })
 
-  jeedom.log.autoupdate({
+  jeedom.log.autoUpdateDelta({
     log: jeephp2js.md_logDislay_Name,
     default_search: jeephp2js.md_logDislay_defaultSearch,
     display: document.getElementById('pre_eventlog'),

--- a/desktop/modal/scenario.log.execution.php
+++ b/desktop/modal/scenario.log.execution.php
@@ -47,7 +47,7 @@ sendVarToJs('jeephp2js.md_scenarioLog_scId', init('scenario_id'));
 if (!jeeFrontEnd.md_scenarioLog) {
   jeeFrontEnd.md_scenarioLog = {
     init: function() {
-      jeedom.log.autoupdate({
+      jeedom.log.autoUpdateDelta({
         log: 'scenarioLog/scenario' + jeephp2js.md_scenarioLog_scId + '.log',
         display: document.getElementById('pre_scenariolog'),
         search: document.getElementById('in_scenarioLogSearch'),
@@ -92,15 +92,13 @@ if (!jeeFrontEnd.md_scenarioLog) {
 
   document.getElementById('brutlogcheck').addEventListener('click', function(event) {
     event.target.setAttribute('autoswitch', 0)
-    var scroll = document.getElementById('pre_scenariolog').scrollTop
-    jeedom.log.autoupdate({
-      log: jeephp2js.md_logDislay_Name,
+    document.getElementById('pre_scenariolog').empty()
+    jeedom.log.autoUpdateDelta({
+      log: 'scenarioLog/scenario' + jeephp2js.md_scenarioLog_scId + '.log',
       display: document.getElementById('pre_scenariolog'),
       search: document.getElementById('in_scenarioLogSearch'),
-      control: document.getElementById('bt_scenarioLogStopStart'),
-      once: 1
+      control: document.getElementById('bt_scenarioLogStopStart')
     })
-    document.getElementById('pre_scenariolog').scrollTop = scroll
   })
 
 })()

--- a/desktop/php/log.php
+++ b/desktop/php/log.php
@@ -16,6 +16,12 @@ natcasesort($list_logfile);
 
 <div class="row row-overflow">
 	<div class="hasfloatingbar col-lg-12 col-md-12 col-sm-12 col-xs-12">
+		<div class="input-group pull-left col-lg-2 col-md-3 col-sm-12 col-xs-12" style="top: 7px;">
+			<span class="input-group-btn pull-left">
+				<input id="in_searchLogFilter" class="form-control input-sm roundedLeft" placeholder="Rechercher | nom | :not(nom" style="width:250px;">
+				<a id="bt_resetLogFilterSearch" class="btn btn-sm roundedRight"><i class="fas fa-times"></i></a>
+			</span>
+		</div>
 		<div class="floatingbar">
 			<div class="input-group">
 				<span class="input-group-btn">
@@ -37,14 +43,6 @@ natcasesort($list_logfile);
 	<br /><br />
 	<div class="col-lg-2 col-md-3 col-sm-12 col-xs-12" id="div_displayLogList">
 		<ul id="ul_object" class="nav nav-list bs-sidenav">
-			<li style="margin-bottom: 5px;">
-				<div class="input-group">
-					<span class="input-group-btn">
-						<input id="in_searchLogFilter" class="form-control input-sm roundedLeft" placeholder="{{Rechercher | nom | :not(nom}}" style="width: calc(100% - 20px)" />
-						<a id="bt_resetLogFilterSearch" class="btn btn-sm roundedRight"><i class="fas fa-times"></i></a>
-					</span>
-				</div>
-			</li>
 			<?php
 			$html = '';
 			foreach ($list_logfile as $file) {

--- a/mobile/js/log.js
+++ b/mobile/js/log.js
@@ -27,7 +27,7 @@ function initLog(_log) {
         _log = $('#bottompanel .ui-listview li.ui-first-child > a > span').text().trim()
       }
 
-      jeedom.log.autoupdate({
+      jeedom.log.autoUpdateDelta({
         log : _log,
         display : $('#pre_globallog'),
         search : $('#in_globalLogSearch'),

--- a/mobile/js/scenariolog.js
+++ b/mobile/js/scenariolog.js
@@ -7,7 +7,7 @@ function initScenariolog(_scenarioId) {
   $('#pre_scenariolog').empty()
   if (isset(_scenarioId)) {
     setTimeout(function() {
-      jeedom.log.autoupdate({
+      jeedom.log.autoUpdateDelta({
         log : 'scenarioLog/scenario'+_scenarioId+'.log',
         display : $('#pre_scenariolog'),
         search : $('#in_globalLogSearch'),


### PR DESCRIPTION
## Proposed change
Since a long time (creation of Jeedom?), the logs are handled in a basic way: the whole file is downloaded at each refresh.
As Jeedom is becoming a more complex ecosystem and more logs are generated, it should be interesting to re-think that.

**This PR aims to enhance the way logs are fetched and processed:**
- Log fetch:
  + First time log is requested or each time search field is updated, the whole file is (still) downloaded,
![image](https://github.com/jeedom/core/assets/8396512/33f89993-6526-4b11-a1b1-661affb3a8d7)
![image](https://github.com/jeedom/core/assets/8396512/c4c57bad-15fe-4781-892f-5a817f6ac063)
  + At next fetch, only the newly generated logs are transmitted and append to buffer.
![image](https://github.com/jeedom/core/assets/8396512/31b352c9-b72c-4237-8564-9697d6f7d9fe)
![image](https://github.com/jeedom/core/assets/8396512/d4761599-c166-4866-a77e-11de520c64e1)
No change is visible from the user point of view, except it is BLAZING FAST !
![image](https://github.com/jeedom/core/assets/8396512/aa21f2f5-eea5-498b-b79e-b61ef62818df)

- Searching, line numbering and coloring are done on server side,
- Too big logs are truncated server-side, but the file remains untouched (to avoid issues by exemple with a local running tail):
![image](https://github.com/jeedom/core/assets/8396512/86aa536c-ba56-4d82-a0c7-4351165596da)

&nbsp;
**To have retro compatibility for plugins, new functions have created and core has been adapted (old functions remains):**
- `core/class/log.class.php`: added `log::getDelta($_log, $_position, $_search, $_colored, $_numbered, $_numStart, $_max)` function to handle file seek, search, line numbering and coloring server-side ;
- `core/ajax/log.ajax.php`: added `getDelta` ajax method related to `log::getDelta()` function ;
- `core/js/log.class.js`: added `jeedom.log.getDelta` to call ajax method, added `jeedom.log.updateBtn` to handle
Pause/Resume toggle button and added main function  keeping most of the logic
of `jeedom.log.autoupdate`, with the expected enhancements ;

+ `desktop/js/log.js` ; `desktop/modal/log.display.php` ; `desktop/modal/scenario.log.execution.php` ; 
`mobile/js/log.js` ; `mobile/js/scenariolog.js`: 
replaced `jeedom.log.autoupdate` by `jeedom.log.autoUpdateDelta` and slightly adapted ;

- `desktop/php/log.php`: moved log file search field in the menu bar to save some space:
![image](https://github.com/jeedom/core/assets/8396512/e6c28a6b-e01c-4416-91ab-b6be6502f1a7)


## Type of change
- [ ] 3rd party lib update
- [ ] Bugfix (non breaking change)
- [x] Core new feature
- [ ] UI new functionnality
- [x] Code quality improvements
- [ ] Core documentation

## Test check
No formal test suit.
Tested on Jeedom Core v4.4.0 alpha (commit 310a25640aaae9340d19e4c5da0bd366a6842083):
- Desktop> Log> Colored/not colored/search/pause/resume -> OK
- Desktop> Scenario> Colored/not colored/search/pause/resume -> OK
- Mobile> Log> Search/pause/resume -> OK
- Mobile> Scenario> Search/pause/resume -> OK


## Documentation
N/A