### PR TITLE
Fix error on setSchedule

### DIFF
--- a/install/consistency.php
+++ b/install/consistency.php
@@ -386,12 +386,12 @@ try {
 			$cron->setClass('network');
 			$cron->setFunction('cron10');
 			$rand_min = rand(0,9);
-			$cron = '';
+			$cronString = '';
 			for($i=0;$i<6;$i++){
-				$cron .= ($rand_min+($i*10)).',';
+				$cronString .= ($rand_min+($i*10)).',';
 			}
-			$cron = trim($cron,',').' * * * *';
-			$cron->setSchedule($cron);
+			$cronString = trim($cronString,',').' * * * *';
+			$cron->setSchedule($cronString);
 			$cron->setEnable(1);
 			$cron->setDeamon(0);
 			$cron->setTimeout(60);


### PR DESCRIPTION
PHP Fatal error:  Uncaught Error: Call to a member function setSchedule() on string in /var/www/html/install/consistency.php:394
Stack trace:
#0 /var/www/html/install/update.php(327): require_once()
#1 {main}
thrown in /var/www/html/install/consistency.php on line 394