### PR TITLE
Add filter in "Accueil" submenus

### DIFF
--- a/desktop/common/js/utils.js
+++ b/desktop/common/js/utils.js
@@ -778,6 +778,26 @@ jeedomUtils.setJeedomGlobalUI = function() {
   jeedomUtils.setButtonCtrlHandler('bt_showDatastoreVariable', '{{Variables}}', 'dataStore.management&type=scenario', 'jee_modal', false)
   jeedomUtils.setButtonCtrlHandler('bt_showSearching', '{{Recherche}}', 'search', 'jee_modal')
 
+  document.getElementById('bt_gotoDashboard')?.addEventListener('mouseover', function(event) {
+    document.getElementById('bt_dashboardFilter').value = ''
+    document.getElementById('dashboardClearFilter')?.dispatchEvent(new Event('click'));
+  })
+                                                                
+  document.getElementById('bt_gotoView')?.addEventListener('mouseover', function(event) {
+    document.getElementById('bt_planFilter').value = '';
+    document.getElementById('planClearFilter')?.dispatchEvent(new Event('click'));    
+  })
+
+  document.getElementById('bt_gotoPlan')?.addEventListener('mouseover', function(event) {
+    document.getElementById('bt_planFilter').value = ''
+    document.getElementById('planClearFilter')?.dispatchEvent(new Event('click'));
+  })
+
+  document.getElementById('bt_gotoPlan3d')?.addEventListener('mouseover', function(event) {
+    document.getElementById('bt_plan3DFilter').value = ''
+    document.getElementById('plan3DClearFilter')?.dispatchEvent(new Event('click'));
+  })
+
   document.getElementById('bt_gotoDashboard')?.addEventListener('click', function(event) {
     if (!getDeviceType()['type'] == 'desktop' || window.innerWidth < 768) {
       event.stopPropagation()
@@ -813,7 +833,71 @@ jeedomUtils.setJeedomGlobalUI = function() {
     }
     jeedomUtils.loadPage('index.php?v=d&p=plan3d')
   })
+  
+  function filterMenus(filterValue, ul, lis) {
+    Array.from(lis).forEach((li, index) => {
+      if (index === 0) return;
+      const liValue = li.textContent.toLowerCase().stripAccents()
+      li.style.display = liValue.indexOf(filterValue) > -1 ? '' : 'none'
+    })
+  }
 
+  document.getElementById('bt_dashboardFilter')?.addEventListener('input', function() {
+    const filterValue = this.value.toLowerCase().stripAccents()
+    const ul = document.getElementById('bt_dashboardList')
+    const lis = ul.getElementsByTagName('li')
+    
+    filterMenus(filterValue, ul, lis)
+  })
+  
+  document.getElementById('bt_viewFilter')?.addEventListener('input', function() {
+    const filterValue = this.value.toLowerCase().stripAccents()
+    const ul = document.getElementById('bt_viewList')
+    const lis = ul.getElementsByTagName('li')
+    
+    filterMenus(filterValue, ul, lis)
+  })
+  
+  document.getElementById('bt_planFilter')?.addEventListener('input', function() {
+    const filterValue = this.value.toLowerCase().stripAccents()
+    const ul = document.getElementById('bt_planList')
+    const lis = ul.getElementsByTagName('li')
+    
+    filterMenus(filterValue, ul, lis)
+  })
+  
+  document.getElementById('bt_plan3DFilter')?.addEventListener('input', function() {
+    const filterValue = this.value.toLowerCase().stripAccents()
+    const ul = document.getElementById('bt_plan3DList')
+    const lis = ul.getElementsByTagName('li')
+    
+    filterMenus(filterValue, ul, lis)
+  })
+
+  document.getElementById('dashboardClearFilter')?.addEventListener('click', function() {
+    let input = document.getElementById('bt_dashboardFilter')
+    input.value = ''
+    input.dispatchEvent(new Event('input'))
+  })
+  
+  document.getElementById('viewClearFilter')?.addEventListener('click', function() {
+    let input = document.getElementById('bt_viewFilter')
+    input.value = ''
+    input.dispatchEvent(new Event('input'))
+  })
+  
+  document.getElementById('planClearFilter')?.addEventListener('click', function() {
+    let input = document.getElementById('bt_planFilter')
+    input.value = ''
+    input.dispatchEvent(new Event('input'))
+  })
+  
+  document.getElementById('plan3DClearFilter')?.addEventListener('click', function() {
+    let input = document.getElementById('bt_plan3DFilter')
+    input.value = ''
+    input.dispatchEvent(new Event('input'))
+  })
+  
   document.getElementById('bt_jeedomAbout')?.addEventListener('click', function(event) {
     jeedomUtils.closeJeedomMenu()
     jeeDialog.dialog({

--- a/desktop/css/desktop.main.css
+++ b/desktop/css/desktop.main.css
@@ -5097,3 +5097,24 @@ div.eqLogic-widget.editingMode .panelLink {
     }
 
   }
+
+  .filter-input {
+    position: relative;
+    display: inline-block;
+  }
+  .filter-input input[type="text"] {
+    width: 100% !important;
+  }
+  .filter-input .clear-btn {
+    position: absolute;
+    right: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 20px;
+    height: 20px;
+    cursor: pointer;
+    color: gray;
+  }
+  .filter-input input[type="text"]:valid + .clear-btn {
+    display: block;
+  }

--- a/desktop/php/index.php
+++ b/desktop/php/index.php
@@ -352,8 +352,12 @@ if (config::byKey('core::jqueryless') == 1) $loadJquery = false;
 											<label class="drop-icon" for="drop-dashboard"><i class="fas fa-chevron-down fa-2x"></i></label>
 										</a>
 										<input type="checkbox" id="drop-dashboard">
-										<ul>
-											<?php
+										<ul id="bt_dashboardList">
+											<li class="filter-input">
+                                              <input type="text" id="bt_dashboardFilter" placeholder="{{Filtre des objets}}">
+                                              <span class="clear-btn" id="dashboardClearFilter"><i class="fas fa-times"></i></span>
+                                            </li>
+                                            <?php
 											$echo = '';
 											foreach ((jeeObject::buildTree(null, false)) as $object_li) {
 												$echo .= '<li><a href="index.php?v=d&p=dashboard&object_id=' . $object_li->getId() . '">' . str_repeat('&nbsp;&nbsp;', $object_li->getConfiguration('parentNumber')) . $object_li->getHumanName(true) . '</a></li>';
@@ -375,7 +379,7 @@ if (config::byKey('core::jqueryless') == 1) $loadJquery = false;
 											$echo .= '<li><a href="index.php?v=d&p=view&view_id=' . $view_menu->getId() . '">' . trim($view_menu->getDisplay('icon', '<i class="far fa-image"></i>')) . ' ' . $view_menu->getName() . '</a></li>';
 										}
 										if ($echo != '') {
-											echo '<ul>' . $echo . '</ul>';
+											echo '<ul id="bt_viewList"><li class="filter-input"><input type="text" id="bt_viewFilter" placeholder="{{Filtre des vues}}"><span class="clear-btn" id="viewClearFilter"><i class="fas fa-times"></i></span></li>' . $echo . '</ul>';
 										}
 										?>
 									</li>
@@ -392,7 +396,7 @@ if (config::byKey('core::jqueryless') == 1) $loadJquery = false;
 											$echo .= '<li><a href="index.php?v=d&p=plan&plan_id=' . $plan_menu->getId() . '">' . trim($plan_menu->getConfiguration('icon', '<i class="fas fa-paint-brush"></i>') . ' ' . $plan_menu->getName()) . '</a></li>';
 										}
 										if ($echo != '') {
-											echo '<ul>' . $echo . '</ul>';
+											echo '<ul id="bt_planList"><li class="filter-input"><input type="text" id="bt_planFilter" placeholder="{{Filtre des designs}}"><span class="clear-btn" id="planClearFilter"><i class="fas fa-times"></i></span></li>' . $echo . '</ul>';
 										}
 										?>
 									</li>
@@ -409,7 +413,7 @@ if (config::byKey('core::jqueryless') == 1) $loadJquery = false;
 											$echo .= '<li><a href="index.php?v=d&p=plan3d&plan3d_id=' . $plan3d_menu->getId() . '">' . trim($plan3d_menu->getConfiguration('icon') . ' ' . $plan3d_menu->getName()) . '</a></li>';
 										}
 										if ($echo != '') {
-											echo '<ul>' . $echo . '</ul>';
+											echo '<ul id="bt_plan3DList"><li class="filter-input"><input type="text" id="bt_plan3DFilter" placeholder="{{Filtre des designs 3D}}"><span class="clear-btn" id="plan3DClearFilter"><i class="fas fa-times"></i></span></li>' . $echo . '</ul>';
 										}
 										?>
 									</li>


### PR DESCRIPTION
Add filter in "Accueil" submenus

## Description
Add a filter when opening a submenu from the main menu "Accueil" ("Dashboard", "Vue", "Design" and "Design 3D")

The PR adds a filter to the submenus list from the main menu "Accueil".
Only matching items from the submenus to the filter are visible in the list.
Filter can be deleted with the cross.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [x] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.