### PR TITLE
Docker apache config port

### DIFF
--- a/install/OS_specific/Docker/init.sh
+++ b/install/OS_specific/Docker/init.sh
@@ -105,6 +105,11 @@ chmod 777 /dev/tty*
 chmod 755 -R ${WEBSERVER_HOME}
 
 echo 'Start apache2'
+if [[ "${APACHE_PORT}" != 80 ]]; then
+  echo "Port update for apache2: ${APACHE_PORT}"
+  echo "Listen ${APACHE_PORT}" > /etc/apache2/ports.conf
+  sed -i -E "s/\<VirtualHost \*:(.*)\>/VirtualHost \*:${APACHE_PORT}/" /etc/apache2/sites-available/000-default.conf
+fi
 service apache2 start
 service apache2 status
 echo 'Start CRON daemon'

--- a/install/OS_specific/Docker/init.sh
+++ b/install/OS_specific/Docker/init.sh
@@ -23,7 +23,7 @@ docker_stop(){
 	echo "${VERT}Stopping ATD gracefully${NORMAL}"
 	service atd stop
 	echo "${ROUGE}Requesting stop on init.sh${NORMAL}"
-	touch ${FILE_STOP}
+	touch "${FILE_STOP}"
 	exit 0
 }
 
@@ -32,9 +32,9 @@ set -e
 
 # $WEBSERVER_HOME and $VERSION env variables comes from Dockerfile
 
-if [[ -f ${WEBSERVER_HOME}/initialisation ]]; then
+if [[ -f "${WEBSERVER_HOME}/initialisation" ]]; then
     echo "************************
-Start JEEDOM initialisation !
+Start Jeedom initialisation !
 ************************"
 	JEEDOM_INSTALL=0
 
@@ -46,39 +46,39 @@ Start mariadb service
 	service mariadb status
 
 	DB_PASSWORD=$(cat /dev/urandom | tr -cd 'a-f0-9' | head -c 15)
-	echo "DROP USER IF EXISTS 'jeedom'@'localhost';" | mysql
-	echo  "CREATE USER 'jeedom'@'localhost' IDENTIFIED BY '${DB_PASSWORD}';" | mysql
-	echo  "DROP DATABASE IF EXISTS jeedom;" | mysql
-	echo  "CREATE DATABASE jeedom;" | mysql
-	echo  "GRANT ALL PRIVILEGES ON jeedom.* TO 'jeedom'@'localhost';" | mysql
+	echo "DROP USER IF EXISTS '${DB_USERNAME:-jeedom}'@'${DB_HOST:-localhost}';" | mysql
+	echo "CREATE USER '${DB_USERNAME:-jeedom}'@'${DB_HOST:-localhost}' IDENTIFIED BY '${DB_PASSWORD}';" | mysql
+	echo "DROP DATABASE IF EXISTS ${DB_NAME:-jeedom};" | mysql
+	echo "CREATE DATABASE ${DB_NAME:-jeedom};" | mysql
+	echo "GRANT ALL PRIVILEGES ON ${DB_NAME:-jeedom}.* TO '${DB_USERNAME:-jeedom}'@'${DB_HOST:-localhost}';" | mysql
 
-	cp ${WEBSERVER_HOME}/core/config/common.config.sample.php ${WEBSERVER_HOME}/core/config/common.config.php
-	sed -i "s/#PASSWORD#/${DB_PASSWORD}/g" ${WEBSERVER_HOME}/core/config/common.config.php
-	sed -i "s/#DBNAME#/${DB_NAME:-jeedom}/g" ${WEBSERVER_HOME}/core/config/common.config.php
-	sed -i "s/#USERNAME#/${DB_USERNAME:-jeedom}/g" ${WEBSERVER_HOME}/core/config/common.config.php
-	sed -i "s/#PORT#/${DB_PORT:-3306}/g" ${WEBSERVER_HOME}/core/config/common.config.php
-	sed -i "s/#HOST#/${DB_HOST:-localhost}/g" ${WEBSERVER_HOME}/core/config/common.config.php
+	cp "${WEBSERVER_HOME}/core/config/common.config.sample.php" "${WEBSERVER_HOME}/core/config/common.config.php"
+	sed -i "s/#PASSWORD#/${DB_PASSWORD}/g" "${WEBSERVER_HOME}/core/config/common.config.php"
+	sed -i "s/#DBNAME#/${DB_NAME:-jeedom}/g" "${WEBSERVER_HOME}/core/config/common.config.php"
+	sed -i "s/#USERNAME#/${DB_USERNAME:-jeedom}/g" "${WEBSERVER_HOME}/core/config/common.config.php"
+	sed -i "s/#PORT#/${DB_PORT:-3306}/g" "${WEBSERVER_HOME}/core/config/common.config.php"
+	sed -i "s/#HOST#/${DB_HOST:-localhost}/g" "${WEBSERVER_HOME}/core/config/common.config.php"
 
     echo "************************
-start JEEDOM PHP script installation
+Start Jeedom PHP script installation
 ************************"
 
-	php ${WEBSERVER_HOME}/install/install.php mode=force
+	php "${WEBSERVER_HOME}/install/install.php" mode=force
 	# remove the flag file after the first successfull installation
-	rm ${WEBSERVER_HOME}/initialisation
+	rm "${WEBSERVER_HOME}/initialisation"
 fi
 
-if [[ ${JEEDOM_INSTALL} == 0 ]] && [[ ! -z "${ADMIN_PASSWORD}" ]]; then
+if [[ "${JEEDOM_INSTALL}" == 0 ]] && [[ ! -z "${ADMIN_PASSWORD}" ]]; then
 	echo "Set admin password with env var"
