### PR TITLE
fix: manage php8 migration for curl functions

### DIFF
--- a/core/class/jsonrpcClient.class.php
+++ b/core/class/jsonrpcClient.class.php
@@ -175,7 +175,7 @@ class jsonrpcClient {
 		if (curl_errno($ch)) {
 			$this->error = 'Erreur curl sur : ' . $this->apiAddr . '. Détail :' . curl_error($ch);
 		}
-		curl_close($ch);
+		unset($ch);
 		return $response;
 	}
 

--- a/core/class/network.class.php
+++ b/core/class/network.class.php
@@ -275,7 +275,7 @@ class network {
 				return false;
 			}
 		}
-		curl_close($ch);
+		unset($ch);
 		if (trim($data) != 'ok') {
 			log::add('network', 'debug', 'Retour NOK sur ' . $url . ' => ' . $data);
 			return false;

--- a/core/com/http.com.php
+++ b/core/com/http.com.php
@@ -128,7 +128,7 @@ class com_http {
 		if (!isset($response)) {
 			$response = '';
 		}
-		if (isset($ch) && is_resource($ch)) {
+		if (isset($ch) && $ch !== false) {
 			if (curl_errno($ch)) {
 				$curl_error = curl_error($ch);
 				curl_close($ch);
@@ -142,7 +142,7 @@ class com_http {
 					throw new Exception(__('Echec de la requête HTTP :', __FILE__) . ' ' . $this->url . ' cURL error : ' . $curl_error, 404);
 				}
 			} else {
-				curl_close($ch);
+				unset($ch);
 			}
 		}
 		$ch = null;


### PR DESCRIPTION
## Description

[curl_init, starting from php8:](https://www.php.net/manual/en/function.curl-init.php) On success, this function returns a [CurlHandle](https://www.php.net/manual/en/class.curlhandle.php) instance now; previously, a [resource](https://www.php.net/manual/en/language.types.resource.php) was returned.

any other curl_* function (e.g. [curl_setopt](https://www.php.net/manual/en/function.curl-setopt.php) ) starting from php8:
handle expects a [CurlHandle](https://www.php.net/manual/en/class.curlhandle.php) instance now; previously, a [resource](https://www.php.net/manual/en/language.types.resource.php) was expected.

conclusion : nothing to change, except for ìs_resource()` and `curl_close()`

### Suggested changelog entry

* fix: manage php8 migration for curl functions

### Related issues/external references

Fixes #2676 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [x] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.
