### PR TITLE
feat: build docker image with current branch source code and test it

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -1,0 +1,57 @@
+# build docker image based on debian bullseye and bookworm
+# start both containers and run sick.php
+# stop & clean
+name: Docker Build and Test Image
+
+on:
+  # only trigger CI when pull request on following branches
+  pull_request:
+    branches:
+      - 'alpha'
+  # this is to manually trigger the worklow
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Reason'     
+        default: 'Manual launch'
+
+jobs:
+  buildAndTestDockerImg:
+    runs-on: ubuntu-latest
+    steps:
+    
+      - name: Check Out Repo
+        # Check out the repo, using current branch
+        # https://github.com/marketplace/actions/checkout
+        uses: actions/checkout@v4
+
+      - name: Build jeedom:bullseye
+        # build current image for bullseye
+        run: |
+          docker build -t jeedom:bullseye --build-arg DEBIAN=bullseye .
+
+      - name: run jeedom:bullseye and check
+        # build current image for bullseye and check it
+        run: |
+          docker run -p 80:80 -d --rm --name jeedom_bullseye jeedom:bullseye
+          sleep 60
+          docker exec jeedom_bullseye php sick.php
+
+      - name: Build jeedom:bookworm
+        # build current image for bookworm
+        run: |
+          docker build -t jeedom:bookworm --build-arg DEBIAN=bookworm .
+
+      - name: run jeedom:bookworm and check
+        # build current image for bookworm and check it
+        run: |
+          docker run -p 81:80 -d --rm --name jeedom_bookworm jeedom:bookworm
+          sleep 60
+          docker exec jeedom_bookworm php sick.php
+    
+      - name: Clean docker image
+        continue-on-error: true
+        run: |
+          docker stop jeedom_bullseye jeedom_bookworm 
+          docker rm jeedom_bullseye jeedom_bookworm 
+          docker rmi jeedom:bullseye jeedom:bookworm

