### PR TITLE
Add filter on Jeedom keywords list in scenario

### DIFF
--- a/desktop/modal/action.insert.php
+++ b/desktop/modal/action.insert.php
@@ -47,7 +47,7 @@ if (!isConnect()) {
   <option value="genericType">{{Type générique}}</option>
   <option value="changeTheme">{{Changer de thème}}</option>
 </select>
-<input id="mod_actionValue_fil" class="form-control" placeholder="{{Filtre de commandes}}">
+<input id="mod_actionValue_fil" class="form-control" placeholder="{{Filtre des commandes}}">
 <br />
 <div class="alert alert-info mod_actionValue_selDescription sleep" style="display:none;">
   {{Pause de x seconde(s)}}
@@ -180,21 +180,26 @@ if (!isConnect()) {
       document.querySelectorAll('.mod_actionValue_selDescription').unseen()
       document.querySelector('.mod_actionValue_selDescription.' + value).seen()
     })
-                                                                                      
-    document.getElementById('mod_actionValue_fil').addEventListener('keyup', function(event) {
-      const select = document.getElementById('mod_actionValue_sel')
-      const text = event.target.value
-      const options = Array.from(select.options)
-      const regex = new RegExp("^" + text, "i")
-      const lowerText = text.toLowerCase()
 
-      options.forEach(option => {
-        const optionText = option.text
-        const lowerOptionText = optionText.toLowerCase()
-        const match = optionText.match(regex)
-        const contains = lowerOptionText.indexOf(lowerText) !== -1
-        option.hidden = !(match || contains)
-      });
-    })                                                                                      
+    const select = document.getElementById('mod_actionValue_sel')
+    const input = document.getElementById('mod_actionValue_fil')
+    const allOptions = Array.from(select.options)
+                                                                                      
+    function filterOptions() {
+      const text = input.value.trim().toLowerCase().stripAccents()
+
+      select.innerHTML = ''
+
+      allOptions
+        .filter(option => {
+          const optionText = option.textContent.toLowerCase().stripAccents()
+          return text === '' || optionText.includes(text)
+        })
+        .forEach(option => {
+          select.add(option.cloneNode(true))
+        })
+    }
+                                                                                      
+    input.addEventListener('input', filterOptions)                                                                                                                        
   })()
 </script>

--- a/desktop/modal/action.insert.php
+++ b/desktop/modal/action.insert.php
@@ -47,6 +47,7 @@ if (!isConnect()) {
   <option value="genericType">{{Type générique}}</option>
   <option value="changeTheme">{{Changer de thème}}</option>
 </select>
+<input id="mod_actionValue_fil" class="form-control" placeholder="{{Filtre de commandes}}">
 <br />
 <div class="alert alert-info mod_actionValue_selDescription sleep" style="display:none;">
   {{Pause de x seconde(s)}}
@@ -179,5 +180,21 @@ if (!isConnect()) {
       document.querySelectorAll('.mod_actionValue_selDescription').unseen()
       document.querySelector('.mod_actionValue_selDescription.' + value).seen()
     })
+                                                                                      
+    document.getElementById('mod_actionValue_fil').addEventListener('keyup', function(event) {
+      const select = document.getElementById('mod_actionValue_sel')
+      const text = event.target.value
+      const options = Array.from(select.options)
+      const regex = new RegExp("^" + text, "i")
+      const lowerText = text.toLowerCase()
+
+      options.forEach(option => {
+        const optionText = option.text
+        const lowerOptionText = optionText.toLowerCase()
+        const match = optionText.match(regex)
+        const contains = lowerOptionText.indexOf(lowerText) !== -1
+        option.hidden = !(match || contains)
+      });
+    })                                                                                      
   })()
 </script>


### PR DESCRIPTION
Add filter on Jeedom keywords list in scenario

## Description
Add a scenarios list filter when adding a scenario in a scenario modification

The PR adds a filter to Jeedom keywords list when a Jeedom keyword is added in a scenario.
Only matching Jeedom keywords to the filter are visible in the list.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [x] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.
