### PR TITLE
[BUGFIX] Refreshing battery widget on eqAnalyse page

### DIFF
--- a/core/class/eqLogic.class.php
+++ b/core/class/eqLogic.class.php
@@ -639,7 +639,7 @@ class eqLogic {
 		}
 		$classAttr = $level . ' ' . $battery . ' ' . $plugins . ' ' . $object_name;
 		$idAttr = $level . '__' . $battery . '__' . $plugins . '__' . $object_name;
-		$html .= '<div class="eqLogic eqLogic-widget text-center ' . $classAttr . '" id="' . $idAttr . '" data-eqlogic_id="' . $this->getId() . '">';
+		$html .= '<div class="eqLogic eqLogic-widget battery-widget text-center ' . $classAttr . '" id="' . $idAttr . '" data-eqlogic_id="' . $this->getId() . '">';
 
 		$eqName = $this->getName();
 		if ($_version == 'mobile') {

--- a/core/js/eqLogic.class.js
+++ b/core/js/eqLogic.class.js
@@ -472,6 +472,7 @@ jeedom.eqLogic.refreshValue = function(_params) {
 
     eqLogics[_params[i].eqLogic_id] = {
       eqLogic: eqLogic,
+      type: eqLogic?.classList.contains('battery-widget') ? 'battery' : 'default'
     }
     sends[_params[i].eqLogic_id] = {
       version: ((version = eqLogic?.getAttribute('data-version')) != undefined) ? version : 'dashboard'
@@ -490,6 +491,9 @@ jeedom.eqLogic.refreshValue = function(_params) {
       for (var i in result) {
         tile = domUtils.parseHTML(result[i].html)
         if (tile.childNodes.length == 0) {
+          continue
+        }
+        if (eqLogics[i].type === 'battery') {
           continue
         }
         eqLogic = eqLogics[i].eqLogic


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->
On eqAnalyse page, when eqLogic are refreshed in alertEqlogic tab it also affects eqLogic in battery tab.

![Jan-04-2025 18-31-30](https://github.com/user-attachments/assets/814e51e5-7e98-4d81-83b3-e046f7da17d8)

So, battery widget is replaced by toHtml widget.
To reproduce, stay on Battery tab and wait for the update event to refresh eqLogic.

<!--Please target the `beta` branch when submitting your pull request, unless your change **only** applies to Jeedom 4.x.
-->

## Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
-->
I just added a class for battery widget, and use it to not refresh eqLogic on refreshValue.

Extend fix : But I think it would be wiser to refresh those battery widgets with js function htmlBattery, don't you think? 

### Suggested changelog entry
<!-- Please provide a short description of the change for the changelog. -->
- Fix battery refresh on eqAnalyse page

### Related issues/external references

Fixes #


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [x] I grant the project the right to include and distribute the code under the GNU.
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