--- a/.gitignore
+++ b/.gitignore
@@ -45,4 +45,4 @@ tmp/*
 !tmp/.htaccess
 
 !.htaccess
-.github/
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,36 @@ VOLUME ${WEBSERVER_HOME}
 VOLUME /var/lib/mysql
 
 COPY install/install.sh /tmp/
-RUN sh /tmp/install.sh -v ${VERSION} -w ${WEBSERVER_HOME} -d ${DATABASE}
+# install step by step : step_1_upgrade
+RUN sh /tmp/install.sh -s 1 -v ${VERSION} -w ${WEBSERVER_HOME} -d ${DATABASE} -i docker
+# step_2_mainpackage
+RUN sh /tmp/install.sh -s 2 -v ${VERSION} -w ${WEBSERVER_HOME} -d ${DATABASE} -i docker
+# step_3_database
+RUN sh /tmp/install.sh -s 3 -v ${VERSION} -w ${WEBSERVER_HOME} -d ${DATABASE} -i docker
+# step_4_apache
+RUN sh /tmp/install.sh -s 4 -v ${VERSION} -w ${WEBSERVER_HOME} -d ${DATABASE} -i docker
+# step_5_php
+RUN sh /tmp/install.sh -s 5 -v ${VERSION} -w ${WEBSERVER_HOME} -d ${DATABASE} -i docker
+# step 6 : copy jeedom source files
+COPY . ${WEBSERVER_HOME}
+# step_7_jeedom_customization_mariadb
+RUN sh /tmp/install.sh -s 7 -v ${VERSION} -w ${WEBSERVER_HOME} -d ${DATABASE} -i docker
+# step_8_jeedom_customization
+RUN sh /tmp/install.sh -s 8 -v ${VERSION} -w ${WEBSERVER_HOME} -d ${DATABASE} -i docker
+# step_9_jeedom_configuration
+RUN sh /tmp/install.sh -s 9 -v ${VERSION} -w ${WEBSERVER_HOME} -d ${DATABASE} -i docker
+# step_10_jeedom_installation
+RUN sh /tmp/install.sh -s 10 -v ${VERSION} -w ${WEBSERVER_HOME} -d ${DATABASE} -i docker
+# step_11_jeedom_post
+RUN sh /tmp/install.sh -s 11 -v ${VERSION} -w ${WEBSERVER_HOME} -d ${DATABASE} -i docker
+
+# cleanup
+RUN apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# this file is a flag to trigger init.sh initialisation
+RUN touch initialisation
 
 EXPOSE 80
 COPY install/OS_specific/Docker/init.sh /root/
-CMD ["sh", "/root/init.sh"]
+CMD ["bash", "/root/init.sh"]

--- a/install/OS_specific/Docker/init.sh
+++ b/install/OS_specific/Docker/init.sh
@@ -19,51 +19,40 @@ docker_stop(){
 	echo "${VERT}Stopping Apache gracefully${NORMAL}"
 	service apache2 stop
 	echo "${VERT}Stopping Database gracefully${NORMAL}"
-	service_mariadb stop
+	service mariadb stop
 	echo "${VERT}Stopping ATD gracefully${NORMAL}"
 	service atd stop
+	echo "${VERT}Stopping fail2ban gracefully${NORMAL}"
+	service fail2ban stop
 	echo "${ROUGE}Requesting stop on init.sh${NORMAL}"
 	touch ${FILE_STOP}
 	exit 0
 }
 
-service_mariadb(){
-	service mysql $1
-	if [ $? -ne 0 ]; then
-		service mariadb $1
-		if [ $? -ne 0 ]; then
-			echo "${ROUGE}Cannot start mariadb - Cancelling${NORMAL}"
-			return 1
-		fi
-	fi
-	return 0
-}
-
-echo 'Start init'
+# flag to fail fast on errors
+set -e
 
 # $WEBSERVER_HOME and $VERSION env variables comes from Dockerfile
 
-if [ -f ${WEBSERVER_HOME}/core/config/common.config.php ]; then
-	echo 'Jeedom is already install'
-	JEEDOM_INSTALL=1
-else
-	echo 'Start jeedom installation'
+if [[ -f ${WEBSERVER_HOME}/initialisation ]]; then
+    echo "************************
+Start JEEDOM initialisation !
+************************"
 	JEEDOM_INSTALL=0
-	rm -rf /root/install.sh
-	wget https://raw.githubusercontent.com/jeedom/core/${VERSION}/install/install.sh -O /root/install.sh
-	chmod +x /root/install.sh
-	/root/install.sh -s 6 -v ${VERSION} -w ${WEBSERVER_HOME}
-	if [ $(which mysqld | wc -l) -ne 0 ]; then
-		chown -R mysql:mysql /var/lib/mysql
-		mysql_install_db --user=mysql --basedir=/usr/ --ldata=/var/lib/mysql/
-		service_mariadb restart
-		DB_PASSWORD=$(cat /dev/urandom | tr -cd 'a-f0-9' | head -c 15)
-		echo "DROP USER 'jeedom'@'localhost';" | mysql > /dev/null 2>&1
-		echo  "CREATE USER 'jeedom'@'localhost' IDENTIFIED BY '${DB_PASSWORD}';" | mysql
-		echo  "DROP DATABASE IF EXISTS jeedom;" | mysql
-		echo  "CREATE DATABASE jeedom;" | mysql
-		echo  "GRANT ALL PRIVILEGES ON jeedom.* TO 'jeedom'@'localhost';" | mysql
-	fi
+
+    echo "************************
+Start mariadb service
+************************"
+
+	service mariadb start
+	service mariadb status
+
+	DB_PASSWORD=$(cat /dev/urandom | tr -cd 'a-f0-9' | head -c 15)
+	echo "DROP USER IF EXISTS 'jeedom'@'localhost';" | mysql
+	echo  "CREATE USER 'jeedom'@'localhost' IDENTIFIED BY '${DB_PASSWORD}';" | mysql
+	echo  "DROP DATABASE IF EXISTS jeedom;" | mysql
+	echo  "CREATE DATABASE jeedom;" | mysql
+	echo  "GRANT ALL PRIVILEGES ON jeedom.* TO 'jeedom'@'localhost';" | mysql
 
 	cp ${WEBSERVER_HOME}/core/config/common.config.sample.php ${WEBSERVER_HOME}/core/config/common.config.php
 	sed -i "s/#PASSWORD#/${DB_PASSWORD}/g" ${WEBSERVER_HOME}/core/config/common.config.php
@@ -71,32 +60,42 @@ else
 	sed -i "s/#USERNAME#/${DB_USERNAME:-jeedom}/g" ${WEBSERVER_HOME}/core/config/common.config.php
 	sed -i "s/#PORT#/${DB_PORT:-3306}/g" ${WEBSERVER_HOME}/core/config/common.config.php
 	sed -i "s/#HOST#/${DB_HOST:-localhost}/g" ${WEBSERVER_HOME}/core/config/common.config.php
-	/root/install.sh -s 10 -v ${VERSION} -w ${WEBSERVER_HOME}
-	/root/install.sh -s 11 -v ${VERSION} -w ${WEBSERVER_HOME}
+
+	# remove default fail2ban, contains useless sshd check
+	rm /etc/fail2ban/jail.d/defaults-debian.conf
+
+    echo "************************
+start JEEDOM PHP script installation
+************************"
+
+	php ${WEBSERVER_HOME}/install/install.php mode=force
+
+	# remove the flag file after the first successfull installation
+	rm ${WEBSERVER_HOME}/initialisation
 fi
 
 echo 'Start atd'
 service atd restart
+service atd status
 
-if [ $(which mysqld | wc -l) -ne 0 ]; then
+if [[ $(which mysqld | wc -l) -ne 0 ]]; then
 	echo 'Starting mariadb'
 	chown -R mysql:mysql /var/lib/mysql /var/run/mysqld
-	service_mariadb restart
+	service mariadb restart
 	if [ $? -ne 0 ]; then
 		# That can lead to FATAL corruption of databases
 		# rm /var/lib/mysql/ib_logfile*
-		# service_mariadb restart
 		echo "${ROUGE}Starting Database FAILED${NORMAL}"
 		exit 1
 	fi
 fi
 
-if [ ${JEEDOM_INSTALL} -eq 0 ] && [ ! -z "${RESTOREBACKUP}" ] && [ "${RESTOREBACKUP}" != 'NO' ]; then
+if [[ ${JEEDOM_INSTALL} == 0 ]] && [[ ! -z "${RESTOREBACKUP}" ]] && [[ "${RESTOREBACKUP}" != 'NO' ]]; then
 	echo 'Need restore backup '${RESTOREBACKUP}
 	wget ${RESTOREBACKUP} -O /tmp/backup.tar.gz
 	php ${WEBSERVER_HOME}/install/restore.php backup=/tmp/backup.tar.gz
 	rm /tmp/backup.tar.gz
-	if [ ! -z "${UPDATEJEEDOM}" ] && [ "${UPDATEJEEDOM}" != 'NO' ]; then
+	if [[ ! -z "${UPDATEJEEDOM}" ]] && [[ "${UPDATEJEEDOM}" != 'NO' ]]; then
 		echo 'Need update jeedom'
 		php ${WEBSERVER_HOME}/install/update.php
 	fi
@@ -104,19 +103,24 @@ fi
 
 echo 'All init complete'
 chmod 777 /dev/tty*
-chmod 777 -R /tmp
 chmod 755 -R ${WEBSERVER_HOME}
-chown -R www-data:www-data ${WEBSERVER_HOME}
 
 echo 'Start apache2'
 service apache2 start
+service apache2 status
+
+echo 'Start fail2ban'
+service fail2ban start
+service fail2ban status
 
 echo 'Start CRON daemon'
 cron
+
+# step_12_jeedom_check
+sh /tmp/install.sh -s 12 -v ${VERSION} -w ${WEBSERVER_HOME} -i docker
 
 #TAKE CARE : the init.sh script is running under sh so trap only takes signal_number
 echo 'Add trap docker_stop'
 trap "docker_stop $$ ;" 15
 
-rm "${FILE_STOP}" 1>/dev/null 2>&1
-while [ ! -e "${FILE_STOP}" ]; do sleep 1; done
+while [[ ! -e "${FILE_STOP}" ]]; do sleep 1; done

--- a/install/install.sh
+++ b/install/install.sh
@@ -179,16 +179,20 @@ step_7_jeedom_customization_mariadb() {
   echo '[Service]' > /lib/systemd/system/mariadb.service.d/override.conf
   echo 'Restart=always' >> /lib/systemd/system/mariadb.service.d/override.conf
   echo 'RestartSec=10' >> /lib/systemd/system/mariadb.service.d/override.conf
-  systemctl daemon-reload
-  
-  service_action stop mariadb > /dev/null 2>&1
-  if [ $? -ne 0 ]; then
-    service_action status mariadb
-    service_action stop mysql > /dev/null 2>&1
+
+  # do not start oany new service during docker build sequence
+  if [ "${INSTALLATION_TYPE}" -ne "docker" ];then
+    systemctl daemon-reload
+    
+    service_action stop mariadb > /dev/null 2>&1
     if [ $? -ne 0 ]; then
-      service_action status mysql
-      echo "${RED}Cannot stop mariadb - Canceling${NORMAL}"
-      exit 1
+      service_action status mariadb
+      service_action stop mysql > /dev/null 2>&1
+      if [ $? -ne 0 ]; then
+        service_action status mysql
+        echo "${RED}Cannot stop mariadb - Canceling${NORMAL}"
+        exit 1
+      fi
     fi
   fi
 
@@ -216,14 +220,16 @@ step_7_jeedom_customization_mariadb() {
    # echo "default-storage-engine=myisam" >> /etc/mysql/conf.d/jeedom_my.cnf
   fi
   
-  service_action start mariadb > /dev/null 2>&1
-  if [ $? -ne 0 ]; then
-    service_action status mariadb
-    service_action start mysql > /dev/null 2>&1
+  if [ "${INSTALLATION_TYPE}" -ne "docker" ];then
+    service_action start mariadb > /dev/null 2>&1
     if [ $? -ne 0 ]; then
-      service_action status mysql
-      echo "${RED}Cannot start mariadb - Cancelling${NORMAL}"
-      exit 1
+      service_action status mariadb
+      service_action start mysql > /dev/null 2>&1
+      if [ $? -ne 0 ]; then
+        service_action status mysql
+        echo "${RED}Cannot start mariadb - Cancelling${NORMAL}"
+        exit 1
+      fi
     fi
   fi
   
@@ -257,8 +263,10 @@ step_8_jeedom_customization() {
   echo "PrivateTmp=no" >> /etc/systemd/system/apache2.service.d/override.conf
   echo "Restart=always" >> /etc/systemd/system/apache2.service.d/override.conf
   echo "RestartSec=10" >> /etc/systemd/system/apache2.service.d/override.conf
-  
-  systemctl daemon-reload
+
+  if [ "${INSTALLATION_TYPE}" -ne "docker" ];then
+    systemctl daemon-reload
+  fi
   
   for file in $(find /etc/ -iname php.ini -type f); do
     echo "Update php file ${file}"
@@ -279,7 +287,9 @@ step_8_jeedom_customization() {
 
   sed -i -e "s%\${APACHE_LOG_DIR}/error.log%${WEBSERVER_HOME}/log/http.error%g" /etc/apache2/apache2.conf
   
-  service_action restart apache2 > /dev/null 2>&1
+  if [ "${INSTALLATION_TYPE}" -ne "docker" ];then
+    service_action restart apache2 > /dev/null 2>&1
+  fi
   
   echo "vm.swappiness = 10" >>  /etc/sysctl.conf
   sysctl vm.swappiness=10
@@ -290,8 +300,11 @@ step_8_jeedom_customization() {
   echo '[Service]' > /lib/systemd/system/fail2ban.service.d/override.conf
   echo 'Restart=always' >> /lib/systemd/system/fail2ban.service.d/override.conf
   echo 'RestartSec=10' >> /lib/systemd/system/fail2ban.service.d/override.conf
-  systemctl daemon-reload
-  service_action restart fail2ban > /dev/null 2>&1
+
+  if [ "${INSTALLATION_TYPE}" -ne "docker" ];then
+    systemctl daemon-reload
+    service_action restart fail2ban > /dev/null 2>&1
+  fi
   
   echo "${GREEN}Step 8 - Jeedom customization done${NORMAL}"
 }
@@ -299,17 +312,21 @@ step_8_jeedom_customization() {
 step_9_jeedom_configuration() {
   echo "---------------------------------------------------------------------"
   echo "${YELLOW}Starting step 9 - Jeedom configuration${NORMAL}"
-  echo "DROP USER 'jeedom'@'localhost';" | mariadb -uroot > /dev/null 2>&1
-  mariadb_sql "CREATE USER 'jeedom'@'localhost' IDENTIFIED BY '${MARIADB_JEEDOM_PASSWD}';"
-  mariadb_sql "DROP DATABASE IF EXISTS jeedom;"
-  mariadb_sql "CREATE DATABASE jeedom;"
-  mariadb_sql "GRANT ALL PRIVILEGES ON jeedom.* TO 'jeedom'@'localhost';"
-  cp ${WEBSERVER_HOME}/core/config/common.config.sample.php ${WEBSERVER_HOME}/core/config/common.config.php
-  sed -i "s/#PASSWORD#/${MARIADB_JEEDOM_PASSWD}/g" ${WEBSERVER_HOME}/core/config/common.config.php
-  sed -i "s/#DBNAME#/jeedom/g" ${WEBSERVER_HOME}/core/config/common.config.php
-  sed -i "s/#USERNAME#/jeedom/g" ${WEBSERVER_HOME}/core/config/common.config.php
-  sed -i "s/#PORT#/3306/g" ${WEBSERVER_HOME}/core/config/common.config.php
-  sed -i "s/#HOST#/localhost/g" ${WEBSERVER_HOME}/core/config/common.config.php
+
+  if [ "${INSTALLATION_TYPE}" -ne "docker" ];then
+    echo "DROP USER 'jeedom'@'localhost';" | mariadb -uroot > /dev/null 2>&1
+    mariadb_sql "CREATE USER 'jeedom'@'localhost' IDENTIFIED BY '${MARIADB_JEEDOM_PASSWD}';"
+    mariadb_sql "DROP DATABASE IF EXISTS jeedom;"
+    mariadb_sql "CREATE DATABASE jeedom;"
+    mariadb_sql "GRANT ALL PRIVILEGES ON jeedom.* TO 'jeedom'@'localhost';"
+
+    cp ${WEBSERVER_HOME}/core/config/common.config.sample.php ${WEBSERVER_HOME}/core/config/common.config.php
+    sed -i "s/#PASSWORD#/${MARIADB_JEEDOM_PASSWD}/g" ${WEBSERVER_HOME}/core/config/common.config.php
+    sed -i "s/#DBNAME#/jeedom/g" ${WEBSERVER_HOME}/core/config/common.config.php
+    sed -i "s/#USERNAME#/jeedom/g" ${WEBSERVER_HOME}/core/config/common.config.php
+    sed -i "s/#PORT#/3306/g" ${WEBSERVER_HOME}/core/config/common.config.php
+    sed -i "s/#HOST#/localhost/g" ${WEBSERVER_HOME}/core/config/common.config.php
+  fi
   chmod 775 -R ${WEBSERVER_HOME}
   chown -R www-data:www-data ${WEBSERVER_HOME}
   echo "${GREEN}Step 9 - Jeedom configuration done${NORMAL}"
@@ -332,11 +349,15 @@ step_10_jeedom_installation() {
   mkdir -p /tmp/jeedom
   chmod 777 -R /tmp/jeedom
   chown www-data:www-data -R /tmp/jeedom
-  php ${WEBSERVER_HOME}/install/install.php mode=force
-  if [ $? -ne 0 ]; then
-    echo "${RED}Cannot install Jeedom - Cancelling${NORMAL}"
-    exit 1
+
+  if [ "${INSTALLATION_TYPE}" -ne "docker" ];then
+    php ${WEBSERVER_HOME}/install/install.php mode=force
+    if [ $? -ne 0 ]; then
+      echo "${RED}Cannot install Jeedom - Cancelling${NORMAL}"
+      exit 1
+    fi
   fi
+  
   echo "${GREEN}Step 10 - Jeedom install done${NORMAL}"
 }
 
@@ -453,7 +474,6 @@ case ${STEP} in
   fi
   step_8_jeedom_customization
  
-
   if [ ${DATABASE} -eq 1 ]; then
     step_9_jeedom_configuration
     step_10_jeedom_installation


### PR DESCRIPTION
## Description

feat: init.sh with initialisation flag file
feat: add workflow to build image, run and test with sick.php script
fix: remove sshd configuration for fail2ban
fix: dont start any service during docker image build step i.e. install.sh script exclude starting services

Je modifie le Dockerfile pour utiliser le code de la branche en cours (au lieu de download une branche $version step 6)
je fixe quelques petites erreurs dans le install.sh spécifique pour le build de l'image docker. le démarrage du container est beaucoup plus simple et rapide. et j'ajoute aussi un workflow pour build run & test l'image avec le script sick.php

Une prochaine étape sera de faire jouer les tests PHPUnit dans le container une fois lancé :) 

### Suggested changelog entry

* Docker image build improvement & optimization

### Related issues/external references


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [x] I grant the project the right to include and distribute the code under the GNU.
- [x] I have added tests to cover my changes.
- [ ] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.
