### PR TITLE
add a scenarios list filter when adding a scenario in a scenario modification

### DIFF
--- a/core/template/scenario/scenario.default.html
+++ b/core/template/scenario/scenario.default.html
@@ -17,6 +17,27 @@
   <textarea class="tags expressionAttr form-control ta_autosize roundedRight" data-l1key="options" data-l2key="tags" rows="1" data-cmd_id="#id#" data-uid="#uid#" style="resize:vertical;" placeholder="{{Tags}}">#tags#</textarea>
 </div>
 <script>
+  function addScenariosFilter(selectElm) {
+    const searchInput = document.createElement('input');
+    searchInput.classList.add('form-control', 'rounded-left');
+    searchInput.placeholder = `Filtre de scénarios`;
+    selectElm.parentElement.insertBefore(searchInput, selectElm.nextSibling);
+  
+    searchInput.addEventListener("keyup", function (e) {
+      const text = e.target.value;
+      const options = Array.from(selectElm.options);
+      options.forEach (function(option) {
+        const optionText = option.text; 
+        const lowerOptionText = optionText.toLowerCase();
+        const lowerText = text.toLowerCase(); 
+        const regex = new RegExp("^" + text, "i");
+        const match = optionText.match(regex); 
+        const contains = lowerOptionText.indexOf(lowerText) != -1;
+        option.hidden = match || contains ? false: true ;
+      })
+    });
+  }
+  
   if ('#action#' != '' && document.querySelector('.expressionAttr[data-uid="#uid#"][data-l1key="options"][data-l2key="action"] option[value="#action#"]')?.innerHTML != '') {
     document.querySelector('.expressionAttr[data-uid="#uid#"][data-l1key="options"][data-l2key="action"]').value = '#action#'
   }
@@ -34,6 +55,8 @@
         newOption.value = scenarios[i].id
         select.appendChild(newOption)
       }
+
+      addScenariosFilter(select);
 
       if ('#scenario_id#' != '' && document.querySelector('.expressionAttr[data-uid="#uid#"][data-l1key="options"][data-l2key="scenario_id"] option[value="#scenario_id#"]')?.innerHTML != '') {
         document.querySelector('.expressionAttr[data-uid="#uid#"][data-l1key="options"][data-l2key="scenario_id"]').value = '#scenario_id#'


### PR DESCRIPTION

Add a scenarios list filter when adding a scenario in a scenario modification


## Description
The PR adds a filter to the scenarios list when the action 'scenario' is added.
Only matching scenarios to the filter (scenario name, scenario group or scenario object parent) are visible in the list.

### Suggested changelog entry
add a scenarios list filter in a scenario


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes)_
- [x ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x ] I have checked there is no other PR open for the same change.
- [ x] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [x ] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [ x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
