### PR TITLE
config::genKey(): string $chaine should contain 'o' and 'z' (#2270)

### DIFF
--- a/core/class/config.class.php
+++ b/core/class/config.class.php
@@ -249,7 +249,7 @@ class config {
 
 	public static function genKey($_car = 64) {
 		$key = '';
-		$chaine = "abcdefghijklmnpqrstuvwxy1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+		$chaine = "abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 		for ($i = 0; $i < $_car; $i++) {
 			if (function_exists('random_int')) {
 				$key .= $chaine[random_int(0, strlen($chaine) - 1)];


### PR DESCRIPTION
## Proposed change
According to issue #2270
The variable $chaine from which the characters to generate the API keys are extracted does not contain 'o' and 'z'. In order to increase the possible combination count, these missing characters should be added.


## Type of change
- [ ] 3rd party lib update
- [x] Bugfix (non breaking change)
- [ ] Core new feature
- [ ] UI new functionnality
- [ ] Code quality improvements
- [ ] Core documentation


## Test check
Install a new plugin and check the API key


## Documentation
None

[beta-testing](https://doc.jeedom.com/en_US/beta/)
[contribute](https://doc.jeedom.com/en_US/contribute/)
[community](https://community.jeedom.com/)
[plugins](https://doc.jeedom.com/en_US/dev/)

