### PR TITLE
fix: do not exclude all folders named "log"

### DIFF
--- a/install/backup.php
+++ b/install/backup.php
@@ -77,7 +77,7 @@ try {
 		}
 	}
 
-	
+
 	if (isset($CONFIG['db']['unix_socket'])) {
 		$str_db_connexion = "--socket=" . $CONFIG['db']['unix_socket'] . " --user=" . $CONFIG['db']['username'] . " --password='" . $CONFIG['db']['password'] . "' " . $CONFIG['db']['dbname'];
 	} else {
@@ -90,14 +90,14 @@ try {
 	$tables = DB::Prepare("SHOW TABLES", array(), DB::FETCH_TYPE_ALL);
 	foreach ($tables as $table) {
 		$table = array_values($table)[0];
-		if($table == 'event'){
+		if ($table == 'event') {
 			continue;
 		}
-		echo "Checking  table ".$table."...";
-		system("mysqlcheck " . $str_db_connexion . ' --auto-repair --silent --tables '.$table);
+		echo "Checking  table " . $table . "...";
+		system("mysqlcheck " . $str_db_connexion . ' --auto-repair --silent --tables ' . $table);
 		echo "OK" . "\n";
 	}
-	
+
 	echo 'Backing up database...';
 	if (file_exists($jeedom_dir . "/DB_backup.sql")) {
 		unlink($jeedom_dir . "/DB_backup.sql");
@@ -109,7 +109,7 @@ try {
 		throw new Exception('can\'t delete database backup. Check rights');
 	}
 	system("mysqldump " . $str_db_connexion . "  > " . $jeedom_dir . "/DB_backup.sql", $rc);
-	
+
 	if ($rc != 0) {
 		throw new Exception('Backing up database failed. Check mysqldump installation. Code: ' . $rc);
 	}
@@ -130,7 +130,7 @@ try {
 
 	$excludes = array(
 		'tmp',
-		'log',
+		'./log',
 		'docs',
 		'doc',
 		'tests',
@@ -195,10 +195,10 @@ try {
 			if ($value['scope']['backup'] === false) {
 				continue;
 			}
-			if (config::byKey($key . '::enable','core',0) == 0) {
+			if (config::byKey($key . '::enable', 'core', 0) == 0) {
 				continue;
 			}
-			if (config::byKey($key . '::cloudUpload','core',0) == 0) {
+			if (config::byKey($key . '::cloudUpload', 'core', 0) == 0) {
 				continue;
 			}
 			$class = 'repo_' . $key;


### PR DESCRIPTION
## Description

Currently all folders named "log" are excluded from backup but this break plugin installation if they have such folder; 
exemple if they have composer dependency "psr/log", which are not log files, corresponding code won't be included in the backup breaking the plugin: see case https://community.jeedom.com/t/failed-to-open-stream-docker-jeedom-jeedom-latest/136762/13

Goal of this change is to exclude only the log folder on the root of jeedom installation, the one actually containing log files

### Suggested changelog entry
Correction de bug


### Related issues/external references

Fixes #


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have checked there is no other PR open for the same change.
- [X] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [X] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [X] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.
