### PR TITLE
3152 php deprecated scenarioexpressionclass

### DIFF
--- a/core/class/scenarioExpression.class.php
+++ b/core/class/scenarioExpression.class.php
@@ -1275,7 +1275,9 @@ class scenarioExpression {
 		}
 		if ($_quote) {
 			foreach ($replace1 as &$value) {
-				$value = (string)$value;
+				if ($value === null) {
+					continue;
+				}
 				if (strpos($value, ' ') !== false || preg_match("/[a-zA-Z]/", $value) || $value === '') {
 					$value = '"' . trim($value, '"') . '"';
 				}


### PR DESCRIPTION
Fixes #3152 

Chosen option is to cast `$value` to a string by default, although we could `continue` if `$value === null`.

After some investigation, it appears that `scenarioExpression::getRequestTags` may return a null tag in certain cases.