### PR TITLE
Add filter in blocs selection in a scenario

### DIFF
--- a/desktop/js/scenario.js
+++ b/desktop/js/scenario.js
@@ -1612,7 +1612,28 @@ document.querySelector('.scenarioAttr[data-l1key="mode"]').addEventListener('cha
   }
 })
 
-document.getElementById('in_addElementType').addEventListener('change', function(event) {
+const select = document.getElementById('in_addElementType')
+const input = document.getElementById('in_addElementTypeFilter')
+const allOptions = Array.from(select.options)
+
+function filterOptions() {
+  const text = input.value.trim().toLowerCase().stripAccents()
+
+  select.innerHTML = ''
+
+  allOptions
+    .filter(option => {
+      const optionText = option.textContent.toLowerCase().stripAccents()
+      return text === '' || optionText.includes(text)
+    })
+    .forEach(option => {
+      select.add(option.cloneNode(true))
+    })
+}
+
+input.addEventListener('input', filterOptions) 
+
+select.addEventListener('change', function(event) {
   document.querySelectorAll('.addElementTypeDescription').unseen()
   document.querySelectorAll('.addElementTypeDescription.' + this.jeeValue()).seen()
 })
@@ -1960,6 +1981,8 @@ document.getElementById('div_editScenario').querySelector('div.floatingbar').add
         jeeP.addElementSave.elementDiv = document.getElementById('div_scenarioElement')
       }
     }
+    input.value = ''
+    input.triggerEvent('input')
     jeeDialog.modal(document.getElementById('md_addElement'))._jeeDialog.show() //=> #bt_addElementSave
     return
   }

--- a/desktop/php/scenario.php
+++ b/desktop/php/scenario.php
@@ -384,6 +384,7 @@ sendVarToJS([
 							<option value="code">{{Code}}</option>
 							<option value="comment">{{Commentaire}}</option>
 						</select>
+						<input id="in_addElementTypeFilter" class="form-control" placeholder="{{Filtre des blocs}}">
 						<br />
 						<div class="alert alert-info addElementTypeDescription if">
 							{{Permet de faire des conditions dans votre scénario. Par exemple : Si mon détecteur d’ouverture de porte se déclenche Alors allumer la lumière.}}


### PR DESCRIPTION
Add filter in blocs selection in a scenario

## Description
Add a blocs selection list filter when adding a bloc in a scenario modification

The PR adds a filter to Jeedom keywords list when a Jeedom keyword is added in a scenario.
Only matching Jeedom keywords to the filter are visible in the list.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [x] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.