### PR TITLE
Fix issue with serialize and queue (alternative)

### DIFF
--- a/core/class/DB.class.php
+++ b/core/class/DB.class.php
@@ -129,6 +129,10 @@ class DB {
 							$obj->setChanged(false);
 						}
 					}
+
+                    if (is_object($obj) && method_exists($obj, 'initialize')) {
+                        $obj->initialize();
+                    }
 				}
 			} else {
 				if (is_object($res) && method_exists($res, 'decrypt')) {
@@ -137,6 +141,10 @@ class DB {
 						$res->setChanged(false);
 					}
 				}
+
+                if (is_object($res) && method_exists($res, 'initialize')) {
+                    $res->initialize();
+                }
 			}
 		}
 		return $res;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

<!--
Please target the `beta` branch when submitting your pull request, unless your change **only** applies to Jeedom 4.x.
-->

## Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
-->
Alternative to PR #3049

Cette PR résout un problème de sérialisation/désérialisation des arguments dans la classe queue qui provoque des erreurs lors de l'exécution des tâches en file d'attente.

Le problème se manifeste lors d'un cycle sauvegarde puis récupération des données : la méthode `getArguments()` retourne des données désérialisées lors de la sauvegarde, mais ces données sont alors stockées sans être resérialisées. À la récupération ultérieure, quand le système tente de désérialiser ces données (qui ne sont pas dans un format sérialisé), l'opération échoue et provoque une erreur lors de l'appel à `call_user_func_array()`.

Cette solution propose une approche différente qui inverse la logique de stockage :
1. L'attribut `$arguments` stocke directement les arguments sous forme d'array
2. La méthode `getArguments()` détecte automatiquement le contexte de sauvegarde via un flag `_onSave`
3. Lors d'une sauvegarde, la méthode retourne les arguments sérialisés, sinon elle retourne les arguments tels quels
4. Des méthodes privées gèrent la conversion entre format array et format sérialisé

Cette approche élimine les désérialisations inutiles, améliore les performances et reste compatible avec le code existant.

### Suggested changelog entry
<!-- Please provide a short description of the change for the changelog. -->
Correction d'un bug de sérialisation des arguments dans la classe queue qui provoquait des erreurs lors de l'exécution des tâches.

### Related issues/external references

Fixes #


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [x] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->