-	php ${WEBSERVER_HOME}/core/php/jeecli.php user password admin ${ADMIN_PASSWORD}
+	php "${WEBSERVER_HOME}/core/php/jeecli.php" user password admin "${ADMIN_PASSWORD}"
 fi
 
-echo 'Start atd'
+echo "Start atd service"
 service atd restart
 service atd status
 
 if [[ $(which mysqld | wc -l) -ne 0 ]]; then
-	echo 'Starting mariadb'
+	echo "Restarting mariadb service"
 	chown -R mysql:mysql /var/lib/mysql /var/run/mysqld
 	service mariadb restart
 	if [ $? -ne 0 ]; then
@@ -89,22 +89,22 @@ if [[ $(which mysqld | wc -l) -ne 0 ]]; then
 	fi
 fi
 
-if [[ ${JEEDOM_INSTALL} == 0 ]] && [[ ! -z "${RESTOREBACKUP}" ]] && [[ "${RESTOREBACKUP}" != 'NO' ]]; then
-	echo 'Need restore backup '${RESTOREBACKUP}
-	wget ${RESTOREBACKUP} -O /tmp/backup.tar.gz
-	php ${WEBSERVER_HOME}/install/restore.php backup=/tmp/backup.tar.gz
+if [[ "${JEEDOM_INSTALL}" == 0 ]] && [[ ! -z "${RESTOREBACKUP}" ]] && [[ "${RESTOREBACKUP}" != "NO" ]]; then
+	echo "Need restore backup ${RESTOREBACKUP}"
+	wget "${RESTOREBACKUP}" -O /tmp/backup.tar.gz
+	php "${WEBSERVER_HOME}/install/restore.php backup=/tmp/backup.tar.gz"
 	rm /tmp/backup.tar.gz
-	if [[ ! -z "${UPDATEJEEDOM}" ]] && [[ "${UPDATEJEEDOM}" != 'NO' ]]; then
-		echo 'Need update jeedom'
-		php ${WEBSERVER_HOME}/install/update.php
+	if [[ ! -z "${UPDATEJEEDOM}" ]] && [[ "${UPDATEJEEDOM}" != "NO" ]]; then
+		echo "Need update Jeedom"
+		php "${WEBSERVER_HOME}/install/update.php"
 	fi
 fi
 
-echo 'All init complete'
+echo "All init complete"
 chmod 777 /dev/tty*
-chmod 755 -R ${WEBSERVER_HOME}
+chmod 755 -R "${WEBSERVER_HOME}"
 
-echo 'Start apache2'
+echo "Start apache2 service"
 if [[ "${APACHE_PORT}" != 80 ]]; then
   echo "Port update for apache2: ${APACHE_PORT}"
   echo "Listen ${APACHE_PORT}" > /etc/apache2/ports.conf
@@ -112,14 +112,15 @@ if [[ "${APACHE_PORT}" != 80 ]]; then
 fi
 service apache2 start
 service apache2 status
-echo 'Start CRON daemon'
+
+echo "Start cron daemon"
 cron
 
 # step_12_jeedom_check
-sh /tmp/install.sh -s 12 -v ${VERSION} -w ${WEBSERVER_HOME} -i docker
+sh /tmp/install.sh -s 12 -v "${VERSION}" -w "${WEBSERVER_HOME}" -i docker
 
 #TAKE CARE : the init.sh script is running under sh so trap only takes signal_number
-echo 'Add trap docker_stop'
+echo "Add trap docker_stop"
 trap "docker_stop $$ ;" 15
 
 while [[ ! -e "${FILE_STOP}" ]]; do sleep 1; done


### PR DESCRIPTION
Cette PR permet de spécifier le port de fonctionnement d'apache2 via la variable d'environnement `APACHE_PORT` lors de l'utilisation via docker + https://github.com/jeedom/core/issues/2630.

## Description
Il est parfois utile de pouvoir spécifier le port d'apache dans certain cas.
Par exemple en utilisant le mode host (`network_mode: "host"`) pour le faire fonctionner dans un NAS Synology.

C'est une demande qui a aussi été faite ici : https://github.com/jeedom/core/issues/2630

Il y a 2 commits.
Le plus important : https://github.com/jeedom/core/commit/151633c07ca11ff9bb1ef2474dfe78ee9313f5ec qui permet de rendre le port dynamique.
Le 2e, une amélioration du code du script d'init pour docker : https://github.com/jeedom/core/commit/e95f7245661430ba347c146c4a054efff86aed86


Exemple d'utilisation via `docker compose` : 
```yaml
services:
  http:
    image: jeedom/jeedom:beta
    volumes:
      - http:/var/www/html
    tmpfs:
      - /tmp/jeedom
    restart: always
    environment:
      - DB_HOST=localhost
      - DB_USERNAME=jeedom
      - DB_PASSWORD=MON_MOT_DE_PASSE_A_CHANGER
      - DB_NAME=jeedom
      - APACHE_PORT=7280	#<-- variable d'env pour le port d'apache
    network_mode: "host"
    healthcheck:
      test: ["CMD", "curl", "-fs", "-S", "--max-time", "2", "http://localhost:7280"]
      interval: 30s
      timeout: 10s
      retries: 5
volumes:
  http:
```

### Suggested changelog entry
Docker Apache port config via `APACHE_PORT`

### Related issues/external references

Fixes #
N.C.

## Types of changes
- [ ] Bug fix _(non-breaking change which fixes)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [x] I grant the project the right to include and distribute the code under the GNU.
- [ ] ~~I have added tests to cover my changes.~~
- [x] I have verified that the code complies with the projects coding standards.
- [ ] ~~[Required for new sniffs] I have added MD documentation for the sniff.~~