### PR TITLE
Add /dev/serial/by-id in system

### DIFF
--- a/desktop/php/system.php
+++ b/desktop/php/system.php
@@ -17,6 +17,7 @@ $sysCmdsSudo = array(
   array("cmd" => 'sudo ip addr', "name" => 'ip addr'),
   array("cmd" => 'sudo lsusb', "name" => 'lsusb'),
   array("cmd" => 'sudo ls -la /dev/ttyUSB*', "name" => 'ls -la /dev/ttyUSB*'),
+  array("cmd" => 'sudo ls -la /dev/serial/by-id', "name" => 'ls -la /dev/serial/by-id'),
   array("cmd" => 'sudo ps ax', "name" => 'ps ax'),
   array("cmd" => 'sudo rm -f /var/lib/dpkg/updates/*', "name" => 'Fix dpkg'),
   array("cmd" => 'echo "yes | sudo apt -f install" | sudo at now', "name" => 'Fix install'),

--- a/desktop/php/system.php
+++ b/desktop/php/system.php
@@ -4,20 +4,20 @@ if (!isConnect('admin')) {
 }
 
 $sysCmds = array(
-  array("cmd" => 'ps -eo size,pid,user,command --sort -size"', "name" => 'Memory Usage'),
-  array("cmd" => 'ps -eo pid,ppid,%mem,%cpu,cmd --sort=-%cpu"', "name" => 'CPU Usage'),
-  array("cmd" => 'free -m"', "name" => 'free -m'),
-  array("cmd" => 'df -h"', "name" => 'df -h'),
-  array("cmd" => 'w"', "name" => 'w'),
-  array("cmd" => 'dpkg -l"', "name" => 'dpkg -l'),
-  array("cmd" => 'netstat -tupln"', "name" => 'netstat -tupln'),
+  array("cmd" => 'ps -eo size,pid,user,command --sort -size', "name" => 'Memory Usage'),
+  array("cmd" => 'ps -eo pid,ppid,%mem,%cpu,cmd --sort=-%cpu', "name" => 'CPU Usage'),
+  array("cmd" => 'free -m', "name" => 'free -m'),
+  array("cmd" => 'df -h', "name" => 'df -h'),
+  array("cmd" => 'w', "name" => 'w'),
+  array("cmd" => 'dpkg -l', "name" => 'dpkg -l'),
+  array("cmd" => 'netstat -tupln', "name" => 'netstat -tupln'),
 );
 $sysCmdsSudo = array(
-  array("cmd" => 'sudo dmesg"', "name" => 'dmesg'),
-  array("cmd" => 'sudo ip addr"', "name" => 'ip addr'),
-  array("cmd" => 'sudo lsusb"', "name" => 'lsusb'),
-  array("cmd" => 'sudo ls -la /dev/ttyUSB*"', "name" => 'ls -la /dev/ttyUSB*'),
-  array("cmd" => 'sudo ps ax"', "name" => 'ps ax'),
+  array("cmd" => 'sudo dmesg', "name" => 'dmesg'),
+  array("cmd" => 'sudo ip addr', "name" => 'ip addr'),
+  array("cmd" => 'sudo lsusb', "name" => 'lsusb'),
+  array("cmd" => 'sudo ls -la /dev/ttyUSB*', "name" => 'ls -la /dev/ttyUSB*'),
+  array("cmd" => 'sudo ps ax', "name" => 'ps ax'),
   array("cmd" => 'sudo rm -f /var/lib/dpkg/updates/*', "name" => 'Fix dpkg'),
   array("cmd" => 'echo "yes | sudo apt -f install" | sudo at now', "name" => 'Fix install'),
   array("cmd" => 'echo "sudo dpkg --configure -a --force-confdef" | sudo at now', "name" => 'Dpkg configure'),


### PR DESCRIPTION
## Proposed change
1) Remov some unnecessary `"`
2) Add `sudo ls -la /dev/serial/by-id` as per request https://community.jeedom.com/t/device-list/104143

## Type of change
- [ ] 3rd party lib update
- [ ] Bugfix (non breaking change)
- [ ] Core new feature
- [x] UI new functionnality
- [x] Code quality improvements
- [ ] Core documentation


## Test check
Tested on last alpha ([commit 138d560](https://github.com/BadWolf42/core/commit/138d5601e54323466ae4f5e48cb3bd0205849247))

## Documentation
N/A