### PR TITLE
Return $this for addEvent and emptyEvent

### DIFF
--- a/core/class/listener.class.php
+++ b/core/class/listener.class.php
@@ -301,6 +301,7 @@ class listener {
 
 	public function emptyEvent() {
 		$this->event = array();
+		return $this;
 	}
 
 	public function addEvent($_id) {
@@ -313,6 +314,7 @@ class listener {
 			$event[] = '#' . $id . '#';
 		}
 		$this->setEvent($event);
+		return $this;
 	}
 
 	/*     * **********************Getteur Setteur*************************** */


### PR DESCRIPTION
# listeners addEvent & emptyEvent chaining

## Description
Return `$this` for addEvent and emptyEvent in order to be able to chain functions

### Related issues/external references

Fixes #2969


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement
