### PR TITLE
fix: createCommunityPost daemon last_launch

### DIFF
--- a/core/ajax/plugin.ajax.php
+++ b/core/ajax/plugin.ajax.php
@@ -174,8 +174,9 @@ try {
 		$infoPost .= 'Version : ' . $update->getLocalVersion() . ' (' . ($isBeta ? 'beta' : 'stable') . ')<br/>';
 
 		if ($plugin->getHasOwnDeamon()) {
-			$daemon_info = $plugin_id::deamon_info();
-			$infoPost .= 'Statut Démon : ' . ($daemon_info['state'] == 'ok' ? 'Démarré ' : 'Stoppé') . ' - (' . ($daemon_info['last_launch'] ?? 'NA') . ')<br/>';
+			$daemon_info = $plugin->deamon_info();
+			$infoPost .= 'Statut Démon : ' . ($daemon_info['state'] == 'ok' ?  __('Démarré', __FILE__) :  __('Stoppé', __FILE__));
+			$infoPost .= ' - (' . ($daemon_info['last_launch'] ?? __('Inconnue', __FILE__)) . ')<br/>';
 		}
 
 		$infoPlugin = '';


### PR DESCRIPTION
## Proposed change
`$daemon_info['last_launch']` should come from class `plugin` for the plugin, not the class of the plugin (itself).

Also added some translation symbols

Before:
```
Core : 4.4.0 (alpha)
DNS Jeedom : non

Plugin : jMQTT
Version : [...] (beta)
Statut Démon : Démarré - (NA)
```

After:
```
Core : 4.4.0 (alpha)
DNS Jeedom : non

Plugin : jMQTT
Version : [...] (beta)
Statut Démon : Démarré - (2023-11-21 13:40:01)
```

## Type of change
- [ ] 3rd party lib update
- [x] Bugfix (non breaking change)
- [ ] Core new feature
- [ ] UI new functionnality
- [x] Code quality improvements
- [ ] Core documentation

## Test check
N/A

## Documentation
N/A
