### PR TITLE
Avoid database corruption on docker stop or docker compose stop

### DIFF
--- a/install/OS_specific/Docker/init.sh
+++ b/install/OS_specific/Docker/init.sh
@@ -1,4 +1,3 @@
-root@majordome03:/docker/z2m# cat jeedom/init.sh
 #!/bin/bash
 
 VERT="\\033[1;32m"


### PR DESCRIPTION
Changes in init.sh (entrypoint) of container to manage a clean stop of database on docker stop or docker compose stop

## Bug
Have a look here from MariaDB JIRA: https://jira.mariadb.org/browse/MDEV-34047 
=> [your container entrypoint is intentionally corrupting your database after any service start failure with "rm /var/lib/mysql/ib_logfile*" [[ref](https://github.com/jeedom/core/blob/83980432db97152e042f670d8cbf5b83e11b84d0/install/OS_specific/Docker/init.sh#L68)]. It won't be recoverable]

## Description
init.sh script will trap the SIGTERM signal sent by docker on stop, and then request a "service_mariadb stop" before touching a file to stop the main process (PID=1)

## Types of changes
- [x] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
- [ ] I have checked there is no other PR open for the same change.
- [ ] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [x] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [ ] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.
