### PR TITLE
fix docker service_mariadb function

### DIFF
--- a/install/OS_specific/Docker/init.sh
+++ b/install/OS_specific/Docker/init.sh
@@ -15,7 +15,7 @@ service_mariadb(){
     service mariadb $1
     if [ $? -ne 0 ]; then
       echo "${ROUGE}Cannot start mariadb - Cancelling${NORMAL}"
-      exit 1
+      return 1
     fi
   fi
   return 0


### PR DESCRIPTION
docker is killed by exit function in case the start is impossible
with impact in case of restarting a jeedom container with a new docker image containing a new version of mariadb which requires `rm /var/lib/mysql/ib_logfile*`
