### PR TITLE
fix docker service_mariadb function

### DIFF
--- a/install/OS_specific/Docker/init.sh
+++ b/install/OS_specific/Docker/init.sh
@@ -15,7 +15,7 @@ service_mariadb(){
     service mariadb $1
     if [ $? -ne 0 ]; then
       echo "${ROUGE}Cannot start mariadb - Cancelling${NORMAL}"
-      exit 1
+      return 1
     fi
   fi
   return 0


### PR DESCRIPTION
## Proposed change
docker container is killed by `exit 1` in `service_mariadb` function if the start is impossible
impact are visible in case of restarting a jeedom container with a new docker image containing a new version of mariadb service which requires `rm /var/lib/mysql/ib_logfile*`
proposed hotfix in V4-stable branch as in alpha branch with PR https://github.com/jeedom/core/pull/2366

## Type of change
- [ ] 3rd party lib update
- [x] Bugfix (non breaking change)
- [ ] Core new feature
- [ ] UI new functionnality
- [ ] Code quality improvements
- [ ] Core documentation