### PR TITLE
Optimise makeSuccess, error if _result is an object

### DIFF
--- a/core/class/jsonrpc.class.php
+++ b/core/class/jsonrpc.class.php
@@ -71,7 +71,7 @@ class jsonrpc {
 		exit;
 	}
 	
-	public function makeSuccess($_result) {
+	public function makeSuccess($_result = null) {
 		if(is_object($_result)){
 			$_result = utils::o2a($_result);
 		}

--- a/core/class/jsonrpc.class.php
+++ b/core/class/jsonrpc.class.php
@@ -71,7 +71,15 @@ class jsonrpc {
 		exit;
 	}
 	
-	public function makeSuccess($_result = 'ok') {
+	public function makeSuccess($_result) {
+		if(is_object($_result)){
+			$_result = utils::o2a($_result);
+		}
+
+		if(empty($_result)){
+			$_result = 'ok';
+		}
+
 		$return = array(
 			'jsonrpc' => '2.0',
 			'id' => $this->id,


### PR DESCRIPTION
## Description
<!--
Si ol'on passe un objet la fonctionne ne retourne rien dans le return
-->


### Suggested changelog entry
Fix if is an object parameter



## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement
Idéalement la fonction devrait être :

```
public function makeSuccess(mixed $_result): void {
		if(is_object($_result)){
			$_result = utils::o2a($_result);
		}

		if(empty($_result)){
			$_result = 'ok';
		}

		$return = array(
			'jsonrpc' => '2.0',
			'id' => $this->id,
			'result' => $_result,
		);
		$return = array_merge($return, $this->getAdditionnalParams());
		if (init('callback') != '') {
			echo init('callback') . '(' . json_encode($return) . ')';
		} else {
			echo json_encode($return);
		}
		exit;
	}

```