### PR TITLE
Update utils.inc.php

### DIFF
--- a/core/php/utils.inc.php
+++ b/core/php/utils.inc.php
@@ -131,7 +131,7 @@ function template_replace($_array, $_subject) {
 		$_array['#uid#'] = '';
 	}
 	if (strpos($_array['#uid#'], 'eqLogic') !== false && (!isset($_array['#calledFrom#']) || $_array['#calledFrom#'] != 'eqLogic')) {
-		if (is_object($eqLogic = eqLogic::byId($_array['#id#'])) && $eqLogic->getDisplay('widgetTmpl', 1) == 0) {
+		if (is_object($eqLogic = eqLogic::byId($_array['#id#'])) && ($eqLogic->getDisplay('widgetTmpl', 1) == 0 || $_subject == '')) {
 			$reflected = new ReflectionClass($eqLogic->getEqType_name());
 			$method = $reflected->getParentClass()->getMethod('toHtml');
 			return $method->invokeArgs($eqLogic, [$_array['#version#']]);


### PR DESCRIPTION
https://community.jeedom.com/t/ne-s-affiche-pas-si-dans-la-configuration-avanve-de-l-equipement-template-de-widget-est-active/124520

En version mobile lorsque l'option "widgetTmpl" (Template de widget) est activé et que le plugin dispose seulement d'un template dashboard (toHtml), la tuile n'est pas affiché car le template est vide (getTemplate).

## Proposed change
Afficher le template des commandes par défaut si `getTemplate == ''`


## Type of change
<!--
  What type of change your PR is
-->

- [ ] 3rd party lib update
- [X] Bugfix (non breaking change)
- [ ] Core new feature
- [ ] UI new functionnality
- [ ] Code quality improvements
- [ ] Core documentation


## Test check
<!--
  Describe here on which hardware, OS, Core version and eventually plugins you have tested your PR against.
  Give a maximum of details on what you did test, under which circumstances, and which side effect you did tried to handle.
-->


## Documentation
<!--
  Some useful links for contributors
-->


[beta-testing](https://doc.jeedom.com/en_US/beta/)
[contribute](https://doc.jeedom.com/en_US/contribute/)
[community](https://community.jeedom.com/)
[plugins](https://doc.jeedom.com/en_US/dev/)

