### PR TITLE
Fix error Declaration of log::log on update

### DIFF
--- a/core/class/log.class.php
+++ b/core/class/log.class.php
@@ -51,7 +51,7 @@ class log extends AbstractLogger {
 		return new self($_logName);
 	}
 
-	public function log($level, Stringable|string  $message, array $context = array()) : void {
+	public function log($level, string  $message, array $context = array()) : void {
 		log::add($this->_log_name, $level, $message);
 	}
 

--- a/core/class/log.class.php
+++ b/core/class/log.class.php
@@ -51,7 +51,7 @@ class log extends AbstractLogger {
 		return new self($_logName);
 	}
 
-	public function log($level, $message, array $context = array()) {
+	public function log($level, Stringable|string  $message, array $context = array()) : void {
 		log::add($this->_log_name, $level, $message);
 	}
 


### PR DESCRIPTION
Fix error : 
```
0005|[Tue Apr 29 17:51:27.460623 2025] [php:error] [pid 549:tid 549] [client 192.168.1.156:56611] PHP Fatal error:  Declaration of log::log($level, $message, array $context = []) must be compatible with Psr\\Log\\AbstractLogger::log($level, Stringable|string $message, array $context = []): void in /var/www/html/core/class/log.class.php on line 54
0006|[Tue Apr 29 17:51:27.635730 2025] [php:error] [pid 1152:tid 1152] [client 192.168.1.156:56616] PHP Fatal error:  Declaration of log::log($level, $message, array $context = []) must be compatible with Psr\\Log\\AbstractLogger::log($level, Stringable|string $message, array $context = []): void in /var/www/html/core/class/log.class.php on line 54
0007|[Tue Apr 29 17:51:27.809344 2025] [php:error] [pid 1150:tid 1150] [client 192.168.1.156:56617] PHP Fatal error:  Declaration of log::log($level, $message, array $context = []) must be compatible with Psr\\Log\\AbstractLogger::log($level, Stringable|string $message, array $context = []): void in /var/www/html/core/class/log.class.php on line 54
0008|[Tue Apr 29 17:51:27.985467 2025] [php:error] [pid 1513:tid 1513] [client 192.168.1.156:56618] PHP Fatal error:  Declaration of log::log($level, $message, array $context = []) must be compatible with Psr\\Log\\AbstractLogger::log($level, Stringable|string $message, array $context = []): void in /var/www/html/core/class/log.class.php on line 54
```