### PR TITLE
cmd event default value to 0

### DIFF
--- a/core/class/cmd.class.php
+++ b/core/class/cmd.class.php
@@ -1856,7 +1856,7 @@ class cmd {
 		return $template;
 	}
 
-	public function event($_value, $_datetime = null, $_loop = 1) {
+	public function event($_value = 0, $_datetime = null, $_loop = 1) {
 		if ($_loop > 4 || $this->getType() != 'info') {
 			return;
 		}


### PR DESCRIPTION
## Description
Set a default value (`0`) for `$cmd->event()` function

### Related issues/external references

Fixes #2989

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement
