### PR TITLE
:hammer: Add graph option in history modal

### DIFF
--- a/desktop/php/history.php
+++ b/desktop/php/history.php
@@ -85,7 +85,7 @@ $date = array(
 				<i class="icon techno-courbes3"></i> {{Commandes}}
 				<a id="bt_openCmdHistoryConfigure" class="btn btn-default btn-sm pull-right" style="top: -5px; padding: 5px 10px; margin-right: 0;" title="{{Configuration de l'historique des commandes}}"><i class="fas fa-cogs"></i> {{Configuration}}</a>
 			</li>
-			<li class="filter input-group input-group-sm" style="margin-top: 10px; //width: 98%;">
+			<li class="filter input-group input-group-sm" style="margin-top: 10px; /*width: 98%;*/">
 				<input id="in_searchHistory" class="filter form-control input-sm roundedLeft" style="width: calc(100% - 28px);" placeholder="{{Rechercher}}" autocomplete="off" />
 				<span class="input-group-btn ">
 					<a id="bt_resetSearch" class="btn btn-default roundedRight" title="{{Vider le champ de recherche}}"><i class="fas fa-times"></i></a>


### PR DESCRIPTION
## Proposed change
As per my request here :
https://community.jeedom.com/t/ajouter-les-parametres-du-graphique-dans-les-proprietes-avancees-des-commandes-info/106875

Add graph option in **history modal**:
![image](https://github.com/jeedom/core/assets/8396512/08db0049-c03b-4099-bbb6-c66766843e3f)


## Type of change
- [ ] 3rd party lib update
- [ ] Bugfix (non breaking change)
- [ ] Core new feature
- [x] UI new functionnality
- [ ] Code quality improvements
- [ ] Core documentation


## Test check
Checked with info/action cmd, on last alpha (commit d799e119bcdd6a567936376131dcfaaba1228fc8)

## Documentation
N/A