### PR TITLE
JS Error when saving command configuration fix in plugin calendar

### DIFF
--- a/desktop/modal/cmd.configure.php
+++ b/desktop/modal/cmd.configure.php
@@ -1091,12 +1091,13 @@ $configEqDisplayType = jeedom::getConfiguration('eqLogic:displayType');
         if (!isset(cmd.display)) cmd.display = {}
         if (!isset(cmd.display.parameters)) cmd.display.parameters = {}
 
-        //Get widget optionnal parameters:
-        document.querySelector('#cmd_display #table_widgetParametersCmd').tBodies[0].childNodes.forEach(_tr => {
-          if (_tr.nodeType != 3) {
-            cmd.display.parameters[_tr.querySelector('.key').jeeValue()] = _tr.querySelector('.value').jeeValue()
-          }
-        })
+        if (document.querySelector('#cmd_display #table_widgetParametersCmd')) { 
+          document.querySelector('#cmd_display #table_widgetParametersCmd').tBodies[0].childNodes.forEach(_tr => {
+            if (_tr.nodeType != 3) {
+              cmd.display.parameters[_tr.querySelector('.key').jeeValue()] = _tr.querySelector('.value').jeeValue()
+            }
+          })
+        }
 
         try {
           var checkCmdParameter = document.getElementById('div_jeedomCheckCmdCmdOption').getJeeValues('.expressionAttr')[0]


### PR DESCRIPTION


## Proposed change
JS Error in plugin agenda on command configuration save

## Type of change
check null value for tab "Affichage"

- [X] Bugfix (non breaking change)


## Test check
- open plugin calendar
- select "configuration avancée"
- select a configuration command
- save
- no JS error
