### PR TITLE
security fix: session not always initialized before accessing session data

### DIFF
--- a/core/class/user.class.php
+++ b/core/class/user.class.php
@@ -314,6 +314,7 @@ class user {
 			}
 		}
 		$values = $values_tmp;
+		@session_start();
 		if (isset($_SESSION['failed_count']) && $_SESSION['failed_count'] >= config::byKey('security::maxFailedLogin') && (strtotime('now') - config::byKey('security::timeLoginFailed')) < $_SESSION['failed_datetime']) {
 			$values_tmp = array();
 			foreach ($values as $value) {

--- a/core/class/user.class.php
+++ b/core/class/user.class.php
@@ -325,7 +325,6 @@ class user {
 			}
 			$values = $values_tmp;
 			$values[] = array('datetime' => strtotime('now'), 'ip' => getClientIp());
-			@session_start();
 			$_SESSION['failed_count'] = 0;
 			$_SESSION['failed_datetime'] = -1;
 			@session_write_close();


### PR DESCRIPTION
## Description
This is a security fix: in some case, at least when coming from jeeApi, session is not yet initialized and so isBan failed to retrieve correct value of "failed_count" session variable and so client ip is never ban on failed attempts.

calling `@session_start();` make sure session is correctly initialized, it can be done several times so it is not a problem if it was already done.

### Suggested changelog entry

Correction de bug


### Related issues/external references


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have checked there is no other PR open for the same change.
- [X] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [X] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [X] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.
