### PR TITLE
[FEATURE] Support des certificats SSL auto-signés pour l'authentification LDAP/AD

### DIFF
--- a/desktop/php/administration.php
+++ b/desktop/php/administration.php
@@ -1609,6 +1609,14 @@ $productName = config::byKey('product_name');
 									</div>
 								</div>
 								<div class="form-group">
+									<label class="col-md-3 col-sm-4 col-xs-12 control-label">{{Autoriser certificats auto-signés}}
+										<sup><i class="fas fa-question-circle" tooltip="{{Désactiver la vérification des certificats SSL pour les certificats auto-signés}}"></i></sup>
+									</label>
+									<div class="col-md-3 col-sm-4 col-xs-12">
+										<input type="checkbox" class="configKey form-control" data-l1key="ldap:allow_selfsigned">
+									</div>
+								</div>
+								<div class="form-group">
 									<label class="col-md-3 col-sm-4 col-xs-12 control-label">{{Hôte}}
 										<sup><i class="fas fa-question-circle" tooltip="{{URL utilisée pour contacter la base, en précisant le type de connexion (e.g ldap(s)://URL)}}"></i></sup>
 									</label>


### PR DESCRIPTION
## Problème résolu

L'authentification LDAP avec STARTTLS échoue systématiquement avec les certificats auto-signés (erreur "start TLS KO"). Cela rend impossible l'utilisation de Jeedom avec Samba4 AD qui utilise par défaut des certificats auto-signés.

Fixes #3136

## Solution proposée

Ajout d'une checkbox "Autoriser certificats auto-signés" dans la configuration LDAP qui désactive la vérification des certificats SSL lorsqu'elle est cochée.

### Modifications apportées

**1. `core/class/user.class.php`** - Deux fonctions modifiées

- `user::connect()` : Configuration SSL avant `ldap_connect()` et `ldap_start_tls()`
- `user::connectToLDAP()` : Configuration SSL avant `ldap_connect()` et `ldap_start_tls()`

Les options SSL sont configurées de manière conditionnelle selon la valeur de `ldap:allow_selfsigned` :
- Si activé : `LDAPTLS_REQCERT=never` et `LDAP_OPT_X_TLS_REQUIRE_CERT = LDAP_OPT_X_TLS_NEVER`
- Si désactivé : `LDAPTLS_REQCERT=demand` et `LDAP_OPT_X_TLS_REQUIRE_CERT = LDAP_OPT_X_TLS_DEMAND`

**2. `desktop/php/administration.php`**

- Ajout d'une checkbox après l'option TLS (ligne ~1611)
- Clé de configuration : `ldap:allow_selfsigned`
- Par défaut décochée (comportement actuel conservé)
- Tooltip explicatif pour guider l'utilisateur

### Comportement

**Checkbox décochée (défaut)** : Vérification stricte des certificats SSL
- Comportement actuel de Jeedom conservé
- Sécurité maximale

**Checkbox cochée** : Accepte les certificats auto-signés
- Requis pour Samba4 AD avec certificats auto-signés
- Permet STARTTLS avec certificats non valides
- Désactive la vérification SSL (`LDAPTLS_REQCERT=never`)

## Tests effectués

Testé en production avec :
- Samba4 Active Directory (certificats auto-signés)
- STARTTLS sur port 389
- Authentification de plusieurs utilisateurs AD
- Checkbox décochée : STARTTLS échoue comme attendu (comportement actuel)
- Checkbox cochée : STARTTLS fonctionne correctement

Configuration testée :
```
ldap:host = ldap://dc.domain.local
ldap:port = 389
ldap:tls = 1 (STARTTLS)
ldap:allow_selfsigned = 1
ldap:samba4 = 1
ldap:domain = domain.local
```

## Compatibilité

- Rétrocompatible à 100% (comportement par défaut strictement inchangé)
- PHP 7.4, 8.0, 8.1, 8.2, 8.3
- Tous serveurs LDAP (OpenLDAP, Samba4 AD, Microsoft AD, etc.)
- Aucun changement cassant
- Aucune dépendance ajoutée
