### PR TITLE
Fix warning in cmd.configure.php

### DIFF
--- a/desktop/modal/cmd.configure.php
+++ b/desktop/modal/cmd.configure.php
@@ -325,8 +325,10 @@ $configEqDisplayType = jeedom::getConfiguration('eqLogic:displayType');
                 <label class="col-lg-2 col-md-3 col-sm-4 col-xs-6 control-label">{{Plugin(s)}} <?php echo $key; ?></label>
                 <div class="col-lg-10 col-md-9 col-sm-8 col-xs-6">
                   <?php
-                  foreach ($values as $value) {
-                    echo '<span class="btn btn-xs btn-info">' . $value->getName() . '</span><br/>';
+                  if (is_iterable($values)) {
+                    foreach ($values as $value) {
+                      echo '<span class="btn btn-xs btn-info">' . $value->getName() . '</span><br/>';
+                    }
                   }
                   ?>
                 </div>


### PR DESCRIPTION
## Description
Fix warning in cmd.configure.php:
```
PHP Warning:  foreach() argument must be of type array|object, null given in /var/www/html/desktop/modal/cmd.configure.php on line 328
```
Present in 4.4.19 & 4.5

### Suggested changelog entry
Fix warning in Command Configuration Modale

### Related issues/external references
N/A

## Types of changes
- [x] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement

## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [x] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.

Bad