### PR TITLE
Update colors in log view

### DIFF
--- a/core/class/log.class.php
+++ b/core/class/log.class.php
@@ -345,9 +345,9 @@ class log {
 				'<span class="label label-xs label-info">NOTICE</span>',
 				'<span class="label label-xs label-warning">WARNING</span>',
 				'<span class="label label-xs label-danger">ERROR</span>',
-				'<span class="label label-xs label-danger">CRITICAL</span>',
+				'<span class="label label-xs label-danger">CRITI</span>',
 				'<span class="label label-xs label-danger">ALERT</span>',
-				'<span class="label label-xs label-danger">EMERGENCY</span>',
+				'<span class="label label-xs label-danger">EMERG</span>',
 				'<span class="label label-xl label-danger">-------------------- TRUNCATED LOG --------------------</span>'
 			);
 			$logText = str_replace($search, $replace, $logText);

--- a/core/class/log.class.php
+++ b/core/class/log.class.php
@@ -324,11 +324,14 @@ class log {
 				'WARNING:',
 				'Erreur',
 				'OK',
-				'[INFO]',
 				'[DEBUG]',
+				'[INFO]',
+				'[NOTICE]',
 				'[WARNING]',
-				'[ALERT]',
 				'[ERROR]',
+				'[CRITICAL]',
+				'[ALERT]',
+				'[EMERGENCY]',
 				'-------------------- TRUNCATED LOG --------------------'
 			);
 			$replace = array(
@@ -337,11 +340,14 @@ class log {
 				'<span class="warning">WARNING</span>',
 				'<span class="danger">Erreur</span>',
 				'<strong>OK</strong>',
-				'<span class="label label-xs label-info">INFO</span>',
 				'<span class="label label-xs label-success">DEBUG</span>',
+				'<span class="label label-xs label-info">INFO</span>',
+				'<span class="label label-xs label-info">NOTICE</span>',
 				'<span class="label label-xs label-warning">WARNING</span>',
-				'<span class="label label-xs label-warning">ALERT</span>',
 				'<span class="label label-xs label-danger">ERROR</span>',
+				'<span class="label label-xs label-danger">CRITICAL</span>',
+				'<span class="label label-xs label-danger">ALERT</span>',
+				'<span class="label label-xs label-danger">EMERGENCY</span>',
 				'<span class="label label-xl label-danger">-------------------- TRUNCATED LOG --------------------</span>'
 			);
 			$logText = str_replace($search, $replace, $logText);


### PR DESCRIPTION
## Proposed change
This PR aims to align log levels in logs with the existing levels in [Monolog\Logger](https://github.com/BadWolf42/core/blob/a8c5b1de5d235c1504ea4bed863313129f43c06a/vendor/monolog/monolog/src/Monolog/Logger.php#L30-L78).
Added replacements for: NOTICE, CRITICAL & EMERGENCY

Note that new log levels names have been truncated (see Test check section below), 
to avoid alignement issues and CSS change (push `min-width` to `70px` in [desktop.main.css](https://github.com/BadWolf42/core/blob/a8c5b1de5d235c1504ea4bed863313129f43c06a/desktop/css/desktop.main.css#L4701C14-L4701C14)).
I did not truncate `WARNING` into `WARN` but considered to.

**I let you choose** if I should update this PR to truncate `WARNING` or do not truncate anything and update CSS.

## Type of change
- [x] Code quality improvements
- [x] UI new functionnality

## Test check
Tested on last alpha [5ee08ed](https://github.com/jeedom/core/commit/5ee08eda12e19d63f2474490f336b43469956d0e).

Code used:
```php
foreach (array('DEBUG', 'INFO', 'NOTICE', 'WARNING', 'ERROR', 'CRITICAL', 'ALERT', 'EMERGENCY') as $level) {
    log::add('test_levels', $level, 'Message at ' . $level);
}
```

See as: before, updated, then updated and truncated:
![image](https://github.com/jeedom/core/assets/8396512/6b9d8bc3-a847-4bbb-ab1d-04c774c9c808)

## Documentation
No documentation provided with this PR.