### PR TITLE
Fix: Avoid php notice "Only variables should be passed by reference

### DIFF
--- a/core/class/scenarioExpression.class.php
+++ b/core/class/scenarioExpression.class.php
@@ -1587,7 +1587,8 @@ class scenarioExpression {
 								$tags = array();
 								$args = arg2array($this->getOptions('tags'));
 								foreach ($args as $key => $value) {
-									$tags['#' . trim(trim($key), '#') . '#'] = trim(self::setTags(trim($value), $scenario), '"');
+									$value = trim($value);
+									$tags['#' . trim(trim($key), '#') . '#'] = trim(self::setTags($value, $scenario), '"');
 								}
 								$actionScenario->setTags($tags);
 							}


### PR DESCRIPTION

Fix "Only variables should be passed by reference" php notice

## Description

Fix "Only variables should be passed by reference" php notice


### Suggested changelog entry

- Suppression d'avertissement php "Only variables should be passed by reference"
- Fix "Only variables should be passed by reference" php notice


### Related issues/external references

Fixes #


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ X] I have checked there is no other PR open for the same change.
- [ X] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [X ] I grant the project the right to include and distribute the code under the GNU.
- [X ] I have added tests to cover my changes.
- [X ] I have verified that the code complies with the projects coding standards.
- [X ] [Required for new sniffs] I have added MD documentation for the sniff.
