### PR TITLE
Fix V4-stable branch name case

### DIFF
--- a/install/OS_specific/Docker/init_workflow.sh
+++ b/install/OS_specific/Docker/init_workflow.sh
@@ -6,7 +6,7 @@ JEEDOM_SHORT_VERSION="$(echo "$JEEDOM_VERSION" | awk -F. '{print $1"."$2}')"
 # Docker hub repository may be overriden
 REPO=${DOCKER_HUB_REPO:-"jeedom"}
 
-if [[ "${GITHUB_REF_NAME}" == "V4-Stable" ]]; then
+if [[ "${GITHUB_REF_NAME}" == "V4-stable" ]]; then
   JEEDOM_TAGS="${REPO}/jeedom:latest,${REPO}/jeedom:$JEEDOM_SHORT_VERSION";
   GITHUB_BRANCH=${GITHUB_REF_NAME};
 elif [[ "${GITHUB_REF_NAME}" == "beta" ]]; then


### PR DESCRIPTION
## Proposed change

Fix the Github workflow for the main V4-stable branch, a miss case for the branch name make it never built the Docker tag 'latest'

## Type of change

- [ ] 3rd party lib update
- [ ] Bugfix (non breaking change)
- [ ] Core new feature
- [ ] UI new functionnality
- [ ] Code quality improvements
- [ ] Core documentation
- [x] CI/CD workflow

## Test check

This change is already on beta. But only concerns V4-Stable

## Documentation
<!--
  Some useful links for contributors
-->


[beta-testing](https://doc.jeedom.com/en_US/beta/)
[contribute](https://doc.jeedom.com/en_US/contribute/)
[community](https://community.jeedom.com/)
[plugins](https://doc.jeedom.com/en_US/dev/)

