### PR TITLE
fix: http api update with value '0' does not update the info command

### DIFF
--- a/core/api/jeeApi.php
+++ b/core/api/jeeApi.php
@@ -97,7 +97,7 @@ if (init('type') != '') {
 				if ($_USER_GLOBAL != null && !$cmd->hasRight($_USER_GLOBAL)) {
 					throw new Exception(__('Vous n\'êtes pas autorisé à effectuer cette action, IP :', __FILE__) . ' ' . getClientIp());
 				}
-				if ($cmd->getType() == 'info' && init('value')) {
+				if ($cmd->getType() == 'info' && init('value') != '') {
 					$cmd->event(init('value'));
 				}
 				log::add('api', 'debug', __('Exécution de :', __FILE__) . ' ' . $cmd->getHumanName());

--- a/core/api/jeeApi.php
+++ b/core/api/jeeApi.php
@@ -97,7 +97,7 @@ if (init('type') != '') {
 				if ($_USER_GLOBAL != null && !$cmd->hasRight($_USER_GLOBAL)) {
 					throw new Exception(__('Vous n\'êtes pas autorisé à effectuer cette action, IP :', __FILE__) . ' ' . getClientIp());
 				}
-				if ($cmd->getType() == 'info' && init('value')){
+				if ($cmd->getType() == 'info' && init('value')) {
 					$cmd->event(init('value'));
 				}
 				log::add('api', 'debug', __('Exécution de :', __FILE__) . ' ' . $cmd->getHumanName());
@@ -1017,20 +1017,19 @@ try {
 		message::removeAll();
 		$jsonrpc->makeSuccess('ok');
 	}
-	
+
 	if ($jsonrpc->getMethod() == 'message::removebyId') {
-       		 if (is_object($_USER_GLOBAL) && !in_array($_USER_GLOBAL->getProfils(), array('admin'))) {
-          		  throw new Exception(__('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
-                 }
-                  $message = message::byId($params['messageId']);
-                  if(is_object($message)){
-                       $message->remove();
-		       $jsonrpc->makeSuccess('ok');
-                   }else{
-			 throw new Exception(__('Impossible de trouver le message :', __FILE__) . ' ' . secureXSS($params['messageId']));
-		  }
-        
-    	}
+		if (is_object($_USER_GLOBAL) && !in_array($_USER_GLOBAL->getProfils(), array('admin'))) {
+			throw new Exception(__('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
+		}
+		$message = message::byId($params['messageId']);
+		if (is_object($message)) {
+			$message->remove();
+			$jsonrpc->makeSuccess('ok');
+		} else {
+			throw new Exception(__('Impossible de trouver le message :', __FILE__) . ' ' . secureXSS($params['messageId']));
+		}
+	}
 
 	if ($jsonrpc->getMethod() == 'message::all') {
 		if (is_object($_USER_GLOBAL) && !in_array($_USER_GLOBAL->getProfils(), array('admin', 'user'))) {
@@ -1152,17 +1151,17 @@ try {
 		}
 		$jsonrpc->makeSuccess($plugin->deamon_info());
 	}
-	
+
 	if ($jsonrpc->getMethod() == 'plugin::deamonInfoAll') {
 		if (is_object($_USER_GLOBAL) && !in_array($_USER_GLOBAL->getProfils(), array('admin', 'user'))) {
 			throw new Exception(__('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
 		}
-       		 $deamons_infos = [];
+		$deamons_infos = [];
 		foreach ((plugin::listPlugin()) as $plugin) {
-			if($plugin->getHasOwnDeamon() == 1){
-                           $deamons_infos[$plugin->getId()] = $plugin->deamon_info();  
-                         } 
-       		 }
+			if ($plugin->getHasOwnDeamon() == 1) {
+				$deamons_infos[$plugin->getId()] = $plugin->deamon_info();
+			}
+		}
 		$jsonrpc->makeSuccess($deamons_infos);
 	}
 


### PR DESCRIPTION
<!--
  Thanks for your contribution to make Jeedom better!
-->


## Proposed change
init('value') is evaluated to false if with pass `&value=0` in the querystring and so info command is not updated


## Type of change
<!--
  What type of change your PR is
-->

- [ ] 3rd party lib update
- [X] Bugfix (non breaking change)
- [ ] Core new feature
- [ ] UI new functionnality
- [ ] Code quality improvements
- [ ] Core documentation


## Test check
Manually tested http api to update binary command with:
- `value=0`
- `value=1`
- `value=5`
- `value=true`
- `value=false`


## Documentation
<!--
  Some useful links for contributors
-->


[beta-testing](https://doc.jeedom.com/en_US/beta/)
[contribute](https://doc.jeedom.com/en_US/contribute/)
[community](https://community.jeedom.com/)
[plugins](https://doc.jeedom.com/en_US/dev/)

