### PR TITLE
protect function system::fuserk

### DIFF
--- a/core/class/system.class.php
+++ b/core/class/system.class.php
@@ -94,6 +94,8 @@ class system {
 	}
 
 	public static function fuserk($_port, $_protocol = 'tcp'): void {
+		if (!is_string($_port)) return;
+
 		if (file_exists($_port)) {
 			exec(system::getCmdSudo() . 'fuser -k ' . $_port . ' > /dev/null 2>&1');
 		} else {
@@ -467,7 +469,7 @@ class system {
 					if (file_exists(__DIR__ . '/../../' . $package . '/package.json')) {
 						$version = json_decode(file_get_contents(__DIR__ . '/../../' . $package . '/package.json'), true)['version'];
 						if ($type == 'npm') {
-							if (file_exists(__DIR__ . '/../../' . $package . '/node_modules') && isset(scandir(__DIR__ . '/../../' . $package . '/node_modules', SCANDIR_SORT_NONE )[2])) {
+							if (file_exists(__DIR__ . '/../../' . $package . '/node_modules') && isset(scandir(__DIR__ . '/../../' . $package . '/node_modules', SCANDIR_SORT_NONE)[2])) {
 								exec('cd ' . __DIR__ . '/../../' . $package . ';' . self::getCmdSudo() . ' npm ls', $output, $return_var);
 								if ($return_var == 0) {
 									$found = 1;


### PR DESCRIPTION
## Description
Some plugins call `system::fuserk(jeedom::getUsbMapping($port));` but `jeedom::getUsbMapping($port)` will return an array if port is an empty string and then we got error `Erreur sur la fonction deamon_start du plugin : file_exists(): Argument #1 ($filename) must be of type string, array given`
exemple: https://community.jeedom.com/t/dsm7-docker-erreurs-sur-plugins-protocole-domotique/127102

so the goal of this PR is to protect system::fuserk function by validating argument

### Suggested changelog entry
- bugfix debian12


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have checked there is no other PR open for the same change.
- [X] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [X] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [X] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.