### PR TITLE
fix: deprecated and warning notices

### DIFF
--- a/core/class/cron.class.php
+++ b/core/class/cron.class.php
@@ -555,7 +555,7 @@ class cron {
 	}
 
 	public function getOption() {
-		return json_decode($this->option, true);
+		return json_decode($this->option ?? '', true);
 	}
 
 	public function getOnce($_default = 0) {

--- a/core/class/system.class.php
+++ b/core/class/system.class.php
@@ -54,7 +54,7 @@ class system {
 			return 'custom';
 		}
 		if (self::$_distrib === null) {
-			self::$_distrib = trim(shell_exec('grep CPE_NAME /etc/os-release | cut -d \'"\' -f 2 | cut -d : -f 3 '));
+			self::$_distrib = trim(shell_exec('grep CPE_NAME /etc/os-release | cut -d \'"\' -f 2 | cut -d : -f 3 ') ?? '');
 			if (self::$_distrib == '') {
 				self::$_distrib = trim(shell_exec('grep -e "^ID" /etc/os-release | cut -d \'=\' -f 2'));
 			}
@@ -421,7 +421,7 @@ class system {
 				}
 				break;
 			case 'composer':
-				$datas = json_decode(shell_exec(self::getCmdSudo() . ' composer show -f json 2>/dev/null'));
+				$datas = json_decode(shell_exec(self::getCmdSudo() . ' composer show -f json 2>/dev/null'), true);
 				foreach ($datas['installed'] as $value) {
 					self::$_installPackage[$type_key][mb_strtolower($value['name'])] = array('version' => $value['version']);
 				}

--- a/core/class/utils.class.php
+++ b/core/class/utils.class.php
@@ -174,7 +174,7 @@ class utils {
 			if ($_key == '') {
 				return is_json($_attr, array());
 			}
-			if ($_attr === '') {
+			if (empty($_attr)) {
 				if (is_array($_key)) {
 					foreach ($_key as $key) {
 						$return[$key] = $_default;


### PR DESCRIPTION
## Description

Fix deprecated and warning messages while setting error level = E_ALL :

```
E_DEPRECATED: trim(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/html/core/class/system.class.php on line 57 
E_DEPRECATED: json_decode(): Passing null to parameter #1 ($json) of type string is deprecated in /var/www/html/core/class/cron.class.php on line 554
E_DEPRECATED: json_decode(): Passing null to parameter #1 ($json) of type string is deprecated in /var/www/html/core/class/utils.class.php on line 186 

```
PHP Error:  Cannot use object of type stdClass as array in /var/www/html/core/class/system.class.php on line 423
PHP Stack trace:
PHP   1. {main}() /var/www/html/core/php/jeeCron.php:0
PHP   2. plugin::checkDeamon() /var/www/html/core/php/jeeCron.php:78
PHP   3. plugin->dependancy_info($_refresh = *uninitialized*) /var/www/html/core/class/plugin.class.php:583
PHP   4. system::checkAndInstall($_packages = ['composer' => ['phpseclib/phpseclib' => [...]]], $_fix = FALSE, $_foreground = FALSE, $_plugin = 'Monitoring', $_force = *uninitialized*) /var/www/html/core/class/plugin.class.php:674
PHP   5. system::getInstallPackage($_type = 'composer', $_plugin = 'Monitoring') /var/www/html/core/class/system.class.php:461

```
E_DEPRECATED: preg_match_all(): Passing null to parameter #2 ($subject) of type string is deprecated in /var/www/html/core/class/eqLogic.class.php on line 484 
#0: /var/www/html/core/class/eqLogic.class.php:484 preg_match_all(["\/#eqLogic([0-9]*)#\/",null,null])
#1: /var/www/html/core/class/eqLogic.class.php:479 toHumanReadable([null])
#2: /var/www/html/core/class/jeedom.class.php:1400 toHumanReadable([{"id":4,"name":"Chambre 1","father_id":3,"isVisible":1,"position":null,"configuration":{"parentNumber":1,"tagColor":"#000000","tagTextColor":"#FFFFFF","mobile::summaryTextColor":"","icon":"<\/i>"},"display":{"icon":"<\/i>"},"image":{"type":"jpg","sha512":"4bd3961a00828381802c9fde9c2852924c6a59c298a134b9d1cb65b88650a393310f4bb76b551c4cc4da91d5842e20de0a105f84a2d85bcb69f6e4b06c5186f8"},"img":"data\/object\/object4-4bd3961a00828381802c9fde9c2852924c6a59c298a134b9d1cb65b88650a393310f4bb76b551c4cc4da91d5842e20de0a105f84a2d85bcb69f6e4b06c5186f8.jpg"}])
#3: /var/www/html/core/ajax/object.ajax.php:47 toHumanReadable(
[{
        "id": 4,
        "name": "Chambre 1",
        "father_id": 3,
        "isVisible": 1,
        "position": null,
        "configuration": {
            "parentNumber": 1,
            "tagColor": "#000000",
            "tagTextColor": "#FFFFFF",
            "mobile::summaryTextColor": "",
            "icon": "<\/i>"
        },
        "display": {
            "icon": "<\/i>"
        },
        "image": {
            "type": "jpg",
            "sha512": "4bd3961a00828381802c9fde9c2852924c6a59c298a134b9d1cb65b88650a393310f4bb76b551c4cc4da91d5842e20de0a105f84a2d85bcb69f6e4b06c5186f8"
        },
        "img": "data\/object\/object4-4bd3961a00828381802c9fde9c2852924c6a59c298a134b9d1cb65b88650a393310f4bb76b551c4cc4da91d5842e20de0a105f84a2d85bcb69f6e4b06c5186f8.jpg"
    }
]
)
```
### Suggested changelog entry

* fix deprecated and warning notices

### Related issues/external references

Fixes #2678

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [x] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.
