### PR TITLE
Add .env file for database configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ Thumbs.db
 .vscode
 ui
 composer.lock
+.env
+.env.local
 
 test.php
 core/config/common.config.php

--- a/core/config/common.config.env.php
+++ b/core/config/common.config.env.php
@@ -1,0 +1,47 @@
+<?php
+
+$envData = [] + readEnv('.env.local') + readEnv('.env');
+
+$databaseDsn = $envData['DATABASE_DSN'] ?? null;
+if (null === $databaseDsn) {
+    $configFile = __DIR__ . '/common.config.php';
+    if (!is_readable($configFile)) {
+        throw new \RuntimeException('Missing database configuration. Please set DATABASE_DSN in .env file.');
+    }
+    trigger_error(sprintf('The "%s" file is deprecated. Please use .env instead.', $configFile), E_USER_DEPRECATED);
+    require_once $configFile;
+    return;
+}
+
+define('DEBUG', (int) ($envData['DEBUG'] ?? false));
+$databaseConfig = parse_url($databaseDsn);
+foreach (['scheme', 'host', 'path', 'user', 'pass'] as $key) {
+    if (!isset($databaseConfig[$key])) {
+        throw new \RuntimeException(sprintf('Incomplete database configuration, %s is missing.', $key));
+    }
+}
+
+if ($databaseConfig['scheme'] !== 'mysql') {
+    throw new \RuntimeException(sprintf('Unsupported database configuration, %s is not supported. Please use mysql instead.', $databaseConfig['scheme']));
+}
+
+global $CONFIG;
+$CONFIG = [
+    'db' => [
+        'host' => $databaseConfig['host'],
+        'port' => (string) ($databaseConfig['port'] ?? 3306),
+        'dbname' => ltrim($databaseConfig['path'], '/'),
+        'username' => $databaseConfig['user'],
+        'password' => $databaseConfig['pass'],
+    ],
+];
+
+function readEnv(string $name): array
+{
+    $dotenv = dirname(__DIR__, 2) . '/'. $name;
+    if (!is_readable($dotenv)) {
+        return [];
+    }
+
+    return parse_ini_file($dotenv, false) ?: [];
+}

--- a/core/php/core.inc.php
+++ b/core/php/core.inc.php
@@ -17,7 +17,7 @@
 */
 date_default_timezone_set('Europe/Brussels');
 require_once __DIR__ . '/../../vendor/autoload.php';
-require_once __DIR__ . '/../config/common.config.php';
+require_once __DIR__ . '/../config/common.config.env.php';
 require_once __DIR__ . '/../class/DB.class.php';
 require_once __DIR__ . '/../class/config.class.php';
 require_once __DIR__ . '/../class/jeedom.class.php';

--- a/index.php
+++ b/index.php
@@ -16,13 +16,14 @@
 * along with Jeedom. If not, see <http://www.gnu.org/licenses/>.
 */
 try {
-	//no config, install Jeedom!
-	if (!file_exists(__DIR__ . '/core/config/common.config.php')) {
-		echo 'Jeedom not configure, no common.config.php found';
-		die();
-	}
+    require_once __DIR__ . '/core/config/common.config.env.php';
+} catch (\RuntimeException $e) {
+    echo 'Jeedom not configure, no common.config.php found';
+    die();
+}
 
