### PR TITLE
Fix PHP 8+ TypeError in cmd::formatValue() when round() receives non-…

### DIFF
--- a/core/class/cmd.class.php
+++ b/core/class/cmd.class.php
@@ -1042,6 +1042,10 @@ class cmd {
 					return intval($binary xor boolval($this->getConfiguration('invertBinary', false)));
 				case 'numeric':
 					if ($this->getConfiguration('historizeRound') !== '' && is_numeric($this->getConfiguration('historizeRound')) && $this->getConfiguration('historizeRound') >= 0) {
+                        if (!is_numeric($_value)) {
+                            log::add('cmd', 'error', __('La formule de calcul doit retourner une valeur numérique uniquement : ', __FILE__) . $this->getHumanName() . ' => ' . $_value);
+                            $_value = (float) (str_replace(',', '.', $_value));
+                        }
 						$_value = round($_value, $this->getConfiguration('historizeRound'));
 					}
 					if ($_value > $this->getConfiguration('maxValue', $_value)) {

--- a/tests/class/cmdTest.php
+++ b/tests/class/cmdTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/* This file is part of Jeedom.
+*
+* Jeedom is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* Jeedom is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Jeedom. If not, see <http://www.gnu.org/licenses/>.
+*/
+use PHPUnit\Framework\TestCase;
+
+class cmdTest extends TestCase
+{
+    public function testFormatValueNumericRoundWithNonNumericCalculResult()
+    {
+        $cmd = new cmd();
+        $cmd->setType('info');
+        $cmd->setSubType('numeric');
+        $cmd->setConfiguration('historizeRound', 1);
+        $cmd->setConfiguration('calculValueOffset', '#value# * 2 ~ \'mm\'');
+
+        $actualResult = $cmd->formatValue('1,2');
+
+        self::assertSame(2.4, $actualResult);
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->
<!--
Please target the `beta` branch when submitting your pull request, unless your change **only** applies to Jeedom 4.x.
-->
## Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
-->

Discussion community : https://community.jeedom.com/t/correctif-commit-442d472-masquage-dun-vrai-bug-de-typage-au-lieu-de-le-corriger-proprement/143439

Corrige une erreur fatale `TypeError` qui survient en PHP 8+ lorsque la fonction `round()` reçoit une valeur non-numérique dans `cmd::formatValue()`.

**Problème :** 
- Quand `calculValueOffset` contient une formule qui retourne du texte (ex: `#value# * 2 ~ 'mm'` → `"2.4 mm"`), l'appel à `round()` provoque une `TypeError` en PHP 8+
- PHP 7.4 était plus permissif et acceptait les conversions implicites, PHP 8+ est strict sur le typage

**Solution :**
- Vérification de `is_numeric($_value)` avant l'appel à `round()`
- Log d'erreur pour informer l'utilisateur de sa mauvaise configuration
- Conversion forcée avec `floatval()` pour maintenir la compatibilité
- Correction appliquée uniquement quand `historizeRound` est configuré (ciblage précis du problème)

### Suggested changelog entry
<!-- Please provide a short description of the change for the changelog. -->
Correction d'une erreur fatale PHP 8+ dans cmd::formatValue() quand calculValueOffset retourne une valeur non-numérique

### Related issues/external references
Fixes https://community.jeedom.com/t/php-fatal-error-uncaught-typeerror-in-cmd-class-php-on-line-1036-dans-le-log-http-error/143400

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix *(non-breaking change which fixes)*
- [ ] New feature *(non-breaking change which adds functionality)*
- [ ] Breaking change *(fix or feature that would cause existing functionality to change)*
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement

## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [x] I grant the project the right to include and distribute the code under the GNU.
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.