### PR TITLE
Fix/deprecated notices

### DIFF
--- a/core/class/eqLogic.class.php
+++ b/core/class/eqLogic.class.php
@@ -494,6 +494,9 @@ class eqLogic {
 	}
 
 	public static function fromHumanReadable($_input) {
+		if(empty($_input)){
+			return $_input;
+		}
 		$isJson = false;
 		if (is_json($_input)) {
 			$isJson = true;
@@ -525,7 +528,7 @@ class eqLogic {
 			return $_input;
 		}
 		$text = $_input;
-		preg_match_all("/#\[(.*?)\]\[(.*?)\]#/", $text, $matches);
+		preg_match_all( "/#\[(.*?)\]\[(.*?)\]#/", $text, $matches);
 		if (count($matches) == 3) {
 			$countMatches = count($matches[0]);
 			for ($i = 0; $i < $countMatches; $i++) {

--- a/core/class/jeeObject.class.php
+++ b/core/class/jeeObject.class.php
@@ -147,6 +147,9 @@ class jeeObject {
 	}
 
 	public static function fromHumanReadable($_input) {
+		if(empty($_input)){
+			return $_input;
+		}
 		$isJson = false;
 		if (is_json($_input)) {
 			$isJson = true;

--- a/core/class/scenario.class.php
+++ b/core/class/scenario.class.php
@@ -660,6 +660,9 @@ class scenario {
 	 * @return string|object|array return value will depends on $_input received
 	 */
 	public static function fromHumanReadable($_input) {
+		if(empty($_input)){
+			return $_input;
+		}
 		$isJson = false;
 		if (is_json($_input)) {
 			$isJson = true;

--- a/core/class/utils.class.php
+++ b/core/class/utils.class.php
@@ -226,7 +226,7 @@ class utils {
 	}
 
 	public static function decrypt($ciphertext, $password = null) {
-		if ($ciphertext === '') {
+		if (empty($ciphertext)) {
 			return null;
 		}
 		if ($password == null) {

--- a/core/js/core.js
+++ b/core/js/core.js
@@ -14,6 +14,21 @@
  * along with Jeedom. If not, see <http://www.gnu.org/licenses/>.
  */
 
+
+function toggle(id, event = null) {
+  if(event !== null){
+    event.stopPropagation(); 
+  }
+  var x = document.getElementById(id);
+  console.debug(x.style.display);
+  if (x.style.display === "none") {
+    x.style.display = "block";
+  } else {
+    x.style.display = "none";
+  }
+  return false;
+}
+
 function getTemplate(_folder, _version, _filename, _replace) {
   if (_folder == 'core') {
     var path = _folder + '/template/' + _version + '/' + _filename;

--- a/core/php/getResource.php
+++ b/core/php/getResource.php
@@ -42,7 +42,7 @@ if (file_exists($file)) {
 	header('Last-Modified: ' . gmdate('D, d M Y H:i:s', $lastModified) . ' GMT');
 	header('Etag: ' . $etagFile);
 	header('Cache-Control: public');
-	if (@strtotime($_SERVER['HTTP_IF_MODIFIED_SINCE']) == $lastModified || $etagHeader == $etagFile) {
+	if (($ifModifiedSince !== false && $ifModifiedSince == $lastModified) || $etagHeader == $etagFile) {
 		header('HTTP/1.1 304 Not Modified');
 		exit;
 	}

--- a/core/php/utils.inc.php
+++ b/core/php/utils.inc.php
@@ -254,9 +254,9 @@ function mySqlIsHere() {
 
 function displayException($e) {
 	$message = '<span id="span_errorMessage">' . $e->getMessage() . '</span>';
-	if (DEBUG) {
-		$message .= '<a class="pull-right bt_errorShowTrace cursor">Show traces</a>';
-		$message .= '<br/><pre class="pre_errorTrace" style="display : none;">' . print_r($e->getTrace(), true) . '</pre>';
+	if (DEBUG !== 0) {
+		$message .= "<a class=\"pull-right bt_errorShowTrace cursor\" onclick=\"toggle('pre_errorTrace', event);\">Show traces</a>";
+		$message .= '<br/><pre id="pre_errorTrace" style="display : none;">' . print_r($e->getTraceAsString(), true) . '</pre>';
 	}
 	return $message;
 }

--- a/sick.php
+++ b/sick.php
@@ -75,7 +75,7 @@ try {
 		$user->save();
 		echo "OK (admin/admin)\n";
 	}
-} catch (Exeption $e) {
+} catch (Exception $e) {
 	echo "ERROR\n";
 	echo "Description : " . $e->getMessage();
 	echo "\n";


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

<!--
Please target the `beta` branch when submitting your pull request, unless your change **only** applies to Jeedom 4.x.
-->

## Description

il n'est pas acceptable de masquer les notices / deprecation avec un niveau moins élevé d'affichage des erreurs. J'ai donc affiché toutes les notices possible et je les corrige au fil de l'eau... ça pourrait nous éviter de mauvaises surprises pour plus tard.

_Note pour plus tard : pourquoi la fonction `fromHumanReadable` est présente 3 fois à l'identique (dans eqLogic.class.php jeeObject.class.php et scenario.class.php)_

<b>E_WARNING: </b>Undefined array key "HTTP_IF_MODIFIED_SINCE" in <b>/var/www/html/core/php/getResource.php</b> on line <b>45</b><br/>
<b>E_DEPRECATED: </b>strtotime(): Passing null to parameter #1 ($datetime) of type string is deprecated in <b>/var/www/html/core/php/getResource.php</b> on line <b>45</b><br/>

<b>E_DEPRECATED: </b>strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in <b>/var/www/html/core/class/utils.class.php</b> on line <b>235</b><br/>

<b>E_DEPRECATED: </b>preg_match_all(): Passing null to parameter #2 ($subject) of type string is deprecated in <b>/var/www/html/core/class/eqLogic.class.php</b> on line <b>528</b><br/>
<b>E_DEPRECATED: </b>preg_match_all(): Passing null to parameter #2 ($subject) of type string is deprecated in <b>/var/www/html/core/class/scenario.class.php</b> on line <b>695</b><br/>
<b>E_DEPRECATED: </b>preg_match_all(): Passing null to parameter #2 ($subject) of type string is deprecated in <b>/var/www/html/core/class/jeeObject.class.php</b> on line <b>181</b><br/>

### Suggested changelog entry

fix deprecated notices

### Related issues/external references

Fixes #


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have checked there is no other PR open for the same change.
- [ ] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [ ] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [ ] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
