### PR TITLE
Avoid database corruption on docker stop or docker compose stop

### DIFF
--- a/install/OS_specific/Docker/init.sh
+++ b/install/OS_specific/Docker/init.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 VERT="\\033[1;32m"
 NORMAL="\\033[0;39m"
 ROUGE="\\033[1;31m"
@@ -8,17 +9,34 @@ BLANC="\\033[0;02m"
 BLANCLAIR="\\033[1;08m"
 JAUNE="\\033[1;33m"
 CYAN="\\033[1;36m"
-  
+
+FILE_STOP="/root/stop_requested"
+
+docker_stop(){
+	echo "${JAUNE}Stopping Jeedom container${NORMAL}"
+	echo "${VERT}Killing CRON${NORMAL}"
+	killall cron
+	echo "${VERT}Stopping Apache gracefully${NORMAL}"
+	service apache2 stop
+	echo "${VERT}Stopping Database gracefully${NORMAL}"
+	service_mariadb stop
+	echo "${VERT}Stopping ATD gracefully${NORMAL}"
+	service atd stop
+	echo "${ROUGE}Requesting stop on init.sh${NORMAL}"
+	touch ${FILE_STOP}
+	exit 0
+}
+
 service_mariadb(){
-  service mysql $1
-  if [ $? -ne 0 ]; then
-    service mariadb $1
-    if [ $? -ne 0 ]; then
-      echo "${ROUGE}Cannot start mariadb - Cancelling${NORMAL}"
-      return 1
-    fi
-  fi
-  return 0
+	service mysql $1
+	if [ $? -ne 0 ]; then
+		service mariadb $1
+		if [ $? -ne 0 ]; then
+			echo "${ROUGE}Cannot start mariadb - Cancelling${NORMAL}"
+			return 1
+		fi
+	fi
+	return 0
 }
 
 echo 'Start init'
@@ -45,7 +63,7 @@ else
 		echo  "DROP DATABASE IF EXISTS jeedom;" | mysql
 		echo  "CREATE DATABASE jeedom;" | mysql
 		echo  "GRANT ALL PRIVILEGES ON jeedom.* TO 'jeedom'@'localhost';" | mysql
-    fi
+	fi
 
 	cp ${WEBSERVER_HOME}/core/config/common.config.sample.php ${WEBSERVER_HOME}/core/config/common.config.php
 	sed -i "s/#PASSWORD#/${DB_PASSWORD}/g" ${WEBSERVER_HOME}/core/config/common.config.php
@@ -65,7 +83,11 @@ if [ $(which mysqld | wc -l) -ne 0 ]; then
 	chown -R mysql:mysql /var/lib/mysql /var/run/mysqld
 	service_mariadb restart
 	if [ $? -ne 0 ]; then
-		 service_mariadb restart
+		# That can lead to FATAL corruption of databases
+		# rm /var/lib/mysql/ib_logfile*
+		# service_mariadb restart
+		echo "${ROUGE}Starting Database FAILED${NORMAL}"
+		exit 1
 	fi
 fi
 
@@ -89,4 +111,12 @@ chown -R www-data:www-data ${WEBSERVER_HOME}
 echo 'Start apache2'
 service apache2 start
 
-cron -f
+echo 'Start CRON daemon'
+cron
+
+#TAKE CARE : the init.sh script is running under sh so trap only takes signal_number
+echo 'Add trap docker_stop'
+trap "docker_stop $$ ;" 15
+
+rm "${FILE_STOP}" 1>/dev/null 2>&1
+while [ ! -e "${FILE_STOP}" ]; do sleep 1; done


### PR DESCRIPTION
Changes in init.sh (entrypoint) of container to manage a clean stop of database on docker stop or docker compose stop

## Bug
Have a look here from MariaDB JIRA: https://jira.mariadb.org/browse/MDEV-34047 
=> [your container entrypoint is intentionally corrupting your database after any service start failure with "rm /var/lib/mysql/ib_logfile*" [[ref](https://github.com/jeedom/core/blob/83980432db97152e042f670d8cbf5b83e11b84d0/install/OS_specific/Docker/init.sh#L68)]. It won't be recoverable]

## Description
init.sh script will trap the SIGTERM signal sent by docker on stop, and then request a "service_mariadb stop" before touching a file to stop the main process (PID=1)

## Types of changes
- [x] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
- [ ] I have checked there is no other PR open for the same change.
- [ ] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [x] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [ ] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.
