### PR TITLE
fix: #2751

### DIFF
--- a/core/ajax/user.ajax.php
+++ b/core/ajax/user.ajax.php
@@ -83,7 +83,7 @@ try {
 
 	if (init('action') == 'getApikey') {
 		if (!login(init('username'), init('password'), init('twoFactorCode'))) {
-			throw new Exception(__('Mot de passe ou nom d\'utilisateur incorrect'), __FILE__);
+			throw new Exception(__('Mot de passe ou nom d\'utilisateur incorrect', __FILE__));
 		}
 		ajax::success($_SESSION['user']->getHash());
 	}
@@ -229,7 +229,6 @@ try {
 		$_SESSION['user']->setLogin($login);
 		$_SESSION['user']->save();
 		@session_write_close();
-		eqLogic::clearCacheWidget();
 		ajax::success();
 	}
 


### PR DESCRIPTION
vu le bug #2726 j'en conclu qu'il faut virer le clearCacheWidget aussi J'en profite pour corriger un bug sur l'appel à la fonction __ qui demande 2 paramètres. Alors que le constructeur pour Exception se contente d'un seul :)
