### PR TITLE
Add PSR-7 interface to PHP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,10 @@
     "abbadon1334/sun-position-spa-php": "^2.0",
     "league/oauth2-client": "~2.3",
     "bacon/bacon-qr-code": "^2.0",
-    "guzzlehttp/guzzle" : "^6.5.8"
+    "guzzlehttp/guzzle" : "^6.5.8",
+    "http-interop/http-factory-guzzle": "^1.2",
+    "symfony/http-client": "^7.0",
+    "nyholm/psr7": "^1.8"
   },
   "config": {
       "allow-plugins": {


### PR DESCRIPTION
## Proposed change
Update composer.json to have a PSR-7 interface (and Guzzle 6) as per discution here:
https://community.jeedom.com/t/core-v4-4-alpha-impossible-dinstaller-un-plugin-depuis-source-github/116653/5

**More tests may be needed.**

## Type of change
- [x] Bugfix (non breaking change)

## Test check
Tested as per explained on Community, more tests may be needed with other plugins.
