### PR TITLE
Add fonction jeedom.history.getLast

### DIFF
--- a/core/ajax/cmd.ajax.php
+++ b/core/ajax/cmd.ajax.php
@@ -490,6 +490,17 @@ try {
 		ajax::success($return);
 	}
 
+        if (init('action') == 'getLastHistory') {
+            $cmd = cmd::byId(init('id'));
+            $_time = date('Y-m-d H:i:s', strtotime(init('time')));
+            if(is_object($cmd)){
+                ajax::success($cmd->getLastHistory($_time));
+            } 
+            else{
+                throw new Exception(__('Commande ID inconnu :', __FILE__) . ' ' . init('id'));
+            }
+        }
+
 	if (init('action') == 'emptyHistory') {
 		if (!isConnect('admin')) {
 			throw new Exception(__('401 - Accès non autorisé', __FILE__), -1234);

--- a/core/class/cmd.class.php
+++ b/core/class/cmd.class.php
@@ -2514,6 +2514,22 @@ class cmd {
 	public function getHistory($_dateStart = null, $_dateEnd = null, $_groupingType = null, $_addFirstPreviousValue = false) {
 		return history::all($this->id, $_dateStart, $_dateEnd, $_groupingType, $_addFirstPreviousValue);
 	}
+        
+        public function getLastHistory($_time, $_previous = true){
+            $value = 0;
+            if($this->getIsHistorized() == 1){
+                if(!$this->getConfiguration('isHistorizedCalc', 0)){
+                    $result = history::byCmdIdAtDatetime($this->getId(), $_time, $_previous);
+                    if($result){
+                        $value = $result->getValue();
+                    }
+                }
+                else{
+                    $value = history::byCmdIdAtDatetimeFromCalcul (jeedom::fromHumanReadable($this->getConfiguration('calcul')), $_time, $_previous);
+                }
+            }
+            return(array('value'=>$value, 'unite'=>$this->getUnite()));
+        }
 
 	public function getOldest() {
 		return history::getOldestValue($this->id);

--- a/core/class/history.class.php
+++ b/core/class/history.class.php
@@ -183,6 +183,30 @@ class history {
 		}
 		return $result;
 	}
+        
+        public static function byCmdIdAtDatetimeFromCalcul($_strcalcul, $_time, $_previous = true){
+		$cmd_histories = array();
+                preg_match_all("/#([0-9]*)#/", $_strcalcul, $matches);
+                if (count($matches[1]) > 0) {
+                    foreach ($matches[1] as $cmd_id) {
+                        if (is_numeric($cmd_id)) {
+                            $cmd = cmd::byId($cmd_id);
+                            $value = 0;
+                            if (is_object($cmd) && $cmd->getIsHistorized() == 1 && !$cmd->getConfiguration('isHistorizedCalc', 0)) {
+                                $result = history::byCmdIdAtDatetime($cmd_id, $_time, $_previous);
+                                if($result)
+                                    $value = $result->getValue();
+                            }
+                            elseif(is_object($cmd)){
+                                $value = history::byCmdIdAtDatetimeFromCalcul(jeedom::fromHumanReadable($cmd->getConfiguration('calcul')), $_time, $_previous);
+                            }
+                            $cmd_histories['#' . $cmd_id . '#'] = $value;
+                        }
+                    }
+                }
+                $calcul = template_replace($cmd_histories, $_strcalcul);
+                return floatval(jeedom::evaluateExpression($calcul));
+        }
 
 	/**
 	 * Archive data from history into historyArch

--- a/core/js/history.class.js
+++ b/core/js/history.class.js
@@ -49,6 +49,34 @@ jeedom.history.get = function(_params) {
   domUtils.ajax(paramsAJAX);
 }
 
+jeedom.history.getLast = function(_params) {
+  var paramsRequired = ['cmd_id', 'time'];
+  var paramsSpecifics = { 
+    global: _params.global || true,
+    pre_success: function(data) {
+      if (isset(jeedom.cmd.cache.byId[data.result.id])) {
+        delete jeedom.cmd.cache.byId[data.result.id];
+      }
+      return data;
+    }
+  };
+  try {
+    jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
+  } catch (e) {
+    (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
+    return;
+  }
+  var params = $.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  paramsAJAX.url = 'core/ajax/cmd.ajax.php';
+  paramsAJAX.data = {
+    action: 'getLastHistory',
+    id: _params.cmd_id,
+    time: _params.time || '',
+  };
+  $.ajax(paramsAJAX);
+}
+
 jeedom.history.getInitDates = function(_params) {
   var paramsRequired = [];
   var paramsSpecifics = {};


### PR DESCRIPTION
Récupère la dernière valeur à une date donnée aussi bien pour une commande calculée que pour une historisation en base.

Ajout de la fonction jeedom.history.getLast

Ajout fonction getLastHistory dans cmd.class.php

Ajout de la fonction byCmdIdAtDatetimeFromCalcul dans history.class.php

