### PR TITLE
show update core button in table

### DIFF
--- a/desktop/js/update.js
+++ b/desktop/js/update.js
@@ -296,6 +296,8 @@ if (!jeeFrontEnd.update) {
             tr += '<a class="btn btn-warning btn-xs update disabled"><i class="fas fa-sync"></i><span class="hidden-1280"> {{Réinstaller}}</span></a> '
           }
         }
+      } else if (_update.status == 'UPDATE' && jeephp2js.showUpdate == '1') {
+        tr += '<a class="btn btn-warning btn-xs updateJeedom"><i class="fas fa-sync"></i><span class="hidden-1280"> {{Mettre à jour}}</span></a> '
       }
       if (_update.type != 'core') {
         tr += '<a class="btn btn-danger btn-xs remove"><i class="far fa-trash-alt"></i><span class="hidden-1280"> {{Supprimer}}</span></a> '
@@ -621,7 +623,7 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
     return
   }
 
-  if (_target = event.target.closest('#bt_updateJeedom')) {
+  if (_target = event.target.closest('.updateJeedom')) {
     jeeP.getUpdateModal()
     return
   }

--- a/desktop/php/update.php
+++ b/desktop/php/update.php
@@ -15,7 +15,7 @@ $showUpdate = true;
 $showUpgrade = false;
 if ($distrib == 'debian') {
 	$version = trim(strtolower(file_get_contents('/etc/debian_version')));
-	if (version_compare($version, config::byKey('os::min'),'<')) {
+	if (version_compare($version, config::byKey('os::min'), '<')) {
 		$system = strtoupper($hardware) . ' - ' . ucfirst($distrib) . ' ' . $version;
 		$showUpdate = false;
 		$alertLevel = 'alert alert-warning';
@@ -23,14 +23,15 @@ if ($distrib == 'debian') {
 			$messageAlert = '{{Votre système actuel fonctionnant correctement et n\'étant plus assez performant pour être en mesure de continuer à le faire dans les meilleures conditions à l\'avenir, nous vous invitons à ne plus mettre à jour le core de Jeedom dorénavant.}}';
 		} else {
 			$messageAlert = '{{Afin de pouvoir accéder aux futures mises à jour du core, veuillez mettre à niveau l\'environnement Linux de votre box vers}}';
-			$messageAlert .= ' <strong>Debian '.config::byKey('os::min').'</strong>.<br><em>';
+			$messageAlert .= ' <strong>Debian ' . config::byKey('os::min') . '</strong>.<br><em>';
 			if (config::byKey('doc::base_url', 'core') != '') {
-				$messageAlert .= ' {{Il est conseillé de procéder à une nouvelle installation en Debian}} '.config::byKey('os::min').' {{puis de restaurer votre dernière sauvegarde Jeedom plutôt que mettre directement à jour l\'OS en ligne de commande. Consulter}} <a href="' . config::byKey('doc::base_url', 'core') . '/fr_FR/installation/#Installation" target="_blank">{{la documentation d\'installation}}</a> {{pour plus d\'informations.}}' . '</em>';
+				$messageAlert .= ' {{Il est conseillé de procéder à une nouvelle installation en Debian}} ' . config::byKey('os::min') . ' {{puis de restaurer votre dernière sauvegarde Jeedom plutôt que mettre directement à jour l\'OS en ligne de commande. Consulter}} <a href="' . config::byKey('doc::base_url', 'core') . '/fr_FR/installation/#Installation" target="_blank">{{la documentation d\'installation}}</a> {{pour plus d\'informations.}}' . '</em>';
 			}
 		}
 		echo '<div class="col-xs-12 text-center ' . $alertLevel . '"><strong>' . $system . '</strong><br>' . $messageAlert . '</div>';
 	}
 }
+sendVarToJS('jeephp2js.showUpdate', $showUpdate);
 $logUpdate = log::getLastLine('update');
 if (strpos($logUpdate, 'END UPDATE') || count(system::ps('install/update.php', 'sudo')) == 0) {
 	sendVarToJS('jeephp2js.isUpdating', '0');
@@ -47,7 +48,7 @@ if (strpos($logUpdate, 'END UPDATE') || count(system::ps('install/update.php', '
 			<span class="input-group-btn">
 				<a class="btn btn-info btn-sm roundedLeft" id="bt_checkAllUpdate"><i class="fas fa-sync"></i> {{Vérifier les mises à jour}}
 				</a><a class="btn btn-success btn-sm" id="bt_saveUpdate"><i class="fas fa-check-circle"></i> {{Sauvegarder}}
-				</a><?php if ($showUpdate == true) { ?><a href="#" class="btn btn-sm btn-warning roundedRight" id="bt_updateJeedom"><i class="fas fa-check"></i> {{Mettre à jour}}
+				</a><?php if ($showUpdate == true) { ?><a href="#" class="btn btn-sm btn-warning roundedRight updateJeedom"><i class="fas fa-check"></i> {{Mettre à jour}}
 					</a><?php } ?>
 			</span>
 		</div>


### PR DESCRIPTION
## Description
This will display the "update core" button in the table if there are core update available.
The action on the button is exactly the same than the top right button

Goal is to reduce number of question of people that does not find the button in the top right corner.


### Suggested changelog entry
Add update core button in the list of update


### Related issues/external references

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have checked there is no other PR open for the same change.
- [X] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [X] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [X] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.

