### PR TITLE
fix: js issue in System/Config page

### DIFF
--- a/desktop/js/administration.js
+++ b/desktop/js/administration.js
@@ -425,7 +425,7 @@ if (!jeeFrontEnd.administration) {
         },
         success: function(data) {
           document.getElementById('config').setJeeValues(data, '.configKey')
-          //document.querySelector('.configKey[data-l1key="market::allowDNS"]').triggerEvent('change')
+          //document.querySelector('.configKey[data-l1key="market::allowDNS"]')?.triggerEvent('change')
           //document.querySelector('.configKey[data-l1key="ldap:enable"]').triggerEvent('change')
           jeeP.loadActionOnMessage()
 
@@ -862,7 +862,7 @@ document.getElementById('networktab').addEventListener('click', function(event) 
 document.getElementById('networktab').addEventListener('change', function(event) {
   var _target = null
   if ((_target = event.target.closest('.configKey[data-l1key="market::allowDNS"]')) || (_target = event.target.closest('.configKey[data-l1key="network::disableMangement"]'))) {
-    if (document.querySelector('.configKey[data-l1key="market::allowDNS"]').jeeValue() == 1 && document.querySelector('.configKey[data-l1key="network::disableMangement"]').jeeValue() == 0) {
+    if (document.querySelector('.configKey[data-l1key="market::allowDNS"]')?.jeeValue() == 1 && document.querySelector('.configKey[data-l1key="network::disableMangement"]').jeeValue() == 0) {
       document.querySelector('.configKey[data-l1key="externalProtocol"]').setAttribute('disabled', true)
       document.querySelector('.configKey[data-l1key="externalAddr"]').jeeValue('').setAttribute('disabled', true)
       document.querySelector('.configKey[data-l1key="externalPort"]').jeeValue('').setAttribute('disabled', true)


### PR DESCRIPTION
## Proposed change
On Jeedom 4.4.2 last Alpha (commit https://github.com/jeedom/core/commit/7bd15d5e3921cfbb185268ea4ef57cf84a993227) on a fresh install (Debian 11.9).

There is a JS error when **not connected** to Market or **no DNS pack** on Market account:
![image](https://github.com/jeedom/core/assets/8396512/e633b72e-8e2c-43d6-91e9-238192d96b95)
```
getResource.php?file=desktop/js/administration.js&md5=8e61b4877710a585b0b1336cf858e440&lang=fr_FR:382 
The specified value "function() {\n  return this.replace(/[\\u00A0-\\u9999\u003C\u003E\\&]/g, function(i) {\n    return '&#' + i.charCodeAt(0) + ';'\n  })\n}" does not conform to the required format.  The format is "#rrggbb" where rr, gg, bb are two-digit hexadecimal numbers.
addConvertColor @ getResource.php?file=desktop/js/administration.js&md5=8e61b4877710a585b0b1336cf858e440&lang=fr_FR:382

getResource.php?file=desktop/js/administration.js&md5=8e61b4877710a585b0b1336cf858e440&lang=fr_FR:382 
The specified value "function() {\n    var in_chrs = '\u00E0\u00E1\u00E2\u00E3\u00E4\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F9\u00FA\u00FB\u00FC\u00FD\u00FF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D9\u00DA\u00DB\u00DC\u00DD',\n      out_chrs = 'aaaaaceeeeiiiinooooouuuuyyAAAAACEEEEIIIINOOOOOUUUUY',\n      transl = {}\n    eval('var chars_rgx = /[' + in_chrs + ']/g')\n    for (var i = 0; i \u003C in_chrs.length; i++) {\n      transl[in_chrs.charAt(i)] = out_chrs.charAt(i)\n    }\n    return this.replace(chars_rgx, function(match) {\n      return transl[match]\n    })\n  }" does not conform to the required format.  The format is "#rrggbb" where rr, gg, bb are two-digit hexadecimal numbers.
addConvertColor @ getResource.php?file=desktop/js/administration.js&md5=8e61b4877710a585b0b1336cf858e440&lang=fr_FR:382

getResource.php?file=desktop/js/administration.js&md5=8e61b4877710a585b0b1336cf858e440&lang=fr_FR:865 
Uncaught TypeError: Cannot read properties of null (reading 'jeeValue')
    at HTMLDivElement.<anonymous> (getResource.php?file=desktop/js/administration.js&md5=8e61b4877710a585b0b1336cf858e440&lang=fr_FR:865:76)
    at EventTarget.triggerEvent (getResource.php?file=core/dom/dom.utils.js&md5=de6f1cdaed6b4acfbb3f8b94b812a5a5&lang=fr_FR:712:8)
    at Element.jeeValue (getResource.php?file=core/dom/dom.utils.js&md5=de6f1cdaed6b4acfbb3f8b94b812a5a5&lang=fr_FR:254:12)
    at NodeList.jeeValue (getResource.php?file=core/dom/dom.utils.js&md5=de6f1cdaed6b4acfbb3f8b94b812a5a5&lang=fr_FR:284:15)
    at Element.setJeeValues (getResource.php?file=core/dom/dom.utils.js&md5=de6f1cdaed6b4acfbb3f8b94b812a5a5&lang=fr_FR:194:65)
    at Object.success (getResource.php?file=desktop/js/administration.js&md5=8e61b4877710a585b0b1336cf858e440&lang=fr_FR:489:51)
    at Object.success (getResource.php?file=core/js/private.class.js&md5=7b733ae0373ba388cc1760c4b3287ff6&lang=fr_FR:115:17)
    at getResource.php?file=core/dom/dom.utils.js&md5=de6f1cdaed6b4acfbb3f8b94b812a5a5&lang=fr_FR:593:22
```

This issue is related to `document.querySelector('.configKey[data-l1key="market::allowDNS"]')` and missing config key.
![image](https://github.com/jeedom/core/assets/8396512/28f719ce-6569-4e9f-9e28-199f1cfb287d)

## Type of change
- [x] Bugfix (non breaking change)

## Test check
No more error after this change.

## Documentation
N/A