### PR TITLE
Fix scenario "Add bloc" close cross

### DIFF
--- a/desktop/js/scenario.js
+++ b/desktop/js/scenario.js
@@ -2185,7 +2185,11 @@ document.getElementById('scenariotab').addEventListener('click', function(event)
     return
   }
 
-  if (_target = event.target.closest('#bt_cancelElementSave')) {
+  if (_target = event.target.closest('#bt_cancelElementSave'))  {
+    jeeDialog.modal(document.getElementById('md_addElement'))._jeeDialog.hide()
+  }
+
+  if (_target = event.target.closest('#bt_crossElementSave'))  {
     jeeDialog.modal(document.getElementById('md_addElement'))._jeeDialog.hide()
   }
 

--- a/desktop/php/scenario.php
+++ b/desktop/php/scenario.php
@@ -371,7 +371,7 @@ sendVarToJS([
 
 				<div id="md_addElement" class="jeeDialog jeeDialogPrompt" style="display:none;">
 					<div class="jeeDialogTitle">
-						<span class="title">{{Ajouter un bloc}}</span><button class="btClose" type="button">×</button>
+						<span class="title">{{Ajouter un bloc}}</span><button class="btClose" id="bt_crossElementSave" type="button"></button>
 					</div>
 					<br />
 					<div class="jeeDialogContent">


### PR DESCRIPTION
## Proposed change
Fix regarding this bug report: https://community.jeedom.com/t/croix-inactive-dans-scenario-ajouter-un-bloc/119690

**Note that:** Escape button does not close this popup -> not handled by this PR.

## Type of change
- [x] Bugfix (non breaking change)

## Test check
Manual check:

![image](https://github.com/jeedom/core/assets/8396512/312d1159-59d6-4fd9-9a12-01a8488dfc71)
-> Close cross is working and only appear once.

## Documentation
N/A