### PR TITLE
Initialising $return to avoid a PHP notice

### DIFF
--- a/core/ajax/view.ajax.php
+++ b/core/ajax/view.ajax.php
@@ -58,6 +58,7 @@ try {
 	}
 
 	if (init('action') == 'all') {
+		$return = array();
 		$views = view::all();
 		foreach ($views as $view) {
 			if (!$view->hasRight('r')) {


### PR DESCRIPTION
## Description
Initialisation of `$return` to avoid the PHP Notice:  Undefined variable: return in /var/www/html/core/ajax/view.ajax.php on line 68


### Suggested changelog entry
- Little code impovement


### Related issues/external references

Fixes #


## Types of changes
- [x] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [x] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.

