### PR TITLE
fix genericType insert if "all" objects

### DIFF
--- a/desktop/modal/genericType.human.insert.php
+++ b/desktop/modal/genericType.human.insert.php
@@ -112,7 +112,7 @@ $displayNone = (isset($_GET['none'])) ? $_GET['none'] : true;
     if (!genericObject || genericObject.length == 0) {
       return 'genericType(' + genericType[0].value + ')'
     }
-    if (genericObject[0].text == '-1') {
+    if (genericObject[0].value == '-1') {
       return 'genericType(' + genericType[0].value + ')'
     }
     return 'genericType(' + genericType[0].value + ',#[' + genericObject[0].text + ']#)'


### PR DESCRIPTION
## Description
Today when using genericType expression selector with object "All":
![image](https://github.com/user-attachments/assets/9416930e-08df-4089-aa25-a7a6a2cff208)
code generate this: `#genericType(BATTERY,#[Tous]#)#`
it should be `#genericType(BATTERY)#`

see https://community.jeedom.com/t/utilisation-de-generictype-opening-window/129066

### Suggested changelog entry
Fix genericType expression in scenario

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have checked there is no other PR open for the same change.
- [X] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [X] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [ ] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.


