### PR TITLE
Fix scenario report theme parameter: use $options instead of $_parameters

### DIFF
--- a/core/class/scenarioExpression.class.php
+++ b/core/class/scenarioExpression.class.php
@@ -1855,8 +1855,8 @@ class scenarioExpression {
 							break;
 						case 'eqAnalyse':
 							$url = network::getNetworkAccess('internal') . '/index.php?v=d&p=eqAnalyse&report=1';
-							if (isset($_parameters['theme']) && $_parameters['theme'] != '') {
-								$url .= '&theme=' . $_parameters['theme'];
+							if (isset($options['theme']) && $options['theme'] != '') {
+								$url .= '&theme=' . $options['theme'];
 							}
 							$this->setLog($scenario, __('Génération du rapport', __FILE__) . ' ' . $url);
 							$cmd_parameters['files'] = array(report::generate($url, 'other', 'eqAnalyse', $options['export_type'], $options));
@@ -1865,8 +1865,8 @@ class scenarioExpression {
 							break;
 						case 'eqAnalyseAlert':
 							$url = network::getNetworkAccess('internal') . '/index.php?v=d&p=eqAnalyse&report=1';
-							if (isset($_parameters['theme']) && $_parameters['theme'] != '') {
-								$url .= '&theme=' . $_parameters['theme'];
+							if (isset($options['theme']) && $options['theme'] != '') {
+								$url .= '&theme=' . $options['theme'];
 							}
 							$this->setLog($scenario, __('Génération du rapport', __FILE__) . ' ' . $url);
 							$options['tab'] = 'alertEqlogic';
@@ -1876,8 +1876,8 @@ class scenarioExpression {
 							break;
 						case 'health':
 							$url = network::getNetworkAccess('internal') . '/index.php?v=d&p=health&report=1';
-							if (isset($_parameters['theme']) && $_parameters['theme'] != '') {
-								$url .= '&theme=' . $_parameters['theme'];
+							if (isset($options['theme']) && $options['theme'] != '') {
+								$url .= '&theme=' . $options['theme'];
 							}
 							$this->setLog($scenario, __('Génération du rapport', __FILE__) . ' ' . $url);
 							$cmd_parameters['files'] = array(report::generate($url, 'other', 'health', $options['export_type'], $options));
@@ -1886,8 +1886,8 @@ class scenarioExpression {
 							break;
 						case 'timeline':
 							$url = network::getNetworkAccess('internal') . '/index.php?v=d&p=timeline&report=1&timeline=' . $options['timeline'];
-							if (isset($_parameters['theme']) && $_parameters['theme'] != '') {
-								$url .= '&theme=' . $_parameters['theme'];
+							if (isset($options['theme']) && $options['theme'] != '') {
+								$url .= '&theme=' . $options['theme'];
 							}
 							$this->setLog($scenario, __('Génération du rapport timeline', __FILE__) . ' ' . $options['timeline']);
 							$cmd_parameters['files'] = array(report::generate($url, 'other', 'timeline', $options['export_type'], $options));


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

<!--
Please target the `beta` branch when submitting your pull request, unless your change **only** applies to Jeedom 4.x.
-->

## Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
-->

Cette PR corrige une erreur PHPStan dans la classe `scenarioExpression` où la variable `$_parameters` était utilisée au lieu de `$options` pour accéder au paramètre `theme` lors de la génération de rapports.

**Problème identifié :**
- Le commit 362e4c256c922e46659b42ce2d596ea0a9d2abac (19 janvier 2023) avait ajouté la fonctionnalité de sélection de thème pour les rapports
- Dans `scenarioExpression.class.php`, le code utilisait incorrectement `$_parameters['theme']` au lieu de `$options['theme']`
- Cette variable `$_parameters` n'existe pas dans ce contexte, causant une erreur PHPStan

**Solution appliquée :**
- Remplacement de `$_parameters['theme']` par `$options['theme']` dans les 4 occurrences (lignes 1858, 1868, 1879, 1889)
- Cohérence avec les autres paramètres utilisés dans la même fonction (ex: `$options['export_type']`)
- Cohérence avec l'interface utilisateur qui stocke la valeur dans `$options['theme']`




### Suggested changelog entry
<!-- Please provide a short description of the change for the changelog. -->

- **Core** : Correction du paramètre thème pour les rapports de scénarios

### Related issues/external references

N/A


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [x] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
