### PR TITLE
Traduction : Exit from full screen

### DIFF
--- a/core/i18n/de_DE.json
+++ b/core/i18n/de_DE.json
@@ -3598,7 +3598,7 @@
         "Valider": "Validate",
         "Annuler": "Abbrechen",
         "Sélectionner la commande": "Befehl auswählen"
-		"Sortir du plein écran": "Sortir du plein écran"
+	"Sortir du plein écran": "Sortir du plein écran"
     },
     "core\/js\/dataStore.class.js": {
         "Sélectionner une variable": "Wählen Sie eine Variable aus",

--- a/core/i18n/de_DE.json
+++ b/core/i18n/de_DE.json
@@ -3598,6 +3598,7 @@
         "Valider": "Validate",
         "Annuler": "Abbrechen",
         "Sélectionner la commande": "Befehl auswählen"
+		"Sortir du plein écran": "Sortir du plein écran"
     },
     "core\/js\/dataStore.class.js": {
         "Sélectionner une variable": "Wählen Sie eine Variable aus",

--- a/core/i18n/en_US.json
+++ b/core/i18n/en_US.json
@@ -3598,6 +3598,7 @@
         "Valider": "Ok",
         "Annuler": "Cancel",
         "Sélectionner la commande": "Select command"
+		"Sortir du plein écran": "Exit from full screen"
     },
     "core\/js\/dataStore.class.js": {
         "Sélectionner une variable": "Select a variable",

--- a/core/i18n/en_US.json
+++ b/core/i18n/en_US.json
@@ -3598,7 +3598,7 @@
         "Valider": "Ok",
         "Annuler": "Cancel",
         "Sélectionner la commande": "Select command"
-		"Sortir du plein écran": "Exit from full screen"
+	"Sortir du plein écran": "Exit from full screen"
     },
     "core\/js\/dataStore.class.js": {
         "Sélectionner une variable": "Select a variable",

--- a/core/i18n/es_ES.json
+++ b/core/i18n/es_ES.json
@@ -3598,6 +3598,7 @@
         "Valider": "Validar",
         "Annuler": "Cancelar",
         "Sélectionner la commande": "Seleccione el comando"
+		"Sortir du plein écran": "Sortir du plein écran"
     },
     "core\/js\/dataStore.class.js": {
         "Sélectionner une variable": "Seleccionar una variable",

--- a/core/i18n/es_ES.json
+++ b/core/i18n/es_ES.json
@@ -3598,7 +3598,7 @@
         "Valider": "Validar",
         "Annuler": "Cancelar",
         "Sélectionner la commande": "Seleccione el comando"
-		"Sortir du plein écran": "Sortir du plein écran"
+	"Sortir du plein écran": "Sortir du plein écran"
     },
     "core\/js\/dataStore.class.js": {
         "Sélectionner une variable": "Seleccionar una variable",

--- a/core/i18n/fr_FR.json
+++ b/core/i18n/fr_FR.json
@@ -3598,6 +3598,7 @@
         "Valider": "Valider",
         "Annuler": "Annuler",
         "Sélectionner la commande": "Sélectionner la commande"
+		"Sortir du plein écran": "Sortir du plein écran"
     },
     "core\/js\/dataStore.class.js": {
         "Sélectionner une variable": "Sélectionner une variable",

--- a/core/i18n/fr_FR.json
+++ b/core/i18n/fr_FR.json
@@ -3598,7 +3598,7 @@
         "Valider": "Valider",
         "Annuler": "Annuler",
         "Sélectionner la commande": "Sélectionner la commande"
-		"Sortir du plein écran": "Sortir du plein écran"
+	"Sortir du plein écran": "Sortir du plein écran"
     },
     "core\/js\/dataStore.class.js": {
         "Sélectionner une variable": "Sélectionner une variable",

--- a/core/i18n/id_ID.json
+++ b/core/i18n/id_ID.json
@@ -3598,6 +3598,7 @@
         "Valider": "Mengesahkan",
         "Annuler": "Tidak jadi",
         "Sélectionner la commande": "Pilih perintah"
+		"Sortir du plein écran": "Sortir du plein écran"
     },
     "core\/js\/dataStore.class.js": {
         "Sélectionner une variable": "Pilih variabel",

--- a/core/i18n/id_ID.json
+++ b/core/i18n/id_ID.json
@@ -3598,7 +3598,7 @@
         "Valider": "Mengesahkan",
         "Annuler": "Tidak jadi",
         "Sélectionner la commande": "Pilih perintah"
-		"Sortir du plein écran": "Sortir du plein écran"
+	"Sortir du plein écran": "Sortir du plein écran"
     },
     "core\/js\/dataStore.class.js": {
         "Sélectionner une variable": "Pilih variabel",

--- a/core/i18n/it_IT.json
+++ b/core/i18n/it_IT.json
@@ -3598,7 +3598,7 @@
         "Valider": "Convalidare",
         "Annuler": "Cancella",
         "Sélectionner la commande": "Seleziona comando"
-		"Sortir du plein écran": "Sortir du plein écran"
+	"Sortir du plein écran": "Sortir du plein écran"
     },
     "core\/js\/dataStore.class.js": {
         "Sélectionner une variable": "Seleziona una variabile",

--- a/core/i18n/it_IT.json
+++ b/core/i18n/it_IT.json
@@ -3598,6 +3598,7 @@
         "Valider": "Convalidare",
         "Annuler": "Cancella",
         "Sélectionner la commande": "Seleziona comando"
+		"Sortir du plein écran": "Sortir du plein écran"
     },
     "core\/js\/dataStore.class.js": {
         "Sélectionner une variable": "Seleziona una variabile",

--- a/core/i18n/ja_JP.json
+++ b/core/i18n/ja_JP.json
@@ -3598,6 +3598,7 @@
         "Valider": "検証",
         "Annuler": "キャンセル",
         "Sélectionner la commande": "コマンドを選択"
+		"Sortir du plein écran": "Sortir du plein écran"
     },
     "core\/js\/dataStore.class.js": {
         "Sélectionner une variable": "変数を選択してください",

--- a/core/i18n/ja_JP.json
+++ b/core/i18n/ja_JP.json
@@ -3598,7 +3598,7 @@
         "Valider": "検証",
         "Annuler": "キャンセル",
         "Sélectionner la commande": "コマンドを選択"
-		"Sortir du plein écran": "Sortir du plein écran"
+	"Sortir du plein écran": "Sortir du plein écran"
     },
     "core\/js\/dataStore.class.js": {
         "Sélectionner une variable": "変数を選択してください",

--- a/core/i18n/pt_PT.json
+++ b/core/i18n/pt_PT.json
@@ -3598,6 +3598,7 @@
         "Valider": "Confirmar",
         "Annuler": "Cancelar",
         "Sélectionner la commande": "Selecione o comando"
+		"Sortir du plein écran": "Sortir du plein écran"
     },
     "core\/js\/dataStore.class.js": {
         "Sélectionner une variable": "Selecione uma variável",

--- a/core/i18n/pt_PT.json
+++ b/core/i18n/pt_PT.json
@@ -3598,7 +3598,7 @@
         "Valider": "Confirmar",
         "Annuler": "Cancelar",
         "Sélectionner la commande": "Selecione o comando"
-		"Sortir du plein écran": "Sortir du plein écran"
+	"Sortir du plein écran": "Sortir du plein écran"
     },
     "core\/js\/dataStore.class.js": {
         "Sélectionner une variable": "Selecione uma variável",

--- a/core/i18n/ru_RU.json
+++ b/core/i18n/ru_RU.json
@@ -3598,6 +3598,7 @@
         "Valider": "Validate",
         "Annuler": "Отменить",
         "Sélectionner la commande": "Выберите команду"
+		"Sortir du plein écran": "Sortir du plein écran"
     },
     "core\/js\/dataStore.class.js": {
         "Sélectionner une variable": "Выберите переменную",

--- a/core/i18n/ru_RU.json
+++ b/core/i18n/ru_RU.json
@@ -3598,7 +3598,7 @@
         "Valider": "Validate",
         "Annuler": "Отменить",
         "Sélectionner la commande": "Выберите команду"
-		"Sortir du plein écran": "Sortir du plein écran"
+	"Sortir du plein écran": "Sortir du plein écran"
     },
     "core\/js\/dataStore.class.js": {
         "Sélectionner une variable": "Выберите переменную",

--- a/core/i18n/tr.json
+++ b/core/i18n/tr.json
@@ -3598,6 +3598,7 @@
         "Valider": "Onaylayın",
         "Annuler": "Iptal et",
         "Sélectionner la commande": "Komutayı seçin"
+		"Sortir du plein écran": "Sortir du plein écran"
     },
     "core\/js\/dataStore.class.js": {
         "Sélectionner une variable": "Değişken seçin",

--- a/core/i18n/tr.json
+++ b/core/i18n/tr.json
@@ -3598,7 +3598,7 @@
         "Valider": "Onaylayın",
         "Annuler": "Iptal et",
         "Sélectionner la commande": "Komutayı seçin"
-		"Sortir du plein écran": "Sortir du plein écran"
+	"Sortir du plein écran": "Sortir du plein écran"
     },
     "core\/js\/dataStore.class.js": {
         "Sélectionner une variable": "Değişken seçin",

--- a/core/js/jeedom.class.js
+++ b/core/js/jeedom.class.js
@@ -155,7 +155,7 @@ jeedom.init = function() {
       downloadXLS: '{{Téléchargement XLS}}',
       printChart: '{{Imprimer}}',
       viewFullscreen: '{{Plein écran}}',
-	  exitFullscreen: '{{Sortir du plein écran}}',
+      exitFullscreen: '{{Sortir du plein écran}}',
     },
     colors: [
       cssComputedStyle.getPropertyValue('--al-info-color'),

--- a/core/js/jeedom.class.js
+++ b/core/js/jeedom.class.js
@@ -155,6 +155,7 @@ jeedom.init = function() {
       downloadXLS: '{{Téléchargement XLS}}',
       printChart: '{{Imprimer}}',
       viewFullscreen: '{{Plein écran}}',
+	  exitFullscreen: '{{Sortir du plein écran}}',
     },
     colors: [
       cssComputedStyle.getPropertyValue('--al-info-color'),


### PR DESCRIPTION
Traduction du texte 'Exit from full screen' sur la page historique.

## Description
Sur la page historique quand le mode plein écran est activé.
Pour sortir du mode plein écran le texte 'Exit from full screen' apparait et n'est pas traduit en fonction de la langue.
Vu sur la version 4.4.19.
La traduction du texte a été faite uniquement pour le français et l'anglais. Dans les autres langues, la traduction a été ajouté mais le texte est en français comme pour certain autre traduction déjà présente.


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have checked there is no other PR open for the same change.
- [ ] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [ ] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [ ] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.