### PR TITLE
fix cache exist always return true

### DIFF
--- a/core/class/cache.class.php
+++ b/core/class/cache.class.php
@@ -64,7 +64,7 @@ class cache {
 	/**
 	 *
 	 * @param string $_key
-	 * @return object
+	 * @return cache
 	 */
 	public static function byKey($_key) {
 		$cache = self::getEngine()::fetch($_key);
@@ -77,7 +77,7 @@ class cache {
 	}
 
 	public static function exist($_key){
-		return (self::byKey($_key)->getValue() !== null);
+		return (self::byKey($_key)->getValue(null) !== null);
 	}
 
 	public static function flush() {


### PR DESCRIPTION
## Description
currently, method cache::exist alway return true because getValue will return empty string by default which is different than null

problem discovered here: https://community.jeedom.com/t/warning-de-mqtt-dans-http-error/129047

### Suggested changelog entry
- fix cache management


### Related issues/external references

Fixes #


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have checked there is no other PR open for the same change.
- [X] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [X] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [ ] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.


