### PR TITLE
add post_market_install

### DIFF
--- a/core/class/update.class.php
+++ b/core/class/update.class.php
@@ -353,7 +353,7 @@ class update {
 							}
 						} catch (Exception $e) {
 						}
-						shell_exec('find '.$cibDir.'/ -exec touch {} +');
+						shell_exec('find ' . $cibDir . '/ -exec touch {} +');
 						rmove($cibDir . '/', __DIR__ . '/../../plugins/' . $this->getLogicalId(), false, array(), true);
 						rrmdir($cibDir);
 						$cibDir = jeedom::getTmpFolder('market') . '/' . $this->getLogicalId();
@@ -476,10 +476,11 @@ class update {
 					$this->remove();
 					throw new Exception(__("Impossible d'installer le plugin. Le nom du plugin est différent de l'ID ou le plugin n'est pas correctement formé. Veuillez contacter l'auteur", __FILE__));
 				}
+				$plugin->callInstallFunction('post_market_install');
 				if (is_object($plugin) && $plugin->isActive()) {
 					$plugin->setIsEnable(1);
 				}
-				$plugin->setCache('usedSpace',null);
+				$plugin->setCache('usedSpace', null);
 				break;
 		}
 		if (isset($_infos['localVersion'])) {


### PR DESCRIPTION
## Description
See discussion https://community.jeedom.com/t/plugin-post-installation-hook/133020

The goal is to provide a possibility from plugin to trigger a function just after the plugin download/installation but before the actual activation (which trigger the "[plugin]_install" function already).

### Suggested changelog entry
None as it only concerns plugin devs => dev doc and/or plugin-template to be updated once finalized (I will keep a reminder to do it)

### Related issues/external references

none


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes)_
- [X] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have checked there is no other PR open for the same change.
- [X] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [X] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [X] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.

