### PR TITLE
cmd.history.php remember options toggle (#2538)

### DIFF
--- a/desktop/modal/cmd.history.php
+++ b/desktop/modal/cmd.history.php
@@ -168,6 +168,7 @@ if (!jeeFrontEnd.md_history) {
         })
       }
       this.resizeHighChartModal()
+      if (getCookie('md_history_toggleOptions') == 1) this.toggleOptions(true)
     },
     reloadModal: function() {
       let url = 'index.php?v=d&modal=cmd.history&id='
@@ -183,7 +184,26 @@ if (!jeeFrontEnd.md_history) {
           
         }
       })
-    }
+    },
+    toggleOptions: function(_value) {
+      let btIcon = document.querySelector('#bt_toggleOptions i')
+      if(_value){
+        btIcon.removeClass('fa-arrow-down').addClass('fa-arrow-up')
+        document.querySelectorAll('#md_history div.options')?.seen()
+        document.querySelector('#md_history g.highcharts-range-selector-group')?.seen()
+        document.querySelectorAll('.highcharts-button')?.seen()
+        jeeFrontEnd.md_history.resizeHighChartModal(true)
+      } else {
+        btIcon.removeClass('fa-arrow-up').addClass('fa-arrow-down')
+        document.querySelectorAll('#md_history div.options')?.unseen()
+        document.querySelector('#md_history g.highcharts-range-selector-group')?.unseen()
+        document.querySelectorAll('.highcharts-button')?.unseen()
+        jeeFrontEnd.md_history.resizeHighChartModal(false)
+      }
+    },
+    saveOptions: function(_option, _value) {
+      setCookie('md_history_' + _option, _value, 7)
+    },
   }
 }
 
@@ -198,17 +218,11 @@ if (!jeeFrontEnd.md_history) {
   document.getElementById('bt_toggleOptions').addEventListener('click', function(event) {
     let btIcon = document.querySelector('#bt_toggleOptions i')
     if (btIcon.hasClass('fa-arrow-down')) {
-      btIcon.removeClass('fa-arrow-down').addClass('fa-arrow-up')
-      document.querySelectorAll('#md_history div.options')?.seen()
-      document.querySelector('#md_history g.highcharts-range-selector-group')?.seen()
-      document.querySelectorAll('.highcharts-button')?.seen()
-      jeeM.resizeHighChartModal(true)
+      jeeM.toggleOptions(true)
+      jeeM.saveOptions('toggleOptions', 1)
     } else {
-      btIcon.removeClass('fa-arrow-up').addClass('fa-arrow-down')
-      document.querySelectorAll('#md_history div.options')?.unseen()
-      document.querySelector('#md_history g.highcharts-range-selector-group')?.unseen()
-      document.querySelectorAll('.highcharts-button')?.unseen()
-      jeeM.resizeHighChartModal(false)
+      jeeM.toggleOptions(false)
+      jeeM.saveOptions('toggleOptions', 0)
     }
   })
 


### PR DESCRIPTION
memorize user options toggle



### Suggested changelog entry
Mémorisation de l'affichage des options dans la modale "history".


### Related issues/external references

Fixes #2538 


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes)_
- [X] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [x] I grant the project the right to include and distribute the code under the GNU.
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
