### PR TITLE
python2 version not displayed in health page because output was on stderr on python<3.4

### DIFF
--- a/core/class/jeedom.class.php
+++ b/core/class/jeedom.class.php
@@ -459,7 +459,7 @@ class jeedom {
 		);
 
 		if (shell_exec('which python') != '') {
-			$value = shell_exec('python --version');
+			$value = shell_exec('python --version 2>&1'); // prior python 3.4, 'python --version' output was on stderr
 			$return[] = array(
 				'name' => __('Python', __FILE__),
 				'state' => true,


### PR DESCRIPTION
## Description
python2 version not displayed in health page because output was on stderr on python<3.4
on top this add a ligne in http.error (not always)


### Suggested changelog entry
- Fix affichage version python2 sur la page santé

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have checked there is no other PR open for the same change.
- [X] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [X] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [X] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.
