### PR TITLE
Listener remove event ?

### DIFF
--- a/core/class/listener.class.php
+++ b/core/class/listener.class.php
@@ -317,6 +317,16 @@ class listener {
 		return $this;
 	}
 
+	public function removeEvent($_id) {
+		$event = $this->getEvent();
+		if (!is_array($event)) {
+			$event = array();
+		}
+		$id = trim($_id, '#');
+		$this->setEvent(array_diff($event, ['#' . $id . '#']));
+		return $this;
+	}
+
 	/*     * **********************Getteur Setteur*************************** */
 
 	/**

--- a/core/class/listener.class.php
+++ b/core/class/listener.class.php
@@ -323,7 +323,7 @@ class listener {
 			$event = array();
 		}
 		$id = trim($_id, '#');
-		$this->setEvent(array_diff($event, ['#' . $id . '#']));
+		$this->setEvent(array_values(array_diff($event, ['#' . $id . '#'])));
 		return $this;
 	}
 

--- a/docs/fr_FR/changelog.md
+++ b/docs/fr_FR/changelog.md
@@ -2,6 +2,7 @@
 
 # 4.5
 
+- [Développeurs] Ajout de la fonction `$listener->removeEvent($_id)`
 - Possibilité de rendre les colonnes des tableaux redimensionnables (seulement la liste des variables pour le moment ça sera étendu à d'autres tables si besoin) [LIEN](https://github.com/jeedom/core/issues/2499)
 - Ajout d'une alerte si l'espace disque de jeedom est trop faible (la vérification se fait une fois par jour) [LIEN](https://github.com/jeedom/core/issues/2438)
 - Ajout d'un bouton sur la fenêtre de configuration d'une commande au niveau du champ de calcul de valeur pour aller chercher une commande [LIEN](https://github.com/jeedom/core/issues/2776)


### PR DESCRIPTION
I assume this is not tested at all but why no `$listener->removeEvent($_id)` function exists ?

While listeners can handle multiple events and adding one is straightforward, removing an event currently requires several steps, which could be simplified in my opinion.