### PR TITLE
implements Psr3 LoggerInterface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,11 +3,12 @@
     "dragonmantank/cron-expression": "^3",
     "symfony/expression-language": "5 - 7",
     "pragmarx/google2fa-qrcode": "^3",
-    "bacon/bacon-qr-code": "2 - 3"
+    "bacon/bacon-qr-code": "2 - 3",
+    "psr/log": "^1.1"
   },
   "config": {
-      "allow-plugins": {
-          "php-http/discovery": true
-      }
+    "allow-plugins": {
+      "php-http/discovery": true
+    }
   }
 }

--- a/core/class/log.class.php
+++ b/core/class/log.class.php
@@ -38,6 +38,7 @@ class log extends AbstractLogger {
 		'warning' => 300,
 		'error' => 400,
 		'critical' => 500,
+		'alert' => 550,
 		'emergency' => 600
 	);
 

--- a/core/class/log.class.php
+++ b/core/class/log.class.php
@@ -19,16 +19,19 @@
 /* * ***************************Includes********************************* */
 require_once __DIR__ . '/../../core/php/core.inc.php';
 
-class log {
+use Psr\Log\AbstractLogger;
+
+class log extends AbstractLogger {
 	/*     * *************************Constantes****************************** */
 
 	const DEFAULT_MAX_LINE = 200;
 
 	/*     * *************************Attributs****************************** */
 
-	
+	private $_log_name;
+
 	private static $config = null;
- 	private static $level = array(
+	private static $level = array(
 		'debug' => 100,
 		'info'  => 200,
 		'notice' => 250,
@@ -37,6 +40,19 @@ class log {
 		'critical' => 500,
 		'emergency' => 600
 	);
+
+	public function __construct($log_name) {
+		$this->_log_name = $log_name;
+	}
+
+	/*	 * ************Methods to suport Psr\Log\AbstractLogger &  LoggerInterface  ************ */
+	public static function getLogger($_logName) {
+		return new self($_logName);
+	}
+
+	public function log($level, $message, array $context = array()) {
+		log::add($this->_log_name, $level, $message);
+	}
 
 	/*     * ***********************Methode static*************************** */
 


### PR DESCRIPTION
## Description
this pr aims to support [PSR-3: Logger Interface](https://www.php-fig.org/psr/psr-3/) hence code of plugins (or core) can inject a logger to third party librairies that support logger injection via PSR-3: Logger Interface

Usage: call log::getLogger(__CLASS__) to get a logger object that implements Psr3 LoggerInterface that you can pass ot third party libraries.
The context is not used yet but we ca potentially use it to manage param "logicalID" for example if that key is present in context but that's a "nice to have".

This does not change the way to use the logger inside jeedom (via function `log::add()`).

I've also added the "alert" log level (550) which was missing since monolog removal

### Suggested changelog entry
- jeedom log class is now implementing Psr3 LoggerInterface

### Related issues/external references

- fix issues cause by monolog removal

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes)_
- [X] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [X] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have checked there is no other PR open for the same change.
- [X] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [X] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [X] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.

