### PR TITLE
read a widget optional parameter with " fix

### DIFF
--- a/desktop/modal/cmd.configure.php
+++ b/desktop/modal/cmd.configure.php
@@ -839,7 +839,7 @@ $configEqDisplayType = jeedom::getConfiguration('eqLogic:displayType');
                     $tr .= '<input class="form-control key" value="' . $key . '" />';
                     $tr .= '</td>';
                     $tr .= '<td>';
-                    $tr .= '<input class="form-control value" value="' . $value . '" />';
+                    $tr .= '<input class="form-control value" value="' . htmlspecialchars($value, ENT_QUOTES) . '" />';
                     $tr .= '</td>';
                     $tr .= '<td>';
                     $tr .= '<a class="btn btn-danger btn-xs removeWidgetParameter pull-right"><i class="fas fa-times"></i> Supprimer</a>';


### PR DESCRIPTION

The text of a widget optional parameter is not correctly displayed in the optional parameters modal box if it contains a double quote (").

The community link describes in detail the problem and the fix.
https://community.jeedom.com/t/widget-bug-avec-des-parametres-optionnels-contenant-des/125269/12?u=noodom
