### PR TITLE
Enhance icon selector/search

### DIFF
--- a/desktop/css/desktop.main.css
+++ b/desktop/css/desktop.main.css
@@ -1411,10 +1411,6 @@ div.eqLogicZone {
     margin-right: unset !important;
   }
 
-  #mod_selectIcon .imgContainer {
-    padding-top: 10px;
-  }
-
   #mod_selectIcon #treeFunctions {
     padding: 2px 0 0 30px;
     font-size: 16px;
@@ -1425,8 +1421,11 @@ div.eqLogicZone {
   }
 
   #mod_selectIcon .div_treeFolder {
-    position:absolute;
+    height: calc(100% - 80px);
     width:160px;
+    position:absolute;
+    overflow-y: auto;
+    padding-right: 3px;
   }
 
   #mod_selectIcon .div_imageGallery {

--- a/desktop/modal/icon.selector.php
+++ b/desktop/modal/icon.selector.php
@@ -95,7 +95,7 @@ sendVarToJS([
 
 <div id="md_iconSelector" data-modalType="md_iconSelector">
 <?php if (init('showimg') == 1) { ?>
-  <ul class="nav nav-tabs" role="tablist">
+  <ul class="nav nav-tabs" role="tablist" style="padding-top:60px;">
     <li role="presentation" class="active">
       <a href="#tabicon" role="tab" data-toggle="tab"><i class="fas fa-icons"></i> {{Icônes}}</a>
     </li>
@@ -105,19 +105,19 @@ sendVarToJS([
   </ul>
 <?php } ?>
   <div class="tab-content" style="overflow-y:scroll;max-height: 100%">
-      <div id="tabicon" role="tabpanel" class="tab-pane active" <?php if (!init('selectIcon', 1) && init('showimg') != 1) echo ' style="display:none;"' ?>>
+      <div id="tabicon" role="tabpanel" class="tab-pane active"<?php if (!init('selectIcon', 1) && init('showimg') != 1) echo ' style="display:none;"' ?>>
         <div class="imgContainer"<?php if (init('showimg') == 1) echo ' style="padding-top:10px;"' ?>>
           <div id="treeFolder-icon" class="div_treeFolder"></div>
           <div class="div_imageGallery"></div>
         </div>
       </div>
-      <div id="tabobjectbg" role="tabpanel" class="tab-pane active" <?php if (!$objectId) echo ' style="display:none;"' ?>>
-        <div class="imgContainer">
+      <div id="tabobjectbg" role="tabpanel" class="tab-pane active"<?php if (!$objectId) echo ' style="display:none;"' ?>>
+        <div class="imgContainer"<?php if (init('showimg') == 1) echo ' style="padding-top:10px;"' ?>>
           <div id="treeFolder-bg" class="div_treeFolder"></div>
           <div class="div_imageGallery"></div>
         </div>
       </div>
-      <div id="tabimg" role="tabpanel" class="tab-pane" <?php if (init('showimg') != 1) echo ' style="display:none;"' ?>>
+      <div id="tabimg" role="tabpanel" class="tab-pane"<?php if (init('showimg') != 1) echo ' style="display:none;"' ?>>
         <div id="treeFunctions">
             <span class="bt_upload"><i class="fas fa-file-upload" title="{{Ajouter}}"></i></span>
             <span class="bt_new"><i class="fas fa-folder-plus" title="{{Nouveau}}"></i></span>

--- a/desktop/modal/icon.selector.php
+++ b/desktop/modal/icon.selector.php
@@ -671,25 +671,27 @@ if (!jeeFrontEnd.md_iconSelector) {
     }
   })
 
-  new jeeFileUploader({
-    fileInput: document.getElementById('bt_uploadImg'),
-    add: function(event, options) {
-      let currentPath = document.getElementById('bt_uploadImg').getAttribute('data-path')
-      options.url = 'core/ajax/jeedom.ajax.php?action=uploadImageIcon&filepath=' + currentPath
-      options.submit()
-    },
-    done: function(event, data) {
-      if (data.result.state != 'ok') {
-        jeedomUtils.showAlert({
-          attachTo: jeeDialog.get('#md_iconSelector', 'dialog'),
-          message: data.result.result,
-          level: 'danger'
-        })
-        return
+  if (jeephp2js.showimg == 1) {
+    new jeeFileUploader({
+      fileInput: document.getElementById('bt_uploadImg'),
+      add: function(event, options) {
+        let currentPath = document.getElementById('bt_uploadImg').getAttribute('data-path')
+        options.url = 'core/ajax/jeedom.ajax.php?action=uploadImageIcon&filepath=' + currentPath
+        options.submit()
+      },
+      done: function(event, data) {
+        if (data.result.state != 'ok') {
+          jeedomUtils.showAlert({
+            attachTo: jeeDialog.get('#md_iconSelector', 'dialog'),
+            message: data.result.result,
+            level: 'danger'
+          })
+          return
+        }
+        document.querySelector('#treeFolder-img span.tj_description.selected')?.click()
       }
-      document.querySelector('#treeFolder-img span.tj_description.selected')?.click()
-    }
-  })
+    })
+  }
 
   jeeFrontEnd.md_iconSelector.postInit()
 

--- a/desktop/modal/icon.selector.php
+++ b/desktop/modal/icon.selector.php
@@ -75,36 +75,30 @@ sendVarToJS([
 ?>
 
 <div id="md_iconSelector" data-modalType="md_iconSelector">
+<?php if (init('showimg') == 1) { ?>
   <ul class="nav nav-tabs" role="tablist">
-    <li role="presentation" class="active <?php if ($objectId) echo ' hidden' ?>">
-      <a href="#tabicon" aria-controls="home" role="tab" data-toggle="tab"><i class="fas fa-icons"></i> {{Icônes}}</a>
+    <li role="presentation" class="active">
+      <a href="#tabicon" role="tab" data-toggle="tab"><i class="fas fa-icons"></i> {{Icônes}}</a>
     </li>
-    <li role="presentation" class="<?php if (init('showimg') != 1) echo 'hidden' ?>">
-      <a href="#tabimg" aria-controls="home" role="tab" data-toggle="tab"><i class="far fa-images"></i> {{Images}}</a>
-    </li>
-    <li role="presentation" class="<?php echo (!$objectId) ? 'hidden' : 'active' ?>">
-      <a href="#tabobjectbg" aria-controls="home" role="tab" data-toggle="tab"><i class="fas fa-image"></i> {{Librairie}}</a>
+    <li role="presentation">
+      <a href="#tabimg" role="tab" data-toggle="tab"><i class="far fa-images"></i> {{Images}}</a>
     </li>
   </ul>
-
-  <div class="tab-content" style="overflow-y:scroll;">
-      <div id="tabicon" role="tabpanel" class="tab-pane active">
-        <div class="imgContainer">
-          <div id="treeFolder-icon" class="div_treeFolder">
-          </div>
+<?php } ?>
+  <div class="tab-content" style="overflow-y:scroll;max-height: 100%">
+      <div id="tabicon" role="tabpanel" class="tab-pane active" <?php if (!init('selectIcon', 1) && init('showimg') != 1) echo ' style="display:none;"' ?>>
+        <div class="imgContainer"<?php if (init('showimg') == 1) echo ' style="padding-top:10px;"' ?>>
+          <div id="treeFolder-icon" class="div_treeFolder"></div>
           <div class="div_imageGallery"></div>
         </div>
       </div>
-
-      <div id="tabobjectbg" role="tabpanel" class="tab-pane active">
+      <div id="tabobjectbg" role="tabpanel" class="tab-pane active" <?php if (!$objectId) echo ' style="display:none;"' ?>>
         <div class="imgContainer">
-          <div id="treeFolder-bg" class="div_treeFolder">
-          </div>
+          <div id="treeFolder-bg" class="div_treeFolder"></div>
           <div class="div_imageGallery"></div>
         </div>
       </div>
-
-      <div id="tabimg" role="tabpanel" class="tab-pane">
+      <div id="tabimg" role="tabpanel" class="tab-pane" <?php if (init('showimg') != 1) echo ' style="display:none;"' ?>>
         <div id="treeFunctions">
             <span class="bt_upload"><i class="fas fa-file-upload" title="{{Ajouter}}"></i></span>
             <span class="bt_new"><i class="fas fa-folder-plus" title="{{Nouveau}}"></i></span>
@@ -112,9 +106,8 @@ sendVarToJS([
             <span class="bt_delete"><i class="fas fa-folder-minus" title="{{Supprimer}}"></i></span>
         </div>
         <input class="hidden" id="bt_uploadImg" type="file" name="file" multiple="multiple" data-path="">
-        <div class="imgContainer">
-          <div id="treeFolder-img" class="div_treeFolder">
-          </div>
+        <div class="imgContainer" style="padding-top: 10px;">
+          <div id="treeFolder-img" class="div_treeFolder"></div>
           <div class="div_imageGallery"></div>
         </div>
       </div>
@@ -135,6 +128,8 @@ sendVarToJS([
     <input class="form-control" placeholder="{{Rechercher}}" id="in_searchIconSelector">
     <div class="input-group-btn">
       <a id="bt_resetIconSelectorSearch" class="btn roundedRight" style="width:30px"><i class="fas fa-times"></i> </a>
+    </div>
+    <div id="bt_cancelConfirm" class="input-group-btn">
     </div>
   </div>
 </div>
@@ -199,7 +194,11 @@ if (!jeeFrontEnd.md_iconSelector) {
       var modal = jeeDialog.get('#sel_colorIcon', 'dialog')
       var modalFooter = jeeDialog.get('#sel_colorIcon', 'footer')
       var uiOptions = modal.querySelector('#mySearch')
+      var btTarget = uiOptions.querySelector('#bt_cancelConfirm')
       modalFooter.insertBefore(uiOptions, modalFooter.firstChild)
+      btTarget.append(modalFooter.querySelector('button[data-type="cancel"]'))
+      btTarget.append(modalFooter.querySelector('button[data-type="confirm"]'))
+      modal.querySelector('.jeeDialogContent').style.overflowY = 'hidden'
       document.getElementById('sel_colorIcon').selectedIndex = 1
     },
     //Tree builders:
@@ -479,8 +478,9 @@ if (!jeeFrontEnd.md_iconSelector) {
                 success: function(data) {
                   data = JSON.parse(data)
                   for (var i in data.icons) {
-                    var test = (iconClasses && iconClasses[2] === data.icons[i].substr(4)) ? ' iconSelected' : ''
-                    div += '<div class="divIconSel text-center' + test + '">'
+                    var selected = (iconClasses && iconClasses[2] === data.icons[i].substr(4)) ? ' iconSelected' : ''
+                    var icon = data.icons[i] + ' ' + document.getElementById('sel_colorIcon').value
+                    div += '<div class="divIconSel text-center tooltips' + selected + '" title="' + icon + '">'
                     div += '<span class="cursor iconSel"><i class="' + data.icons[i] + ' ' + document.getElementById('sel_colorIcon').value + '"></i></span><br/><span class="iconDesc">' + data.icons[i].substr(7) + '</span>'
                     div += '</div>'
                   }
@@ -504,8 +504,9 @@ if (!jeeFrontEnd.md_iconSelector) {
                   var matches = data.match(exp_reg)
                   for (var i in matches) {
                     var selected = (iconClasses && iconClasses[2] === matches[i]) ? ' iconSelected' : ''
-                    div += '<div class="divIconSel text-center' + selected + '">'
-                    div += '<span class="cursor iconSel"><i class=\'icon ' + matches[i] + ' ' + document.getElementById('sel_colorIcon').value + '\'></i></span><br/><span class="iconDesc">' + matches[i].replace(category + '-', '') + '</span>'
+                    var icon = matches[i] + ' ' + document.getElementById('sel_colorIcon').value
+                    div += '<div class="divIconSel text-center tooltips' + selected + '" title="' + icon + '">'
+                    div += '<span class="cursor iconSel"><i class="icon ' + icon + '"></i></span><br/><span class="iconDesc">' + matches[i].replace(category + '-', '') + '</span>'
                     div += '</div>'
                   }
                   folderDisplayContainer.insertAdjacentHTML('beforeend', div)


### PR DESCRIPTION
## Proposed change
As per request here: https://community.jeedom.com/t/amelioration-de-la-recherche-icones/101705


- More compact view (Cancel/Apply buttons & no tab on top if there are only icons to select),
- Icons (and left menu) are alphabetically sorted,
- Search is done on all icons simultaneously,
- Icon currently selected is searched back in the view and scrolled to.

Global overview before change (v4.3):
![image](https://github.com/jeedom/core/assets/8396512/18feb063-5795-4553-a423-babad84545b4)
Global overview after change:
![image](https://github.com/jeedom/core/assets/8396512/f020d608-bcfe-456b-9692-7c339a41d5d9)
Global overview after change, when an icon is selected:
![image](https://github.com/jeedom/core/assets/8396512/4980bfc1-74a4-4239-9c2a-68dd03ccbc2b)

---

Search before change (v4.3):
![image](https://github.com/jeedom/core/assets/8396512/bfc7379b-f6e7-4693-b36b-6610f6c67e71)
Search after change:
![image](https://github.com/jeedom/core/assets/8396512/14669a4d-f857-44c5-9ae5-e0362c1f9a74)
When scrolling down, left menu follows:
![image](https://github.com/jeedom/core/assets/8396512/bbedf281-24a2-4cb9-91c6-9e3a4d731acb)

---

Compatibility is maintained in Object image selector (for exemple in Tools> Objects menu):
![image](https://github.com/jeedom/core/assets/8396512/7b942afc-d17e-4d46-bc41-2fe121a91e86)
(NO CHANGE HERE, even if it should/may be in another modal for me)

---

Compatibility is maintained with Widget image selector (for exemple in Tools> Widgets menu):
![image](https://github.com/jeedom/core/assets/8396512/89057fea-d26d-48c8-a621-9bd65f4dd59c)
(NO CHANGE HERE, even if it should/may be in another modal for me)


## Type of change
- [ ] 3rd party lib update
- [ ] Bugfix (non breaking change)
- [ ] Core new feature
- [x] UI new functionnality
- [x] Code quality improvements
- [ ] Core documentation


## Test check



## Documentation
