### PR TITLE
Pour le select prenez pas la bonne valeur pour faire la comparaison d…

### DIFF
--- a/core/class/cmd.class.php
+++ b/core/class/cmd.class.php
@@ -1658,7 +1658,7 @@ class cmd {
 				$coupleArray = explode('|', $element);
 				$cmdValue = $this->getCmdValue();
 				if (is_object($cmdValue) && $cmdValue->getType() == 'info') {
-					if ($cmdValue->execCmd() == $coupleArray[0]) {
+					if ($cmdValue->execCmd() == $coupleArray[1]) {
 						$listOption .= '<option value="' . $coupleArray[0] . '" selected>' . $coupleArray[1] . '</option>';
 						$foundSelect = true;
 					} else {


### PR DESCRIPTION
Je pense qu'il y a un soucis de comparaison pour la commande **Select** pour la fonction **toHtml** sur la ligne **1661** `if ($cmdValue->execCmd() == $coupleArray[0]) {` pour ` $coupleArray[0]` en passant de **0** à **1**, on a la bonne comparaison pour prends la valeur de la commande et non l'élément

Avec ce changement la liste se construit correctement sauf ensuite ça ne s'affichage pas avec la présélection car dans le fichier  **cmd.action.select.select.html** dans la partie **dashboard** la fonction **jeedom.cmd.refreshValue** fait un changement, je n'arrive pas à trouver d'où ça vient pour le corriger si vous pouvez voir au passage si vous trouvez avant moi.