### PR TITLE
Fix search on the dashboard

### DIFF
--- a/desktop/js/dashboard.js
+++ b/desktop/js/dashboard.js
@@ -421,7 +421,7 @@ document.getElementById('in_searchDashboard')?.addEventListener('keyup', functio
   var match, text
   document.querySelectorAll('div.eqLogic-widget').forEach(function(element) {
     match = false
-    text = jeedomUtils.normTextLower(element.querySelector('div.widget-name > a, center.widget-name > a')?.textContent)
+    text = jeedomUtils.normTextLower(element.querySelector('.widget-name > a')?.textContent)
     if (text.includes(search)) match = true
 
     if (element.getAttribute('data-tags') != undefined) {

--- a/desktop/js/dashboard.js
+++ b/desktop/js/dashboard.js
@@ -171,7 +171,7 @@ if (!jeeFrontEnd.dashboard) {
         jeedom.cmd.disableExecute = true
         this.resetCategoryFilter()
         document.querySelectorAll('#dashTopBar .btn:not(#bt_editDashboardWidgetOrder)').addClass('disabled')
-        
+
         //set resizables:
         new jeeResize('div.eqLogic-widget, div.scenario-widget', {
           handles: ['right', 'bottom-right', 'bottom'],
@@ -421,7 +421,7 @@ document.getElementById('in_searchDashboard')?.addEventListener('keyup', functio
   var match, text
   document.querySelectorAll('div.eqLogic-widget').forEach(function(element) {
     match = false
-    text = jeedomUtils.normTextLower(element.querySelector('div.widget-name > a')?.textContent)
+    text = jeedomUtils.normTextLower(element.querySelector('div.widget-name > a, center.widget-name > a')?.textContent)
     if (text.includes(search)) match = true
 
     if (element.getAttribute('data-tags') != undefined) {
@@ -736,4 +736,3 @@ window.registerEvent('resize', function dashboard(event) {
   if (event.isTrigger) return
   jeedomUtils.positionEqLogic()
 })
-


### PR DESCRIPTION
## Proposed change
Fix for bug report : https://community.jeedom.com/t/filtres-aleatoires-sur-le-dashboard/119213

Fix search on the dashboard if widget uses `<center class="widget-name">` instead of `<div class="widget-name">`.

## Type of change
- [x] Bugfix (non breaking change)

## Test check
Manual test:
![image](https://github.com/jeedom/core/assets/8396512/c3d61714-567a-477e-b5ff-345d00b0123e)

## Documentation
N/A