### PR TITLE
Update cmd.class.js to use effectively params notify

### DIFF
--- a/core/js/cmd.class.js
+++ b/core/js/cmd.class.js
@@ -54,7 +54,7 @@ jeedom.cmd.execute = function(_params) {
   if (jeedom.cmd.disableExecute) {
     return
   }
-  var notify = _params.notify || true
+  var notify = _params.notify ?? true
   if (notify) {
     var eqLogic = document.querySelector('.cmd[data-cmd_id="' + _params.id + '"]')?.closest('div.eqLogic-widget')
     if (eqLogic) jeedom.cmd.notifyEq(eqLogic, false)


### PR DESCRIPTION
Change:

* core/js/cmd.class.js

pour jeedom.cmd.execute, si on passe le paramètre notify à False/false/0 )=> pour ne pas notifier, la ligne : 
```
var notify = _params.notify || true
```
renverra toujours vrai pour notify
=> changement vers ?? pour valider le false quand passé, et renvoi true si le paramètre n'est pas spécifié.

Note : je ne sais pas sur quelle branche PR
