### PR TITLE
Fix special chars in colored logs

### DIFF
--- a/core/api/jeeApi.php
+++ b/core/api/jeeApi.php
@@ -110,7 +110,7 @@ if (init('type') != '') {
 		if ($type == 'interact') {
 			$query = init('query');
 			if (init('utf8', 0) == 1) {
-				$query = mb_convert_encoding($query, 'UTF-8', 'ISO-8859-1');
+				$query = mb_convert_encoding($query, 'UTF-8');
 			}
 			$param = array();
 			if (init('emptyReply') != '') {

--- a/core/class/log.class.php
+++ b/core/class/log.class.php
@@ -246,8 +246,6 @@ class log {
 			while ($log->valid() && $linesRead != $_nbLines) {
 				$line = trim($log->current()); //get current line
 				if ($line != '') {
-					$line = htmlspecialchars($line, ENT_QUOTES | ENT_HTML5, 'UTF-8');
-					$line = str_replace('&amp;', '&', $line);
 					array_unshift($page, mb_convert_encoding($line, 'UTF-8'));
 				}
 				$log->next();

--- a/core/class/log.class.php
+++ b/core/class/log.class.php
@@ -246,8 +246,9 @@ class log {
 			while ($log->valid() && $linesRead != $_nbLines) {
 				$line = trim($log->current()); //get current line
 				if ($line != '') {
-					$line = secureXSS($line);
-					array_unshift($page, mb_convert_encoding($line, 'UTF-8', 'ISO-8859-1'));
+					$line = htmlspecialchars($line, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+					$line = str_replace('&amp;', '&', $line);
+					array_unshift($page, mb_convert_encoding($line, 'UTF-8'));
 				}
 				$log->next();
 				$linesRead++;

--- a/core/js/log.class.js
+++ b/core/js/log.class.js
@@ -261,6 +261,7 @@ jeedom.log.autoupdate = function(_params) {
       }
 
       if (colorMe) {
+        log = log.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#039;")
         if (isScenaroLog) {
           log = jeedom.log.scenarioColorReplace(log)
         } else {


### PR DESCRIPTION
## Proposed change
Fix special chars in colored logs as per Community:
- Bad charset conversion to UTF8:
https://community.jeedom.com/t/probleme-daffichage-dans-les-log-scenario/119365/16?u=bad
- Bad replacement of `<` and `>`:
https://community.jeedom.com/t/probleme-daffichage-dans-les-log-scenario/119365/19?u=bad
- Replacements event in raw (brut) logs:
https://community.jeedom.com/t/probleme-daffichage-dans-les-log-scenario/119365/28?u=bad

## Type of change
- [x] Bugfix (non breaking change)

## Test check
![image](https://github.com/jeedom/core/assets/8396512/a07b9965-cac3-4817-a92d-11b2c30bda80)
Before:
![image](https://github.com/jeedom/core/assets/8396512/2f0145ab-7afa-47a0-b58e-b1400a213d7b)
![image](https://github.com/jeedom/core/assets/8396512/85b9c039-a007-40f9-9eb7-9244937d7616)
![image](https://github.com/jeedom/core/assets/8396512/868b52ae-e1cf-4f59-8476-324a13e31e6a)
After:
![image](https://github.com/jeedom/core/assets/8396512/914ad3a1-4602-4fc2-8a38-53be27a241cd)
![image](https://github.com/jeedom/core/assets/8396512/3f8856e3-e00e-424d-8b25-a985372ba4fe)


## Documentation
N/A