### PR TITLE
pip2 incompatibilty is not a warning

### DIFF
--- a/desktop/modal/package.check.php
+++ b/desktop/modal/package.check.php
@@ -98,7 +98,7 @@ if (count(system::ps('dpkg ')) > 0 || count(system::ps('apt ')) > 0) {
         } elseif ($info['status'] == 2) {
           $_echo .= '<td class="alert-success">OK (' . $info['alternative_found'] . ')</td>';
         } elseif ($info['status'] == 3) {
-          $_echo .= '<td class="alert-warning">{{Incompatible avec l\'OS}}</td>';
+          $_echo .= '<td class="alert-success">{{Incompatible avec l\'OS}}</td>';
         } else {
           if ($info['needUpdate']) {
             $_echo .= '<td class="alert-warning">{{Mise à jour}}</td>';


### PR DESCRIPTION
## Description
I would like to reduce number of useless questions on community.
incompatibility between python2 and os > deb10 is not an issue, it's actually ok so let's show this in green


### Suggested changelog entry
- Correction de l'écran "package"


### Related issues/external references


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [X] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have checked there is no other PR open for the same change.
- [X] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [X] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [X] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
