### PR TITLE
fix: set pdo err mode silent

### DIFF
--- a/core/class/DB.class.php
+++ b/core/class/DB.class.php
@@ -34,10 +34,19 @@ class DB {
 
 	private static function initConnection() {
 		global $CONFIG;
+		$_options = [
+			PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci',
+			PDO::ATTR_PERSISTENT => true,
+			// silent mode, default for php7: https://www.php.net/manual/fr/pdo.error-handling.php
+			// exception mode for debug
+			PDO::ATTR_ERRMODE => (DEBUG ? PDO::ERRMODE_EXCEPTION : PDO::ERRMODE_SILENT),
+		];
 		if (isset($CONFIG['db']['unix_socket'])) {
-			static::$connection = new PDO('mysql:unix_socket=' . $CONFIG['db']['unix_socket'] . ';dbname=' . $CONFIG['db']['dbname'], $CONFIG['db']['username'], $CONFIG['db']['password'], array(PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci', PDO::ATTR_PERSISTENT => true));
+			static::$connection = new PDO('mysql:unix_socket=' . $CONFIG['db']['unix_socket'] . ';dbname=' . $CONFIG['db']['dbname'],
+			 $CONFIG['db']['username'], $CONFIG['db']['password'], $_options);
 		} else {
-			static::$connection = new PDO('mysql:host=' . $CONFIG['db']['host'] . ';port=' . $CONFIG['db']['port'] . ';dbname=' . $CONFIG['db']['dbname'], $CONFIG['db']['username'], $CONFIG['db']['password'], array(PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci', PDO::ATTR_PERSISTENT => true));
+			static::$connection = new PDO('mysql:host=' . $CONFIG['db']['host'] . ';port=' . $CONFIG['db']['port'] . ';dbname=' . $CONFIG['db']['dbname'], 
+			$CONFIG['db']['username'], $CONFIG['db']['password'], $_options);
 		}
 	}
 


### PR DESCRIPTION
## Description
PDO error mode is silent as a default value before php8, I force it there to override the new php8 mode that is PDO Exception

related to this post:
https://community.jeedom.com/t/erreur-sqlstate-hy093-et-update-impossible-depuis-maj-en-4-4-5/125926/31?u=pifou

The new PDO error mode for PHP8 is PDO Exception, I just set it back to the php7 default value = PDO Silent...
But, for the `DEBUG` mode it would be great to keep the Exception mode to check and fix new sql errors :)  

It would be gread to improve error handler to catch PDO errors into some messages or logs in the future ?

### Suggested changelog entry

* Force database PDO error mode to `silent` that is PHP7 default mode

### Related issues/external references

Help #2561 (Deb12 requires PHP8)


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [x] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.
