### PR TITLE
Hide theme change button if not switchable

### DIFF
--- a/mobile/js/application.js
+++ b/mobile/js/application.js
@@ -502,6 +502,10 @@ jeedomUtils.initApplication = function(_reinit) {
         }
 
         jeedomUtils.triggerThemechange()
+        // hide changeTheme button if theme change is not possible
+        if (jeedom.theme.mobile_theme_color == jeedom.theme.mobile_theme_color_night) {
+          $('#bt_changeTheme').hide()
+        }
         for (let i in plugins) {
           if (plugins[i].eventjs == 1) {
             include.push('plugins/' + plugins[i].id + '/mobile/js/event.js')


### PR DESCRIPTION
## Proposed change
Hide the switch theme button on mobile if theme change is not possible (same theme main and alternative)


## Type of change


- [ ] 3rd party lib update
- [x] Bugfix (non breaking change)
- [ ] Core new feature
- [ ] UI new functionnality
- [ ] Code quality improvements
- [ ] Core documentation
