### PR TITLE
remove jeeNetwork leftovers but keep system halt & reboot

### DIFF
--- a/core/api/proApi.php
+++ b/core/api/proApi.php
@@ -586,12 +586,12 @@ try {
 
 		/*             * ************************System*************************** */
 
-		if ($jsonrpc->getMethod() == 'system::halt') {
+		if ($jsonrpc->getMethod() == 'jeedom::halt') {
 			jeedom::haltSystem();
 			$jsonrpc->makeSuccess('ok');
 		}
 
-		if ($jsonrpc->getMethod() == 'system::reboot') {
+		if ($jsonrpc->getMethod() == 'jeedom::reboot') {
 			jeedom::rebootSystem();
 			$jsonrpc->makeSuccess('ok');
 		}


### PR DESCRIPTION
Fix #3121

jeeNetwork calls are dead code. Removed duplicated and irrelevant methods, but kept `halt`/`reboot` under `system::halt` and `system::reboot`.
