### PR TITLE
Exclude node_modules folders from backup

### DIFF
--- a/install/backup.php
+++ b/install/backup.php
@@ -129,6 +129,7 @@ try {
 		'support',
 		'backup',
 		'script/tunnel',
+		'node_modules',
 		'.git',
 		'.gitignore',
 		'.log',


### PR DESCRIPTION
like python_venv, node_modules should be excluded from backups.

it increases the backup unnecessary.
it avoid plugins to detect the dependancies should be reinstalled automatically.
it forces users to restart dependancies manually instead of automatically : bad user experience.