### PR TITLE
Replace lastFromDate FROM byCmdIdAtDatetime

### DIFF
--- a/core/ajax/cmd.ajax.php
+++ b/core/ajax/cmd.ajax.php
@@ -491,11 +491,14 @@ try {
 	}
 
         if (init('action') == 'getLastHistory') {
-            if(is_numeric(init('id'))){
-                $date = date('Y-m-d H:i:s', strtotime(init('time')));
-                ajax::success(history::lastFromDate(init('id'), $date));
+            $cmd = cmd::byId(init('id'));
+            $_time = date('Y-m-d H:i:s', strtotime(init('time')));
+            if(is_object($cmd)){
+                ajax::success($cmd->getLastHistory($_time));
+            } 
+            else{
+                throw new Exception(__('Commande ID inconnu :', __FILE__) . ' ' . init('id'));
             }
-            return ajax::success(0);
         }
 
 	if (init('action') == 'emptyHistory') {

--- a/core/class/cmd.class.php
+++ b/core/class/cmd.class.php
@@ -2480,6 +2480,22 @@ class cmd {
 	public function getHistory($_dateStart = null, $_dateEnd = null, $_groupingType = null, $_addFirstPreviousValue = false) {
 		return history::all($this->id, $_dateStart, $_dateEnd, $_groupingType, $_addFirstPreviousValue);
 	}
+        
+        public function getLastHistory($_time, $_previous = true){
+            $value = 0;
+            if($this->getIsHistorized() == 1){
+                if(!$this->getConfiguration('isHistorizedCalc', 0)){
+                    $result = history::byCmdIdAtDatetime($this->getId(), $_time, $_previous);
+                    if($result){
+                        $value = $result->getValue();
+                    }
+                }
+                else{
+                    $value = history::byCmdIdAtDatetimeFromCalcul (jeedom::fromHumanReadable($this->getConfiguration('calcul')), $_time, $_previous);
+                }
+            }
+            return(array('value'=>$value, 'unite'=>$this->getUnite()));
+        }
 
 	public function getOldest() {
 		return history::getOldestValue($this->id);

--- a/core/class/history.class.php
+++ b/core/class/history.class.php
@@ -865,53 +865,29 @@ class history {
 		}
 		return DB::Prepare($sql, $values, DB::FETCH_TYPE_ROW);
 	}  
-        
-        public static function lastFromDate($_cmd_id, $_time){
-            $cmd = cmd::byId($_cmd_id);
-            if(is_object($cmd) && $cmd->getIsHistorized() == 1 && !$cmd->getConfiguration('isHistorizedCalc', 0)){
-		$values = array(
-                    'cmd_id' => $_cmd_id,
-                    'time'   => $_time
-		);
-            
-            $sql = 'SELECT (CAST(value AS DECIMAL(12,2))) as value 
-                FROM (
-		 (SELECT value, datetime from history WHERE value is not null AND cmd_id=:cmd_id  AND datetime<=:time ORDER by datetime DESC LIMIT 0,1) 
-		 UNION ALL 
-		 (SELECT value, datetime from historyArch WHERE value is not null AND cmd_id=:cmd_id  AND datetime<=:time ORDER by datetime DESC LIMIT 0,1)
-                 )a
-                 ORDER by datetime DESC LIMIT 0,1';
-            
-                $return = DB::Prepare($sql, $values, DB::FETCH_TYPE_ALL, PDO::FETCH_CLASS, __CLASS__);
-                if(isset($return[0]))
-                    return array('unite' => $cmd->getUnite(), 'value' => $return[0]->getValue());
-            }
-            elseif(is_object($cmd)){
-                return array('unite' => $cmd->getUnite(), 'value' =>history::getLastHistoryFromCalcul (jeedom::fromHumanReadable($cmd->getConfiguration('calcul')), $_time));
-            }
-            return array('unite' => $cmd->getUnite(), 'value' => 0);
-        }
               
-        public static function getLastHistoryFromCalcul($_strcalcul, $_time){
+        public static function byCmdIdAtDatetimeFromCalcul($_strcalcul, $_time, $_previous = true){
 		$cmd_histories = array();
                 preg_match_all("/#([0-9]*)#/", $_strcalcul, $matches);
                 if (count($matches[1]) > 0) {
 			foreach ($matches[1] as $cmd_id) {
 				if (is_numeric($cmd_id)) {
                                     $cmd = cmd::byId($cmd_id);
+                                    $value = 0;
                                     if (is_object($cmd) && $cmd->getIsHistorized() == 1 && !$cmd->getConfiguration('isHistorizedCalc', 0)) {
-                                            
-                                        $cmd_histories['#' . $cmd_id . '#'] = history::lastFromDate($cmd_id, $_time);
+                                        $result = history::byCmdIdAtDatetime($cmd_id, $_time, $_previous);
+                                        if($result)
+                                            $value = $result->getValue();
                                     }
                                     elseif(is_object($cmd)){
-                                        $cmd_histories['#' . $cmd_id . '#'] = history::getLastHistoryFromCalcul(jeedom::fromHumanReadable($cmd->getConfiguration('calcul')), $_time);
+                                        $value = history::byCmdIdAtDatetimeFromCalcul(jeedom::fromHumanReadable($cmd->getConfiguration('calcul')), $_time, $_previous);
                                     }
+                                    $cmd_histories['#' . $cmd_id . '#'] = $value;
                                 }
                         }
                 }
-//                echo '<br/>uuu'.template_replace($cmd_histories, $_strcalcul).' pour : '.$_strcalcul;
                 $calcul = template_replace($cmd_histories, $_strcalcul);
-                return floatval(jeedom::evaluateExpression($calcul));;
+                return floatval(jeedom::evaluateExpression($calcul));
         }
 
 	public static function getHistoryFromCalcul($_strcalcul, $_dateStart = null, $_dateEnd = null, $_noCalcul = false, $_groupingType = null) {


### PR DESCRIPTION
Utilisation de la fonction byCmdIdAtDatetime déjà présente plutôt que la nouvelle fonction lastFromDate (supprimé).

Renommage de getLastHistoryFromCalcul en byCmdIdAtDatetimeFromCalcul

Fonction intermédiaire "getLastHistory" dans cmd.class.php pour réutilisation.
