### PR TITLE
feat: add automatic workflow merge to V4-stable

### DIFF
--- a/.github/workflows/V4-stable-update.yaml
+++ b/.github/workflows/V4-stable-update.yaml
@@ -1,0 +1,29 @@
+name: Auto Merge to V4-stable
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [closed]
+    branches:
+      - master
+
+jobs:
+  merge-to-v4-stable:
+    if: (github.event_name == 'pull_request' && github.event.pull_request.merged == true) || (github.event_name == 'push' && github.ref == 'refs/heads/master')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code and create/checkout local V4-stable branch
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Fetches all history for all branches and tags
+          ref: refs/heads/V4-stable
+    
+      - name: Merge to V4-stable
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git merge origin/master --no-edit
+          git push origin V4-stable

--- a/install/OS_specific/Docker/init_workflow.sh
+++ b/install/OS_specific/Docker/init_workflow.sh
@@ -10,10 +10,10 @@ if [[ "${GITHUB_REF_NAME}" == "master" ]]; then
   JEEDOM_TAGS="${REPO}/jeedom:latest,${REPO}/jeedom:$JEEDOM_SHORT_VERSION";
   GITHUB_BRANCH=${GITHUB_REF_NAME};
 elif [[ "${GITHUB_REF_NAME}" == "beta" ]]; then
-  JEEDOM_TAGS="${REPO}/jeedom:beta,${REPO}/jeedom:$JEEDOM_SHORT_VERSION";
+  JEEDOM_TAGS="${REPO}/jeedom:beta"; # ${REPO}/jeedom:$JEEDOM_SHORT_VERSION";
   GITHUB_BRANCH=${GITHUB_REF_NAME};
 else
-  JEEDOM_TAGS="${REPO}/jeedom:$JEEDOM_SHORT_VERSION";
+  JEEDOM_TAGS="${REPO}/jeedom:alpha";
   GITHUB_BRANCH=alpha;
 fi
 


### PR DESCRIPTION

## Description

Ce workflow a pour but de merger toute modification / merge de la branche master vers V4-stable.
La branche master actuellement représente la version 3.xx il faut la mettre à niveau pour représenter la dernière version 4.x **avant** de merger cette request(!) (éventuellement garder une copie V3-stable) (mais si un TAG existe pour la dernière version 3.x c'est redondant de conserver aussi une branche)

Ensuite: on merge / push sur la branche master, et ce workflow copie les modifs sur V4-stable.


### Suggested changelog entry

* workflow to replicate master branch on V4-stable

### Related issues/external references

Fixes FEAT #2575 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [x] CI/CD new feature 
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement
