### PR TITLE
Bug in USB Mapping function (list USB)

### DIFF
--- a/core/class/jeedom.class.php
+++ b/core/class/jeedom.class.php
@@ -687,7 +687,7 @@ class jeedom {
 		} else {
 			$name = trim($vendor . ' ' . $model);
 			$number = 2;
-			while (isset($result[$name])) {
+			while (isset($_usbMapping[$name])) {
 				$name = trim($vendor . ' ' . $model . ' ' . $number);
 				$number++;
 			}


### PR DESCRIPTION
<!--
  Thanks for your contribution to make Jeedom better!
-->


## Proposed change
var $result doesn't exist so the while loop will never match the condition et will stop everytime on first hit.

on a modem where you have 2 ports, it prevent to list the two interfaces and so you can't use /dev/serial/by-id in SMS Plugin for example.

## Type of change
  change a var tested in a if condition

- [ ] 3rd party lib update
- [X] Bugfix (non breaking change)
- [ ] Core new feature
- [ ] UI new functionnality
- [ ] Code quality improvements
- [ ] Core documentation


## Test check
Core version affected : 4.3.x & 4.4.x
Plugin tested : SMS Plugin with a HUAWEI Modem (it has 2 ports detected on this modem)

without this change : only one port is listed in the "port list" (serial_by_id) on SMS Plugin configuration page
with this change : the two ports of the modem are listed (serial_by_id) on SMS Plugin configuration page

change tested on 4.3.23 and 4.4.2 (last alpha)
 


## Documentation
<!--
  Some useful links for contributors
-->


[beta-testing](https://doc.jeedom.com/en_US/beta/)
[contribute](https://doc.jeedom.com/en_US/contribute/)
[community](https://community.jeedom.com/)
[plugins](https://doc.jeedom.com/en_US/dev/)

