### PR TITLE
add venv support for debian 12

### DIFF
--- a/core/class/plugin.class.php
+++ b/core/class/plugin.class.php
@@ -667,7 +667,7 @@ class plugin {
 		}
 		if (file_exists(__DIR__ . '/../../plugins/' . $plugin_id . '/plugin_info/packages.json')) {
 			$return = array('log' => $plugin_id . '_packages');
-			$packages = system::checkAndInstall(json_decode(file_get_contents(__DIR__ . '/../../plugins/' . $plugin_id . '/plugin_info/packages.json'), true));
+			$packages = system::checkAndInstall(json_decode(file_get_contents(__DIR__ . '/../../plugins/' . $plugin_id . '/plugin_info/packages.json'), true), false, false, $plugin_id);
 			$has_dep_to_install = false;
 			foreach ($packages as $package => $info) {
 				if ($info['status'] != 0 || $info['optional']) {

--- a/desktop/modal/package.check.php
+++ b/desktop/modal/package.check.php
@@ -22,7 +22,7 @@ $result = array();
 $result['core'] = system::checkAndInstall(json_decode(file_get_contents(__DIR__ . '/../../install/packages.json'), true));
 foreach ((plugin::listPlugin(true, false, false, true)) as $plugin) {
   if (file_exists(__DIR__ . '/../../plugins/' . $plugin . '/plugin_info/packages.json')) {
-    $result[$plugin] = system::checkAndInstall(json_decode(file_get_contents(__DIR__ . '/../../plugins/' . $plugin . '/plugin_info/packages.json'), true));
+    $result[$plugin] = system::checkAndInstall(json_decode(file_get_contents(__DIR__ . '/../../plugins/' . $plugin . '/plugin_info/packages.json'), true), false, false, $plugin);
   }
 }
 $datas = array();
@@ -43,8 +43,8 @@ foreach ($result as $key => $packages) {
       if ($info['remark'] != '') {
         $datas[$package]['remark'] .= '. ' . $info['remark'];
       }
-      if($info['needUpdate']){
-      	$canFix = true; 
+      if ($info['needUpdate']) {
+        $canFix = true;
       }
       $datas[$package]['needBy'][] = $key;
     }
@@ -60,7 +60,7 @@ if (count(system::ps('dpkg ')) > 0 || count(system::ps('apt ')) > 0) {
   <div class="input-group pull-right" style="display:inline-flex">
     <span class="input-group-btn">
       <a id="bt_refreshPackage" class="btn btn-sm btn-default roundedLeft"><i class="fas fa-sync"></i> {{Rafraichir}}</a>
-      <?php echo '<a class="btn btn-sm btn-warning bt_correctPackage roundedRight'. (!$canFix ? ' disabled' : '').'" data-package="all"><i class="fas fa-screwdriver"></i> {{Corriger tout}}</a>'; ?>
+      <?php echo '<a class="btn btn-sm btn-warning bt_correctPackage roundedRight' . (!$canFix ? ' disabled' : '') . '" data-package="all"><i class="fas fa-screwdriver"></i> {{Corriger tout}}</a>'; ?>
     </span>
   </div>
   <br /><br />

--- a/install/backup.php
+++ b/install/backup.php
@@ -142,9 +142,10 @@ try {
 		'.log',
 		'core/config/common.config.php',
 		'data/imgOs',
+		'python_venv',
 		config::byKey('backup::path'),
 	);
-	if(version_compare(PHP_VERSION, '8.0.0') >= 0){
+	if (version_compare(PHP_VERSION, '8.0.0') >= 0) {
 		$excludes[] = '/vendor';
 	}
 


### PR DESCRIPTION
<!--
  Thanks for your contribution to make Jeedom better!
-->


## Proposed change
Add venv support for debian 12. 
With this PR, "pip3" packages will be installed in a VENV (python-venv) when debian version >=12 (and only in this case)


## Type of change
<!--
  What type of change your PR is
-->

- [ ] 3rd party lib update
- [ ] Bugfix (non breaking change)
- [X] Core new feature
- [ ] UI new functionnality
- [ ] Code quality improvements
- [ ] Core documentation


## Test check
<!--
  Describe here on which hardware, OS, Core version and eventually plugins you have tested your PR against.
  Give a maximum of details on what you did test, under which circumstances, and which side effect you did tried to handle.
-->
With a plugin not modified:
  - installation & start on debian 11 is successful (as of today)
  - installation on debian 12 is successful (in a venv) but start fail (as expected)
  
With a modified plugin:
  - installation & start on debian 11 is successful (as of today)
  - installation and start on debian 12 is successful

## Documentation
Plugins needs to adapt their daemon_start function to use `system::getCmdPython3($plugin_id)` instead of `python3`.
The new function will return the path to `python3` bin to use depending debian version.
Plugins should either check core version or test the presence of this new method; e.g.
```PHP
    private static function getPython3() {
        if (method_exists('system', 'getCmdPython3')) {
            return system::getCmdPython3(__CLASS__);
        }
        return 'python3 ';
    }
```


[beta-testing](https://doc.jeedom.com/en_US/beta/)
[contribute](https://doc.jeedom.com/en_US/contribute/)
[community](https://community.jeedom.com/)
[plugins](https://doc.jeedom.com/en_US/dev/)

