### PR TITLE
fix: interactQuery::getQuerySynonym is fetching config from object and not jeeObject

### DIFF
--- a/desktop/php/administration.php
+++ b/desktop/php/administration.php
@@ -1484,7 +1484,7 @@ user::isBan();
 						<div class="form-group">
 							<label class="col-lg-3 col-md-4 col-sm-4 col-xs-6 control-label">{{Synonymes pour les objets}}</label>
 							<div class="col-lg-8 col-md-8 col-sm-8 col-xs-6">
-								<input class="configKey form-control" data-l1key="interact::autoreply::jeeObject::synonym" />
+								<input class="configKey form-control" data-l1key="interact::autoreply::object::synonym" />
 							</div>
 						</div>
 						<div class="form-group">


### PR DESCRIPTION
## Proposed change
interactQuery::getQuerySynonym is fetching config from object and not jeeObject

see issue: https://community.jeedom.com/t/interaction-automatique-et-synonymes-objets/79412


## Type of change
<!--
  What type of change your PR is
-->

- [ ] 3rd party lib update
- [X] Bugfix (non breaking change)
- [ ] Core new feature
- [ ] UI new functionnality
- [ ] Code quality improvements
- [ ] Core documentation


## Test check
manual test on interaction with usage of synonymes for objects


## Documentation
<!--
  Some useful links for contributors
-->


[beta-testing](https://doc.jeedom.com/en_US/beta/)
[contribute](https://doc.jeedom.com/en_US/contribute/)
[community](https://community.jeedom.com/)
[plugins](https://doc.jeedom.com/en_US/dev/)

