### PR TITLE
Modification normalize.name

### DIFF
--- a/core/js/cmd.class.js
+++ b/core/js/cmd.class.js
@@ -1118,6 +1118,8 @@ jeedom.cmd.normalizeName = function(_tagname) {
     'désactiver': 'off',
     'lock': 'on',
     'unlock': 'off',
+    'verrouiller': 'on',
+    'deverrouiller': 'off',
     'marche': 'on',
     'arret': 'off',
     'arrêt': 'off',

--- a/core/js/cmd.class.js
+++ b/core/js/cmd.class.js
@@ -1120,6 +1120,7 @@ jeedom.cmd.normalizeName = function(_tagname) {
     'unlock': 'off',
     'verrouiller': 'on',
     'deverrouiller': 'off',
+    'déverrouiller': 'off',
     'marche': 'on',
     'arret': 'off',
     'arrêt': 'off',


### PR DESCRIPTION
Ajout des mots verrouiller / deverrouiller (ils n'étaient qu'en anglais alors que les autres sont tous en français)

Peut-être prévoir un champ où la liste serait personnalisable par l'utilisateur ? Voulez-vous que je fasse une proposition en ce sens ?

## Proposed change
Add word "verrouiller" and "deverrouiller" in normalize.name function. There are already in English but all other words are in French.

Maybe we could add a menu insettings to give users the right to personnalize this list ? I can wordk on it if you want ?


## Type of change
- [ ] 3rd party lib update
- [] Bugfix (non breaking change)
- [ ] Core new feature
- [ ] UI new functionnality
- [X] Code quality improvements
- [ ] Core documentation


## Test check
Test on Jeedom 4.3.19


## Documentation
N/A