### PR TITLE
add namespace autoloader

### DIFF
--- a/.github/workflows/phpstan.yaml
+++ b/.github/workflows/phpstan.yaml
@@ -18,7 +18,11 @@ jobs:
           php-version: 7.4
 
       - name: Install Dependencies
-        run: composer update --ignore-platform-reqs
+        run: |
+          # copy common.config.php for composer autoloader
+          cp core/config/common.config.sample.php  core/config/common.config.php 
+          # install composer dependencies
+          composer update --ignore-platform-reqs
 
       - name: Setup PHP 8.2 for PHPStan
         uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -15,5 +15,21 @@
     "platform": {
       "php": "7.4"
     }
+  },
+  "autoload": {
+    "psr-4": {
+      "Jeedom\\Core\\": "src/",
+      "Jeedom\\Plugins\\": "plugins/"
+    },
+    "files": [
+      "core/config/common.config.php",
+      "core/php/utils.inc.php",
+      "core/config/compatibility.config.php"
+    ],
+    "classmap": [
+      "core/class/",
+      "core/com/",
+      "core/repo/"
+    ]
   }
 }

--- a/core/class/log.class.php
+++ b/core/class/log.class.php
@@ -59,7 +59,11 @@ class log extends AbstractLogger {
 
 	public static function getConfig($_key, $_default = '') {
 		if (self::$config === null) {
-			self::$config = array_merge(config::getLogLevelPlugin(), config::byKeys(array('log::engine', 'log::formatter', 'log::level', 'addMessageForErrorLog', 'maxLineLog')));
+			try {
+				self::$config = array_merge(config::getLogLevelPlugin(), config::byKeys(array('log::engine', 'log::formatter', 'log::level', 'addMessageForErrorLog', 'maxLineLog')));
+			} catch (Exception $e) {
+				self::$config = array();
+			}
 		}
 		if (isset(self::$config[$_key])) {
 			return self::$config[$_key];

--- a/core/class/translate.class.php
+++ b/core/class/translate.class.php
@@ -215,7 +215,3 @@ class translate {
 
 	/*     * *********************Methode d'instance************************* */
 }
-
-function __($_content, $_name, $_backslash = false) {
-	return translate::sentence(str_replace("\'", "'", $_content), $_name, $_backslash);
-}

--- a/core/class/update.class.php
+++ b/core/class/update.class.php
@@ -360,6 +360,9 @@ class update {
 						if (file_exists($cibDir)) {
 							rrmdir($cibDir);
 						}
+						// re generate composer autoloader
+						$result = shell_exec(system::getCmdSudo() . ' composer dump-autoload --optimize --working-dir $WEBSERVER_HOME');
+						log::add(__CLASS__, 'debug', "Composer autoloader dump result:\n$result");
 					} else {
 						throw new Exception(__("Impossible de décompresser l'archive zip", __FILE__) . ' : ' . $tmp . ' => ' . ZipErrorMessage($res));
 					}

--- a/core/php/core.inc.php
+++ b/core/php/core.inc.php
@@ -17,64 +17,49 @@
 */
 date_default_timezone_set('Europe/Brussels');
 require_once __DIR__ . '/../../vendor/autoload.php';
-require_once __DIR__ . '/../config/common.config.php';
-require_once __DIR__ . '/../class/DB.class.php';
-require_once __DIR__ . '/../class/config.class.php';
-require_once __DIR__ . '/../class/jeedom.class.php';
-require_once __DIR__ . '/../class/plugin.class.php';
-require_once __DIR__ . '/../class/translate.class.php';
-require_once __DIR__ . '/utils.inc.php';
 include_file('core', 'jeedom', 'config');
-include_file('core', 'compatibility', 'config');
-include_file('core', 'utils', 'class');
-include_file('core', 'log', 'class');
 
 try {
 	$configs = config::byKeys(array('timezone', 'log::level'));
 	if (isset($configs['timezone'])) {
 		date_default_timezone_set($configs['timezone']);
 	}
-} catch (Exception $e) {
-} catch (Error $e) {
+} catch (Throwable $e) {
+    log::add('jeedom', 'error', 'Log (level|timezone) configuration failed: ' . $e->getMessage());
 }
 
 try {
 	if (isset($configs['log::level'])) {
 		log::define_error_reporting($configs['log::level']);
 	}
-} catch (Exception $e) {
-} catch (Error $e) {
+} catch (Throwable $e) {
+    log::add('jeedom', 'error', 'Log (level|timezone) configuration failed: ' . $e->getMessage());
 }
 
+/**
+ * Autoload function for specific Jeedom classes
+ * this function is called after the default Composer autoloader
+ * it will load specific classes such as Cmd, Real, etc.
+ * for plugins that do not use namespaces or Composer autoloading
+ */
 function jeedomAutoload($_classname) {
-	/* core class always in /core/class : */
-	$path = __DIR__ . "/../../core/class/$_classname.class.php";
-	if (file_exists($path)) {
-		include_file('core', $_classname, 'class');
-	} else if (substr($_classname, 0, 4) === 'com_') {
-		/* class com_$1 in /core/com/$1.com.php */
-		include_file('core', substr($_classname, 4), 'com');
-	} else if (substr($_classname, 0, 5) === 'repo_') {
-		/* class repo_$1 in /core/repo/$1.repo.php */
-		include_file('core', substr($_classname, 5), 'repo');
-	} else if (strpos($_classname, '\\') === false && strpos($_classname, '/') === false) {
-		/* autoload for plugins : no namespace */
-		$classname = str_replace(array('Real', 'Cmd'), '', $_classname);
+	if (strpos($_classname, '\\') !== false || strpos($_classname, '/') !== false) {
+	    return;
+	}
+	/* autoload for plugins : no namespace */
+	$classname = str_replace(array('Real', 'Cmd'), '', $_classname);
+	$plugin_active = config::byKey('active', $classname, null);
+	if (($plugin_active === null || $plugin_active == '' || $plugin_active == 0) && strpos($classname, '_') !== false) {
+		$classname = explode('_', $classname)[0];
 		$plugin_active = config::byKey('active', $classname, null);
-		if (($plugin_active === null || $plugin_active == '' || $plugin_active == 0) && strpos($classname, '_') !== false) {
-			$classname = explode('_', $classname)[0];
-			$plugin_active = config::byKey('active', $classname, null);
-		}
-		if ($plugin_active == 1) {
-			try {
-				include_file('core', $classname, 'class', $classname);
-			} catch (Exception $e) {
-				
-			} catch (Error $e) {
-				
-			}
+	}
+	if ($plugin_active == 1) {
+		try {
+			include_file('core', $classname, 'class', $classname);
+		} catch (Throwable $e) {
+			log::add('jeedom', 'error', 'Log (level|timezone) configuration failed: ' . $e->getMessage());
 		}
 	}
 }
 
-spl_autoload_register('jeedomAutoload', true, true);
+spl_autoload_register('jeedomAutoload');

--- a/core/php/utils.inc.php
+++ b/core/php/utils.inc.php
@@ -1839,3 +1839,10 @@ function implode_recursive($_array, $_separator, $_key = '') {
 	}
 	return $result;
 }
+
+/**
+ * alias for translate::sentence
+ */
+function __($_content, $_name, $_backslash = false) {
+	return translate::sentence(str_replace("\'", "'", $_content), $_name, $_backslash);
+}


### PR DESCRIPTION
## Description

Bonjour,
Je propose d'ajouter la gestion de namespaces **via l'autoloader de Composer**. Le namespace permet d'éviter des conflits de classes qui auraient le même nom, en particulier avec tous les plugins. Cela permettra à chaque plugin de faire ce qu'il veut dans son propre namespace. Et autre avantage, toutes les classes des plugins seront automatiquement chargées.
_En plus, la fonction autoloader est grandement simplifiée_

**classmap**: scanne automatiquement les répertoires indiqués et ajoute les classes détectées dans un autoloader `vendor/composer/autoload_classmap.php`
**files**: ajoute tous les fichiers requis sur chaque requête
**psr-4**: [comme détaillé par kwizer un peu plus bas](https://github.com/jeedom/core/pull/2910#discussion_r2347356541) ça permettra de déplacer les classes du core dans de nouvelles classes namespacées, dans /src avec un namespace `Jeedom\Core` ... Et pour chaque plugin qui le souhaite d'utiliser son propre namespace, il suffit pour cela de créer nos classe dans le namespace suivant: `Jeedom\plugins\idplugin\src` par exemple :) 

**Point d'attention:**
* dans `translate.class.php` on a une fonction en dehors de la classe (la fameuse fonction __ !! ) je la déplace donc dans utils.inc.php
* dans `files` il faut placer `utils.inc.php` avant `jeedom.config.php` car ce fichier de config utilise la fonction de traduction `__`
* l'autoloader spécifique jeedom n'est plus utile que pour la classe `*Cmd` de chaque plugin, que Composer ne voit pas forcément s'il est dans le même fichier qu'une autre classe.
* il faudrait refaire un `composer dump-autoload` pour regénérer l'autoloader après chaque installation / suppression de plugin

_Il y a encore plein de code php en dehors de toute classe, qui gagnerait à être déplacé dans de nouvelles classes. Ceci est géré par la méthode `include_file` dans `utils.inc.php` ça ne change pas._

### Suggested changelog entry
<!-- Please provide a short description of the change for the changelog. -->
migration to Composer autoloader

### Related issues/external references

Fixes #


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have checked there is no other PR open for the same change.
- [ ] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [ ] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [ ] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
