### PR TITLE
Random network check

### DIFF
--- a/core/class/jeedom.class.php
+++ b/core/class/jeedom.class.php
@@ -1079,13 +1079,6 @@ class jeedom {
 
 	public static function cron10() {
 		try {
-			network::cron10();
-		} catch (Exception $e) {
-			log::add('network', 'error', 'network::cron : ' . log::exception($e));
-		} catch (Error $e) {
-			log::add('network', 'error', 'network::cron : ' . log::exception($e));
-		}
-		try {
 			foreach ((update::listRepo()) as $name => $repo) {
 				$class = 'repo_' . $name;
 				if (class_exists($class) && method_exists($class, 'cron10') && config::byKey($name . '::enable') == 1) {

--- a/docs/fr_FR/changelog.md
+++ b/docs/fr_FR/changelog.md
@@ -84,6 +84,7 @@
 - Ajout d'un bouton de mise à jour sur la ligne "core" en plus de celui en haut à droite [LIEN](https://github.com/jeedom/core/pull/2974)
 - Correction de l'écran "package" au niveau des packages python2 [LIEN](https://github.com/jeedom/core/pull/2973)
 - Correction d'un bug lors de la mise à jour des équipements sur la page de batterie [LIEN](https://github.com/jeedom/core/pull/3008)
+- La verification de la connexion réseaux est maintenant aléatoire toute les 10min pour eviter des soucis de reconnexion de toute les box Jeedom en meme temps lors de micro coupure
 
 >**IMPORTANT**
 >

--- a/docs/fr_FR/changelog.md
+++ b/docs/fr_FR/changelog.md
@@ -84,7 +84,7 @@
 - Ajout d'un bouton de mise à jour sur la ligne "core" en plus de celui en haut à droite [LIEN](https://github.com/jeedom/core/pull/2974)
 - Correction de l'écran "package" au niveau des packages python2 [LIEN](https://github.com/jeedom/core/pull/2973)
 - Correction d'un bug lors de la mise à jour des équipements sur la page de batterie [LIEN](https://github.com/jeedom/core/pull/3008)
-- La verification de la connexion réseaux est maintenant aléatoire toute les 10min pour eviter des soucis de reconnexion de toute les box Jeedom en meme temps lors de micro coupure
+- La vérification de la connexion réseau est désormais effectuée de manière aléatoire toutes les 10 minutes afin d'éviter que toutes les box Jeedom ne tentent de se reconnecter simultanément en cas de microcoupure.
 
 >**IMPORTANT**
 >

--- a/install/consistency.php
+++ b/install/consistency.php
@@ -379,6 +379,25 @@ try {
 		$cron->setTimeout(10);
 		$cron->save();
 
+		$cron = cron::byClassAndFunction('network', 'cron10');
+		if (!is_object($cron)) {
+			echo "Create network::cron10\n";
+			$cron = new cron();
+			$cron->setClass('network');
+			$cron->setFunction('cron10');
+			$rand_min = rand(0,9);
+			$cron = '';
+			for($i=0;$i<6;$i++){
+				$cron .= ($rand_min+($i*10)).',';
+			}
+			$cron = trim($cron,',').' * * * *';
+			$cron->setSchedule($cron);
+			$cron->setEnable(1);
+			$cron->setDeamon(0);
+			$cron->setTimeout(60);
+			$cron->save();
+		}
+
 		if (!file_exists(__DIR__ . '/../plugins')) {
 			mkdir(__DIR__ . '/../plugins');
 		}


### PR DESCRIPTION
La vérification de la connexion réseau est désormais effectuée de manière aléatoire toutes les 10 minutes afin d'éviter que toutes les box Jeedom ne tentent de se reconnecter simultanément en cas de microcoupure.