### PR TITLE
add filters on commands list in a scenario

### DIFF
--- a/desktop/modal/cmd.human.insert.php
+++ b/desktop/modal/cmd.human.insert.php
@@ -53,9 +53,31 @@ if (!isConnect()) {
       document.getElementById('table_mod_insertCmdValue_valueEqLogicToMessage').querySelector('td.mod_insertCmdValue_object select').jeeValue(mod_insertCmd.options.object.id)
     }
 
+    function filterOptions(select, input, allOptions) {
+      const text = input.value.trim().toLowerCase().stripAccents()
+      const currentSelection = select.value
+
+      select.innerHTML = ''
+
+      allOptions
+        .filter(option => {
+          const optionText = option.textContent.toLowerCase().stripAccents()
+          return text === '' || optionText.includes(text)
+        })
+        .forEach(option => {
+          select.add(option.cloneNode(true))
+        })
+
+        const selectedOption = allOptions.find(option => option.value === currentSelection)
+        if (selectedOption && !select.querySelector(`option[value="${currentSelection}"]`)) {
+          select.add(selectedOption.cloneNode(true))
+        }
+        select.value = currentSelection
+    }
+
     mod_insertCmd.setOptions = function(_options) {
       mod_insertCmd.options = _options
-      var _selectObject = document.getElementById('table_mod_insertCmdValue_valueEqLogicToMessage').querySelector('td.mod_insertCmdValue_object select')
+      const _selectObject = document.getElementById('table_mod_insertCmdValue_valueEqLogicToMessage').querySelector('td.mod_insertCmdValue_object select')
       if (!isset(mod_insertCmd.options.cmd)) {
         mod_insertCmd.options.cmd = {}
       }
@@ -79,21 +101,12 @@ if (!isConnect()) {
           mod_insertCmd.changeObjectCmd(_selectObject, mod_insertCmd.options)
         }
       })
-    }
 
-    document.getElementById('table_mod_insertCmdValue_valueEqLogicToMessage').querySelector('td.mod_insertCmdValue_object input').addEventListener('keyup', function(event) {
-        const text = event.target.value
-        const options = Array.from(_selectObject.options)
-        const regex = new RegExp("^" + text, "i")
-        const lowerText = text.toLowerCase()
+      const input = document.getElementById('table_mod_insertCmdValue_valueEqLogicToMessage').querySelector('td.mod_insertCmdValue_object input')
+      const allOptions = Array.from(_selectObject.options)
 
-        options.forEach(option => {
-            const optionText = option.text
-            const lowerOptionText = optionText.toLowerCase()
-            const match = optionText.match(regex)
-            const contains = lowerOptionText.indexOf(lowerText) !== -1
-            option.hidden = !(match || contains)
-        });
+      input.addEventListener('input', function() {
+        filterOptions(_selectObject, input, allOptions)
       })
     }
 
@@ -143,28 +156,23 @@ if (!isConnect()) {
           }
           selectEqLogic += '</select>'
           _select.closest('tr').querySelector('.mod_insertCmdValue_eqLogic').insertAdjacentHTML('beforeend', selectEqLogic)
+          let inputEqLogic = '<input class="form-control" placeholder="{{Filtre des équipements}}">'
+          _select.closest('tr').querySelector('.mod_insertCmdValue_eqLogic').insertAdjacentHTML('beforeend', inputEqLogic)
           if (mod_insertCmd?.options?.eqLogic?.id && Array.from(_select.closest('tr').querySelectorAll('.mod_insertCmdValue_eqLogic select option')).filter(o => o.value === mod_insertCmd.options.eqLogic.id).length > 0) {
             _select.closest('tr').querySelector('.mod_insertCmdValue_eqLogic select').jeeValue(mod_insertCmd.options.eqLogic.id)
           }
           _select.closest('tr').querySelector('.mod_insertCmdValue_eqLogic select').addEventListener('change', function() {
             mod_insertCmd.changeEqLogic(this, mod_insertCmd.options)
           })
+            
+          const select = _select.closest('tr').querySelector('.mod_insertCmdValue_eqLogic select')
+          const input = _select.closest('tr').querySelector('.mod_insertCmdValue_eqLogic input')
+          const allOptions = Array.from(select.options)
 
-          _select.closest('tr').querySelector('.mod_insertCmdValue_eqLogic input').addEventListener('keyup', function(event) {
-            const select = _select.closest('tr').querySelector('.mod_insertCmdValue_eqLogic select')
-            const text = event.target.value
-            const options = Array.from(select.options)
-            const regex = new RegExp("^" + text, "i")
-            const lowerText = text.toLowerCase()
-
-            options.forEach(option => {
-              const optionText = option.text
-              const lowerOptionText = optionText.toLowerCase()
-              const match = optionText.match(regex)
-              const contains = lowerOptionText.indexOf(lowerText) !== -1
-              option.hidden = !(match || contains)
-            });
+          input.addEventListener('input', function() {
+            filterOptions(select, input, allOptions)
           })
+          
           mod_insertCmd.changeEqLogic(_select.closest('tr').querySelector('.mod_insertCmdValue_eqLogic select'), mod_insertCmd.options)
         }
       })
