### PR TITLE
jeecli install plugin by github source

### DIFF
--- a/core/php/jeecli.php
+++ b/core/php/jeecli.php
@@ -36,6 +36,7 @@ switch ($argv[1]) {
                     // install by github source
                     // jeecli.php plugin install [id] [user] [repository=id] [branch=master]
                     echo "Install Plugin $argv[4] / $argv[3] from github\n";
+                    config::save('github::enable', 1);
                     $update = new update();
                     $update->setLogicalId($argv[3]);
                     $update->setConfiguration('user', $argv[4]);

--- a/core/php/jeecli.php
+++ b/core/php/jeecli.php
@@ -64,9 +64,9 @@ switch ($argv[1]) {
                     echo "Error plugin not found";
                     die();
                 }
-                 if($plugin->setIsEnable(1,true,true)){
+                if ($plugin->setIsEnable(1,true,true)) {
                    echo "Plugin ".$argv[3]." installed with success";
-                }else{
+                } else {
                    echo "Error install plugin ".$argv[3];
                    break;
                 }

--- a/core/php/jeecli.php
+++ b/core/php/jeecli.php
@@ -64,7 +64,12 @@ switch ($argv[1]) {
                     echo "Error plugin not found";
                     die();
                 }
-                $plugin->setIsEnable(1,true,true);
+                 if($plugin->setIsEnable(1,true,true)){
+                   echo "Plugin ".$argv[3]." installed with success";
+                }else{
+                   echo "Error install plugin ".$argv[3];
+                   break;
+                }
                 jeedom::cleanFileSystemRight();
                 break;
             case 'dependancy_end':

--- a/core/php/jeecli.php
+++ b/core/php/jeecli.php
@@ -32,17 +32,30 @@ switch ($argv[1]) {
     case 'plugin':
         switch ($argv[2]) {
             case 'install':
-                if (!isset($argv[3])) {
+                if (isset($argv[4])) { 
+                    // install by github source
+                    // jeecli.php plugin install [id] [user] [repository=id] [branch=master]
+                    echo "Install Plugin $argv[4] / $argv[3] from github\n";
+                    $update = new update();
+                    $update->setLogicalId($argv[3]);
+                    $update->setConfiguration('user', $argv[4]);
+                    $update->setSource('github');
+                    // if arg(5) is set, it is the repository configuration, else the repo name is the same as the plugin id
+                    $update->setConfiguration('repository', $argv[5] ?? $argv[3]);
+                    // if arg(6) is set, it is the version configuration i.e. branch name
+                    $update->setConfiguration('version', $argv[6] ?? 'master');
+                } else if (!isset($argv[3])) {
                     echo "Plugin id is mandatory";
                     die();
+                } else {
+                    $update = update::byLogicalId($argv[3]);
+                    if (!is_object($update)) {
+                        $update = new update();
+                    }
+                    $update->setLogicalId($argv[3]);
+                    $update->setSource('market');
+                    $update->setConfiguration('version', 'stable');
                 }
-                $update = update::byLogicalId($argv[3]);
-                if (!is_object($update)) {
-                    $update = new update();
-                }
-                $update->setLogicalId($argv[3]);
-                $update->setSource('market');
-                $update->setConfiguration('version', 'stable');
                 $update->save();
                 $update->doUpdate();
                 $plugin = plugin::byId($argv[3]);
@@ -214,6 +227,7 @@ function help() {
     echo "Commands : \n";
     echo "\t plugin : manage Jeedom plugin\n";
     echo "\t\t install [plugin_id] : install plugin_id from market\n";
+    echo "\t\t install [plugin_id] [user] [repository=plugin_id] [branch=master] : install plugin_id from github\n";
     echo "\t\t dependancy_end [plugin_id] : send end of dependancy install for plugin_id\n";
 
     echo "\n";


### PR DESCRIPTION
## Description 
J'avais besoin de pouvoir installer un plugin à l'initialisation du core, mais on est bloqué par le message d'erreur du market (on doit configurer manuellement nos identifiants du market avant de pouvoir installer un plugin)
Cette modification permet d'installer un plugin via le repo github directement à l'aide de jeecli avec la syntaxe suivante:

`php jeecli.php plugin install [plugin_id] [user] [repository=plugin_id] [branch=master]`

ça nous sera utile aussi pour les phpunit - tests unitaires.

### Suggested changelog entry
jeecli : install plugin from github source

### Related issues/external references

Fixes #

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement

## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [x] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.
