### PR TITLE
fix: debug option show stack trace

### DIFF
--- a/core/js/core.js
+++ b/core/js/core.js
@@ -14,6 +14,21 @@
  * along with Jeedom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+
+function toggle(id, event = null) {
+  if(event !== null){
+    event.stopPropagation(); 
+  }
+  var x = document.getElementById(id);
+  console.debug(x.style.display);
+  if (x.style.display === "none") {
+    x.style.display = "block";
+  } else {
+    x.style.display = "none";
+  }
+  return false;
+}
+
 function getTemplate(_folder, _version, _filename, _replace) {
   if (_folder == 'core') {
     var path = _folder + '/template/' + _version + '/' + _filename;

--- a/core/php/utils.inc.php
+++ b/core/php/utils.inc.php
@@ -254,9 +254,9 @@ function mySqlIsHere() {
 
 function displayException($e) {
 	$message = '<span id="span_errorMessage">' . $e->getMessage() . '</span>';
-	if (DEBUG) {
-		$message .= '<a class="pull-right bt_errorShowTrace cursor">Show traces</a>';
-		$message .= '<br/><pre class="pre_errorTrace" style="display : none;">' . print_r($e->getTrace(), true) . '</pre>';
+	if (DEBUG !== 0) {
+		$message .= "<a class=\"pull-right bt_errorShowTrace cursor\" onclick=\"toggle('pre_errorTrace', event);\">Show traces</a>";
+		$message .= '<br/><pre id="pre_errorTrace" style="display : none;">' . print_r($e->getTraceAsString(), true) . '</pre>';
 	}
 	return $message;
 }

--- a/sick.php
+++ b/sick.php
@@ -75,7 +75,7 @@ try {
 		$user->save();
 		echo "OK (admin/admin)\n";
 	}
-} catch (Exeption $e) {
+} catch (Exception $e) {
 	echo "ERROR\n";
 	echo "Description : " . $e->getMessage();
 	echo "\n";


### PR DESCRIPTION
## Description

Je suppose qu'on a perdu cette fonctionnalité avec la v4.4 mais avant on avait la possibilité d'activer les traces en debug, dans le toaster si erreur :
![image](https://github.com/jeedom/core/assets/20190031/ba4a97b7-3a23-4b0d-a628-a9ef1ff72d27)

J'ai ajouté une fonction `toggle` dans core.js : je suis surpris de ne pas avoir trouvé une fonction équivalente, toggle (pour afficher / masquer des éléments) c'est basique on l'a surement déjà ? Sinon où serait-il pertinent de l'ajouter ...?

je fix aussi une erreur de syntaxe sur `sick.php`

### Suggested changelog entry
* ajout des traces d'erreur en debug


### Related issues/external references

Fixes #


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [x] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [ ] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.