-	require_once __DIR__ . "/core/php/core.inc.php";
+try {
+    require_once __DIR__ . "/core/php/core.inc.php";
 
 	if ((!isset($_GET['ajax']) || $_GET['ajax'] != 1) && count(system::ps('install/restore.php', 'sudo')) > 0) {
 			require_once __DIR__.'/restoring.php';

--- a/install/OS_specific/Docker/init.sh
+++ b/install/OS_specific/Docker/init.sh
@@ -75,7 +75,10 @@ echo 'Start init'
 
 # $WEBSERVER_HOME and $VERSION env variables comes from Dockerfile
 
-if [ -f ${WEBSERVER_HOME}/core/config/common.config.php ]; then
+if [ -f ${WEBSERVER_HOME}/.env ]; then
+	echo 'Jeedom is already install'
+	JEEDOM_INSTALL=1
+elif [ -f ${WEBSERVER_HOME}/core/config/common.config.php ]; then
 	echo 'Jeedom is already install'
 	JEEDOM_INSTALL=1
 else
@@ -95,12 +98,15 @@ else
 		echo  "DROP DATABASE IF EXISTS jeedom;" | mysql
 		echo  "CREATE DATABASE jeedom;" | mysql
 		echo  "GRANT ALL PRIVILEGES ON jeedom.* TO 'jeedom'@'localhost';" | mysql
+		# Part to remove
 		cp ${WEBSERVER_HOME}/core/config/common.config.sample.php ${WEBSERVER_HOME}/core/config/common.config.php
 		sed -i "s/#PASSWORD#/${MYSQL_JEEDOM_PASSWD}/g" ${WEBSERVER_HOME}/core/config/common.config.php
 		sed -i "s/#DBNAME#/jeedom/g" ${WEBSERVER_HOME}/core/config/common.config.php
 		sed -i "s/#USERNAME#/jeedom/g" ${WEBSERVER_HOME}/core/config/common.config.php
 		sed -i "s/#PORT#/3306/g" ${WEBSERVER_HOME}/core/config/common.config.php
 		sed -i "s/#HOST#/localhost/g" ${WEBSERVER_HOME}/core/config/common.config.php
+
+		echo "DATABASE_DSN=mysql://jeedom:${MYSQL_JEEDOM_PASSWD}@localhost/jeedom" > ${WEBSERVER_HOME}/.env
 		/root/install.sh -s 10 -v ${VERSION} -w ${WEBSERVER_HOME}
 		/root/install.sh -s 11 -v ${VERSION} -w ${WEBSERVER_HOME}
 	fi

--- a/install/backup.php
+++ b/install/backup.php
@@ -141,6 +141,8 @@ try {
 		'.gitignore',
 		'node_modules',
 		'.log',
+        '.env',
+        '.env.local',
 		'core/config/common.config.php',
 		'data/imgOs',
 		'python_venv',

--- a/install/database.php
+++ b/install/database.php
@@ -20,7 +20,7 @@
 */
 
 require_once dirname(__DIR__).'/core/php/console.php';
-require_once __DIR__ . '/../core/config/common.config.php';
+require_once __DIR__ . '/../core/config/common.config.env.php';
 require_once __DIR__ . '/../core/class/DB.class.php';
 echo "[START CHECK AND FIX DB]\n";
 try {

--- a/install/install.php
+++ b/install/install.php
@@ -28,7 +28,7 @@ $starttime = strtotime('now');
 try {
 	date_default_timezone_set('Europe/Brussels');
 	require_once __DIR__ . '/../vendor/autoload.php';
-	require_once __DIR__ . '/../core/config/common.config.php';
+	require_once __DIR__ . '/../core/config/common.config.env.php';
 	require_once __DIR__ . '/../core/class/DB.class.php';
 	require_once __DIR__ . '/../core/class/system.class.php';
 	if (count(system::ps('install/install.php', 'sudo')) > 1) {

--- a/install/install.sh
+++ b/install/install.sh
@@ -309,12 +309,15 @@ step_9_jeedom_configuration() {
     mariadb_sql "CREATE DATABASE jeedom;"
     mariadb_sql "GRANT ALL PRIVILEGES ON jeedom.* TO 'jeedom'@'localhost';"
 
+    # Path to remove
     cp ${WEBSERVER_HOME}/core/config/common.config.sample.php ${WEBSERVER_HOME}/core/config/common.config.php
     sed -i "s/#PASSWORD#/${MARIADB_JEEDOM_PASSWD}/g" ${WEBSERVER_HOME}/core/config/common.config.php
     sed -i "s/#DBNAME#/jeedom/g" ${WEBSERVER_HOME}/core/config/common.config.php
     sed -i "s/#USERNAME#/jeedom/g" ${WEBSERVER_HOME}/core/config/common.config.php
     sed -i "s/#PORT#/3306/g" ${WEBSERVER_HOME}/core/config/common.config.php
     sed -i "s/#HOST#/localhost/g" ${WEBSERVER_HOME}/core/config/common.config.php
+
+    echo "DATABASE_DSN=\"mysql://jeedom:${MARIADB_JEEDOM_PASSWD}@localhost:3306/jeedom\"" > ${WEBSERVER_HOME}/.env
   fi
   chmod 775 -R ${WEBSERVER_HOME}
   chown -R www-data:www-data ${WEBSERVER_HOME}

--- a/install/packages.php
+++ b/install/packages.php
@@ -20,7 +20,7 @@
 */
 
 require_once dirname(__DIR__).'/core/php/console.php';
-require_once __DIR__ . '/../core/config/common.config.php';
+require_once __DIR__ . '/../core/config/common.config.env.php';
 require_once __DIR__ . '/../core/class/system.class.php';
 echo "[START CHECK AND FIX PACKAGES]\n";
 try {

--- a/install/restore.php
+++ b/install/restore.php
@@ -93,7 +93,15 @@ try {
 	if (!copy(__DIR__ . '/../core/config/common.config.php', '/tmp/common.config.php')) {
 		echo 'Cannot copy ' . __DIR__ . "/../core/config/common.config.php\n";
 	}
-	
+
+    if (!copy(__DIR__ . '/../.env', '/tmp/.env')) {
+        echo 'Cannot copy ' . dirname(__DIR__) . ".env\n";
+    }
+
+    if (!copy(__DIR__ . '/../.env', '/tmp/.env.local')) {
+        echo 'Cannot copy ' . dirname(__DIR__) . ".env.local\n";
+    }
+
 	echo "OK\n";
 	
 	try {
@@ -111,6 +119,8 @@ try {
 		'.git',
 		'.log',
 		'core/config/common.config.php',
+        '.env',
+        '.env.local',
 		'/vendor',
 		config::byKey('backup::path'),
 	);
@@ -187,7 +197,19 @@ try {
 		copy('/tmp/common.config.php', __DIR__ . '/../core/config/common.config.php');
 		echo "OK\n";
 	}
-	
+
+    if (!file_exists(dirname(__DIR__) . '/.env')) {
+        echo "Restoring .env file...";
+        copy('/tmp/.env', dirname(__DIR__) . '/.env');
+        echo "OK\n";
+    }
+
+    if (!file_exists(dirname(__DIR__) . '/.env.local')) {
+        echo "Restoring .env.local file...";
+        copy('/tmp/.env.local', dirname(__DIR__) . '/.env.local');
+        echo "OK\n";
+    }
+
 	echo "Restoring cache...";
 	try {
 		cache::restore();

--- a/sick.php
+++ b/sick.php
@@ -63,12 +63,12 @@ if( !in_array( 'mysql', PDO::getAvailableDrivers())){
   echo "Driver mysql disponible.\n";
 }
 // check database configuration
-if(!file_exists(__DIR__ . '/core/config/common.config.php')){
-  echo 'Configuration manquante ! core/config/common.config.php non généré.';
-  exit(1);
+try {
+    require_once __DIR__ . '/core/config/common.config.env.php';
+} catch (\RuntimeException $e) {
+    echo 'Configuration manquante : ' . $e->getMessage();
+    exit(1);
 }
-
-require_once __DIR__ . '/core/config/common.config.php';
 
 // check local socket if localhost is configured
 if(isset($CONFIG['db']['unix_socket']) || (isset($CONFIG['db']['host']) && $CONFIG['db']['host'] == 'localhost')) {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->
Déplace la configuration de la base de donnée dans un fichier .env (surchargeable par .env.local).

<!--
Please target the `beta` branch when submitting your pull request, unless your change **only** applies to Jeedom 4.x.
-->

## Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
-->
Cette PR est rétrocompatible, on priorise le nouveau système mais accepte le fichier `/core/config/common.config.php` en renvoyant une deprecated si le fichier `.env` est absent ou ne contient pas la configuration base de donnée.

Le fichier `.env` peut contenir 2 variables d’environnement :

```ini
DEBUG=0
DATABASE_DSN=mysql://user:password@localhost:3306/database_name
```

en pratique le fichier généré par l’installation sera le suivant
```ini
DATABASE_DSN=mysql://jeedom:password@localhost:3306/jeedom
```
(La génération du fichier partie peut être retirée de la PR si besoin, cela n'aura aucune conséquence.

- Cela simplifie grandement la génération du fichier de configuration.
- On peut facilement rajouter d'autres variables utiles (ici on gère DEBUG) sans casser ou regénérer quoi que ce soit.
- On peut imaginer gérer et prendre en charge directement les variables d'environnements du serveur (variables $_ENV, $_SERVER) afin de surcharger le fichier `.env`.

### Suggested changelog entry
<!-- Please provide a short description of the change for the changelog. -->
Move database configuration in /.env file.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [x] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
