### PR TITLE
feat: Add fail2ban status in health

### DIFF
--- a/core/class/jeedom.class.php
+++ b/core/class/jeedom.class.php
@@ -191,6 +191,18 @@ class jeedom {
 			'key' => 'uptodate'
 		);
 
+		$status = shell_exec('systemctl status fail2ban.service');
+		$failed = stripos($status, 'failed') !== false;
+		$running = stripos($status, 'running') !== false;
+		$state = $failed ? 0 : ($running ? 1 : 2);
+		$return[] = array(
+			'name' => __('Etat du service fail2ban', __FILE__),
+			'state' => $failed ? 0 : ($running ? 1 : 2),
+			'result' => $failed ? __('En échec', __FILE__) : ($running ? __('Actif', __FILE__) : __('Désactivé', __FILE__)),
+			'comment' => ($failed || !$running) ? __("Le service Linux fail2ban est désactivé ou en échec : les tentatives d'accès infructueuses à Jeedom ne résulteront pas en un bannissement des IP concernées. Vérifiez l'état du service si vous souhaitez réactiver fail2ban.", __FILE__) : '',
+			'key' => 'service::fail2ban'
+		);
+
 		$state = (config::byKey('enableCron', 'core', 1, true) != 0) ? true : false;
 		$return[] = array(
 			'name' => __('Cron actif', __FILE__),


### PR DESCRIPTION
## Description

As [requested on Community](https://community.jeedom.com/t/etat-du-daemon-fail2ban-dans-la-page-sante/125655), this PR adds fail2ban status on health page:
- When fail2ban is started:
![image](https://github.com/jeedom/core/assets/8396512/f1740d7e-4e21-4d4c-933e-2be5e34485c3)
- When fail2ban is not running:
![image](https://github.com/jeedom/core/assets/8396512/75e0d8f0-6086-46f2-b0a9-15dc61d52a99)
- When fail2ban has failed (not running with errors):
![image](https://github.com/jeedom/core/assets/8396512/8f74e866-510d-4e76-a8c9-400d237f42fa)

### Suggested changelog entry
Add Fail2ban Linux service status on health page

### Related issues/external references
N/A

Fixes #
N/A

## Types of changes
- [x] New feature _(non-breaking change which adds functionality)_

## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [x] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [ ] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.