@@ -190,20 +198,12 @@ if (!isConnect()) {
           	let inputCmd = '<input class="form-control" placeholder="{{Filtre des commandes}}">'
             _select.closest('tr').querySelector('.mod_insertCmdValue_cmd').insertAdjacentHTML('beforeend', inputCmd)
               
-            _select.closest('tr').querySelector('.mod_insertCmdValue_cmd input').addEventListener('keyup', function(event) {
-              const select = _select.closest('tr').querySelector('.mod_insertCmdValue_cmd select')
-              const text = event.target.value
-              const options = Array.from(select.options)
-              const regex = new RegExp("^" + text, "i")
-              const lowerText = text.toLowerCase()
+            const select = _select.closest('tr').querySelector('.mod_insertCmdValue_cmd select')
+            const input = _select.closest('tr').querySelector('.mod_insertCmdValue_cmd input')
+            const allOptions = Array.from(select.options)
 
-              options.forEach(option => {
-                const optionText = option.text
-                const lowerOptionText = optionText.toLowerCase()
-                const match = optionText.match(regex)
-                const contains = lowerOptionText.indexOf(lowerText) !== -1
-                option.hidden = !(match || contains)
-              });
+            input.addEventListener('input', function() {
+              filterOptions(select, input, allOptions)
             })
           } catch (error) {}
         }

--- a/desktop/modal/cmd.human.insert.php
+++ b/desktop/modal/cmd.human.insert.php
@@ -33,6 +33,7 @@ if (!isConnect()) {
         <select class='form-control'>
           <?php echo jeeObject::getUISelectList(); ?>
         </select>
+        <input class="form-control" placeholder="{{Filtre des objets}}">
       </td>
       <td class="mod_insertCmdValue_eqLogic"></td>
       <td class="mod_insertCmdValue_cmd"></td>
@@ -80,6 +81,22 @@ if (!isConnect()) {
       })
     }
 
+    document.getElementById('table_mod_insertCmdValue_valueEqLogicToMessage').querySelector('td.mod_insertCmdValue_object input').addEventListener('keyup', function(event) {
+        const text = event.target.value
+        const options = Array.from(_selectObject.options)
+        const regex = new RegExp("^" + text, "i")
+        const lowerText = text.toLowerCase()
+
+        options.forEach(option => {
+            const optionText = option.text
+            const lowerOptionText = optionText.toLowerCase()
+            const match = optionText.match(regex)
+            const contains = lowerOptionText.indexOf(lowerText) !== -1
+            option.hidden = !(match || contains)
+        });
+      })
+    }
+
     mod_insertCmd.getValue = function() {
       let object = document.querySelector('#table_mod_insertCmdValue_valueEqLogicToMessage .mod_insertCmdValue_object > select')?.selectedOptions
       let eqlogic = document.querySelector('#table_mod_insertCmdValue_valueEqLogicToMessage .mod_insertCmdValue_eqLogic > select')?.selectedOptions
@@ -118,8 +135,8 @@ if (!isConnect()) {
         },
         success: function(eqLogics) {
           _select.closest('tr').querySelector('.mod_insertCmdValue_eqLogic').empty()
-          var selectEqLogic = '<select class="form-control">'
-          for (var i in eqLogics) {
+          let selectEqLogic = '<select class="form-control">'
+          for (let i in eqLogics) {
             if (init(mod_insertCmd.options.eqLogic.eqType_name, 'all') == 'all' || eqLogics[i].eqType_name == mod_insertCmd.options.eqLogic.eqType_name) {
               selectEqLogic += '<option value="' + eqLogics[i].id + '">' + eqLogics[i].name + '</option>'
             }
@@ -131,6 +148,22 @@ if (!isConnect()) {
           }
           _select.closest('tr').querySelector('.mod_insertCmdValue_eqLogic select').addEventListener('change', function() {
             mod_insertCmd.changeEqLogic(this, mod_insertCmd.options)
+          })
+
+          _select.closest('tr').querySelector('.mod_insertCmdValue_eqLogic input').addEventListener('keyup', function(event) {
+            const select = _select.closest('tr').querySelector('.mod_insertCmdValue_eqLogic select')
+            const text = event.target.value
+            const options = Array.from(select.options)
+            const regex = new RegExp("^" + text, "i")
+            const lowerText = text.toLowerCase()
+
+            options.forEach(option => {
+              const optionText = option.text
+              const lowerOptionText = optionText.toLowerCase()
+              const match = optionText.match(regex)
+              const contains = lowerOptionText.indexOf(lowerText) !== -1
+              option.hidden = !(match || contains)
+            });
           })
           mod_insertCmd.changeEqLogic(_select.closest('tr').querySelector('.mod_insertCmdValue_eqLogic select'), mod_insertCmd.options)
         }
@@ -154,6 +187,24 @@ if (!isConnect()) {
             selectCmd += html
             selectCmd += '</select>'
             _select.closest('tr').querySelector('.mod_insertCmdValue_cmd').insertAdjacentHTML('beforeend', selectCmd)
+          	let inputCmd = '<input class="form-control" placeholder="{{Filtre des commandes}}">'
+            _select.closest('tr').querySelector('.mod_insertCmdValue_cmd').insertAdjacentHTML('beforeend', inputCmd)
+              
+            _select.closest('tr').querySelector('.mod_insertCmdValue_cmd input').addEventListener('keyup', function(event) {
+              const select = _select.closest('tr').querySelector('.mod_insertCmdValue_cmd select')
+              const text = event.target.value
+              const options = Array.from(select.options)
+              const regex = new RegExp("^" + text, "i")
+              const lowerText = text.toLowerCase()
+
+              options.forEach(option => {
+                const optionText = option.text
+                const lowerOptionText = optionText.toLowerCase()
+                const match = optionText.match(regex)
+                const contains = lowerOptionText.indexOf(lowerText) !== -1
+                option.hidden = !(match || contains)
+              });
+            })
           } catch (error) {}
         }
       })


### PR DESCRIPTION
add filters on commands list in a scenario

## Description
Add objects, equipments, commands lists filters when adding a command in a scenario modification

The PR adds filters to objects, equipments, commands lists when a command is added in a scenario.
Only matching objects, equipments, commands to each filter are visible in the lists.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [x] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.