### PR TITLE
fix: network::test() takes to much time to fail

### DIFF
--- a/core/class/network.class.php
+++ b/core/class/network.class.php
@@ -267,10 +267,10 @@ class network {
 		}
 		$data = curl_exec($ch);
 		if (curl_errno($ch)) {
-			usleep(rand(1000, 100000));
+			usleep(rand(1000, 10000));
 			$data = curl_exec($ch);
 			if (curl_errno($ch)) {
-				log::add('network', 'debug', 'Erreur sur ' . $url . ' => ' . curl_errno($ch));
+				log::add('network', 'debug', 'Erreur sur ' . $url . ' => ' . curl_error($ch));
 				curl_close($ch);
 				return false;
 			}


### PR DESCRIPTION
## Description
In `network::test()` class, when curl fails to access Jeedom, there is a recheck after a random `usleep()`.
This `usleep()` is from 1000ms to 100000ms, or 1s to 100s.
this is way to much and PHP timeout may be triggered after 30s.

This PR lowers the max from 100s to 10s (which is still much in my opinion and may be 2 or 5 seconds)

### Suggested changelog entry
Fix : `network::test()` takes to much time to fail (up to 100 seconds)
or 
Change 2nd (random) timeout in `network::test()` from 1-100s to 1-10s

### Related issues/external references
N/A

Fixes #
N/A

## Types of changes
- [x] Bug fix _(non-breaking change which fixes)_

## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [x] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [ ] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.
