### PR TITLE
Fix eqlogic delete confirmation

### DIFF
--- a/core/ajax/eqLogic.ajax.php
+++ b/core/ajax/eqLogic.ajax.php
@@ -25,8 +25,8 @@ try {
 	}
 
 	ajax::init(array('uploadImage'));
-  
-  	if (init('action') == 'uploadImage') {
+
+	if (init('action') == 'uploadImage') {
 		if (!isConnect('admin')) {
 			throw new Exception(__('401 - Accès non autorisé', __FILE__));
 		}
@@ -422,6 +422,10 @@ try {
 			}
 			if (count($cmdData['node']) > 0) {
 				foreach ($cmdData['node'] as $name => $data) {
+					if (cmd::byId(str_replace('cmd', '', $data['id']))->getEqLogic_id() == $eqLogic->getId()) {
+						continue;
+					}
+
 					$data['sourceName'] = $cmd->getName();
 					$used[$name . $cmd->getName()] = $data;
 				}

--- a/core/ajax/eqLogic.ajax.php
+++ b/core/ajax/eqLogic.ajax.php
@@ -408,6 +408,9 @@ try {
 		if (isset($used['eqLogic' . $eqLogic->getId()])) {
 			unset($used['eqLogic' . $eqLogic->getId()]);
 		}
+		if (isset($used['object' . $eqLogic->getObject_id()])) {
+			unset($used['object' . $eqLogic->getObject_id()]);
+		}
 		foreach (($eqLogic->getCmd()) as $cmd) {
 			if (isset($used['cmd' . $cmd->getId()])) {
 				unset($used['cmd' . $cmd->getId()]);

--- a/core/ajax/eqLogic.ajax.php
+++ b/core/ajax/eqLogic.ajax.php
@@ -416,7 +416,7 @@ try {
 				unset($used['cmd' . $cmd->getId()]);
 			}
 			$cmdData = array('node' => array(), 'link' => array());
-			$cmdData = $cmd->getLinkData($cmdData, 0, 2);
+			$cmdData = $cmd->getLinkData($cmdData, 0, 2, null, false);
 			if (isset($cmdData['node']['eqLogic' . $eqLogic->getId()])) {
 				unset($cmdData['node']['eqLogic' . $eqLogic->getId()]);
 			}

--- a/core/class/cmd.class.php
+++ b/core/class/cmd.class.php
@@ -992,10 +992,10 @@ class cmd {
 			$_value = 0;
 		}
 		if (trim($_value) == '' && $_value !== false && $_value !== 0) {
-			if($this->getSubType() == 'numeric'){
+			if ($this->getSubType() == 'numeric') {
 				return 0;
 			}
-			if($this->getSubType() == 'binary'){
+			if ($this->getSubType() == 'binary') {
 				return 0;
 			}
 			return '';
@@ -2812,7 +2812,7 @@ class cmd {
 		return $return;
 	}
 
-	public function getLinkData(&$_data = array('node' => array(), 'link' => array()), $_level = 0, $_drill = null) {
+	public function getLinkData(&$_data = array('node' => array(), 'link' => array()), $_level = 0, $_drill = null, $_include_use = true) {
 		if ($_drill === null) {
 			$_drill = config::byKey('graphlink::cmd::drill');
 		}
@@ -2838,7 +2838,6 @@ class cmd {
 			'url' => $this->getEqLogic()->getLinkToConfiguration(),
 		);
 		$usedBy = $this->getUsedBy();
-		$use = $this->getUse();
 		addGraphLink($this, 'cmd', $usedBy['scenario'], 'scenario', $_data, $_level, $_drill);
 		foreach ($usedBy['plugin'] as $key => $value) {
 			addGraphLink($this, 'cmd', $value, $key, $_data, $_level, $_drill);
@@ -2849,10 +2848,13 @@ class cmd {
 		addGraphLink($this, 'cmd', $usedBy['plan'], 'plan', $_data, $_level, $_drill, array('dashvalue' => '2,6', 'lengthfactor' => 0.6));
 		addGraphLink($this, 'cmd', $usedBy['plan3d'], 'plan3d', $_data, $_level, $_drill, array('dashvalue' => '2,6', 'lengthfactor' => 0.6));
 		addGraphLink($this, 'cmd', $usedBy['view'], 'view', $_data, $_level, $_drill, array('dashvalue' => '2,6', 'lengthfactor' => 0.6));
-		addGraphLink($this, 'cmd', $use['scenario'], 'scenario', $_data, $_level, $_drill);
-		addGraphLink($this, 'cmd', $use['eqLogic'], 'eqLogic', $_data, $_level, $_drill);
-		addGraphLink($this, 'cmd', $use['cmd'], 'cmd', $_data, $_level, $_drill);
-		addGraphLink($this, 'cmd', $use['dataStore'], 'dataStore', $_data, $_level, $_drill);
+		if ($_include_use) {
+			$use = $this->getUse();
+			addGraphLink($this, 'cmd', $use['scenario'], 'scenario', $_data, $_level, $_drill);
+			addGraphLink($this, 'cmd', $use['eqLogic'], 'eqLogic', $_data, $_level, $_drill);
+			addGraphLink($this, 'cmd', $use['cmd'], 'cmd', $_data, $_level, $_drill);
+			addGraphLink($this, 'cmd', $use['dataStore'], 'dataStore', $_data, $_level, $_drill);
+		}
 		addGraphLink($this, 'cmd', $this->getEqLogic(), 'eqLogic', $_data, $_level, $_drill, array('dashvalue' => '1,0', 'lengthfactor' => 0.6));
 		return $_data;
 	}
@@ -2860,7 +2862,7 @@ class cmd {
 	public function getUsedBy($_array = false) {
 		$return = array('cmd' => array(), 'eqLogic' => array(), 'scenario' => array(), 'plan' => array(), 'view' => array());
 		$cmds = array_merge(self::searchConfiguration('#' . $this->getId() . '#'), cmd::byValue($this->getId()));
-		if(is_array($cmds) && count($cmds) > 0){
+		if (is_array($cmds) && count($cmds) > 0) {
 			foreach ($cmds as $cmd) {
 				$return['cmd'][$cmd->getId()] = $cmd;
 			}

--- a/core/js/plugin.template.js
+++ b/core/js/plugin.template.js
@@ -411,7 +411,7 @@ if (!jeeFrontEnd.pluginTemplate) {
           success: function(data) {
             var text = '{{Êtes-vous sûr de vouloir supprimer l\'équipement}} ' + textEqtype + ' <b>' + document.querySelector('.eqLogicAttr[data-l1key="name"]').jeeValue() + '</b> ?'
             if (Object.keys(data).length > 0) {
-              text += ' </br> {{Il est utilisé par ou utilise :}}</br>'
+              text += ' </br> {{Il est utilisé par:}}</br>'
               var complement = null
               for (var i in data) {
                 complement = ''


### PR DESCRIPTION
## Description
Today, when we delete an eqLogic we see a confirmation prompt displaying too much data. 
To my understanding, this prompt is supposed to warn user in case the eqLogic is (actually) used somewhere in Jeedom to prevent futur orphans.
The issues are:
- we see command from the eqLogic itself (in case an action command is linked to an info command of the same eqLogic)
- we see the current object owning the eqLogic
- we see commands that current eqLogic is using (mostly the case for virtual but could be the case for others as well)

example with a virtual in which I copied a eqLogic from sonos:
![image](https://github.com/user-attachments/assets/c1839451-c63b-49e2-b6b1-1450c46287f7)

while I expect to not see any warning if I delete it (because the deletion will not bring any issue); example after this PR:
![image](https://github.com/user-attachments/assets/7a63f1a4-b4ab-4d9a-8978-3aa3167c4757)

Of course, if I try to delete the "source" eqLogic (from sonos plugin in my example), I still see the full list of commands (the one from virtual eqLogic:
![image](https://github.com/user-attachments/assets/5053c4bb-6987-443d-9430-18cc14b768a7)


### Suggested changelog entry
Amélioration du message de confirmation d'un eqLogic


### Related issues/external references

Fixes #


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have checked there is no other PR open for the same change.
- [X] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [X] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [X] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.
