### PR TITLE
feat: change docker image building workflow into matrix

### DIFF
--- a/.github/scripts/init_workflow.sh
+++ b/.github/scripts/init_workflow.sh
@@ -2,28 +2,32 @@
 
 # this script is used by CI/CD Github Workflow
 JEEDOM_VERSION=$(cat core/config/version)
+# get current jeedom version number, 2 digits e.g. 4.5
 JEEDOM_SHORT_VERSION="$(echo "$JEEDOM_VERSION" | awk -F. '{print $1"."$2}')"
 # Docker hub repository may be overriden
 REPO=${DOCKER_HUB_REPO:-"jeedom"}
 
 if [[ "${GITHUB_REF_NAME}" == "master" ]]; then
-  JEEDOM_TAGS="${REPO}/jeedom:latest,${REPO}/jeedom:$JEEDOM_SHORT_VERSION";
+  # select the only image for 'latest' tag
+  if [[ "${DEBIAN}" == "bookworm" && "${DATABASE}" == "0" ]]; then
+    JEEDOM_TAGS="${REPO}/jeedom:latest,${REPO}/jeedom:${JEEDOM_SHORT_VERSION}-${TAG_SUFFIX}";
+  else
+    JEEDOM_TAGS="${REPO}/jeedom:${JEEDOM_SHORT_VERSION}-${TAG_SUFFIX}"
+  fi
   GITHUB_BRANCH=${GITHUB_REF_NAME};
 elif [[ "${GITHUB_REF_NAME}" == "beta" ]]; then
-  JEEDOM_TAGS="${REPO}/jeedom:beta"; # ${REPO}/jeedom:$JEEDOM_SHORT_VERSION";
+  JEEDOM_TAGS="${REPO}/jeedom:${JEEDOM_SHORT_VERSION}-${TAG_SUFFIX}-beta"
   GITHUB_BRANCH=${GITHUB_REF_NAME};
 else
-  JEEDOM_TAGS="${REPO}/jeedom:alpha";
+  JEEDOM_TAGS="${REPO}/jeedom:${JEEDOM_SHORT_VERSION}-${TAG_SUFFIX}-alpha"
   GITHUB_BRANCH=alpha;
 fi
 
-# GITHUB_ENV is the environment variables filename
-# https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files
-echo "JEEDOM_VERSION=$JEEDOM_VERSION" >> $GITHUB_ENV
-echo "JEEDOM_SHORT_VERSION=$JEEDOM_SHORT_VERSION" >> $GITHUB_ENV
-echo "JEEDOM_TAGS=$JEEDOM_TAGS" >> $GITHUB_ENV
-echo "GITHUB_BRANCH=$GITHUB_BRANCH" >> $GITHUB_ENV
-echo "JEEDOM_REPO=$REPO" >> $GITHUB_ENV
+# GITHUB_OUTPUT is the output filename
+# https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#setting-an-output-parameter
+echo "JEEDOM_TAGS=$JEEDOM_TAGS" >> "$GITHUB_OUTPUT"
+echo "GITHUB_BRANCH=$GITHUB_BRANCH" >> "$GITHUB_OUTPUT"
+echo "JEEDOM_REPO=$REPO" >> "$GITHUB_OUTPUT"
 
 # GITHUB_STEP_SUMMARY is the workflow summary
 # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary

--- a/.github/scripts/init_workflow.sh
+++ b/.github/scripts/init_workflow.sh
@@ -7,21 +7,14 @@ JEEDOM_SHORT_VERSION="$(echo "$JEEDOM_VERSION" | awk -F. '{print $1"."$2}')"
 # Docker hub repository may be overriden
 REPO=${DOCKER_HUB_REPO:-"jeedom"}
 
-if [[ "${GITHUB_REF_NAME}" == "master" ]]; then
-  # select the only image for 'latest' tag
-  if [[ "${DEBIAN}" == "bookworm" && "${DATABASE}" == "0" ]]; then
-    JEEDOM_TAGS="${REPO}/jeedom:latest,${REPO}/jeedom:${JEEDOM_SHORT_VERSION}-${TAG_SUFFIX}";
-  else
-    JEEDOM_TAGS="${REPO}/jeedom:${JEEDOM_SHORT_VERSION}-${TAG_SUFFIX}"
-  fi
-  GITHUB_BRANCH=${GITHUB_REF_NAME};
-elif [[ "${GITHUB_REF_NAME}" == "beta" ]]; then
-  JEEDOM_TAGS="${REPO}/jeedom:${JEEDOM_SHORT_VERSION}-${TAG_SUFFIX}-beta"
-  GITHUB_BRANCH=${GITHUB_REF_NAME};
+# ${GITHUB_REF_NAME} == master
+# select the only image for 'latest' tag
+if [[ "${DEBIAN}" == "bookworm" && "${DATABASE}" == "0" ]]; then
+  JEEDOM_TAGS="${REPO}/jeedom:latest,${REPO}/jeedom:${JEEDOM_SHORT_VERSION}-${TAG_SUFFIX}";
 else
-  JEEDOM_TAGS="${REPO}/jeedom:${JEEDOM_SHORT_VERSION}-${TAG_SUFFIX}-alpha"
-  GITHUB_BRANCH=alpha;
+  JEEDOM_TAGS="${REPO}/jeedom:${JEEDOM_SHORT_VERSION}-${TAG_SUFFIX}"
 fi
+GITHUB_BRANCH=${GITHUB_REF_NAME};
 
 # GITHUB_OUTPUT is the output filename
 # https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#setting-an-output-parameter

--- a/.github/workflows/docker-image-latest.yml
+++ b/.github/workflows/docker-image-latest.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
     inputs:
       logLevel:
-        description: 'Reason'     
+        description: 'Reason'
         default: 'Manual launch'
 
 jobs:

--- a/.github/workflows/docker-image-latest.yml
+++ b/.github/workflows/docker-image-latest.yml
@@ -5,9 +5,6 @@ on:
     # only trigger CI when push on following branches
     branches:
       - master
-      - alpha
-      - beta
-      - feat/matrix_workflow
   # this is to manually trigger the worklow
   workflow_dispatch:
     inputs:

--- a/.github/workflows/docker-image-latest.yml
+++ b/.github/workflows/docker-image-latest.yml
@@ -4,7 +4,10 @@ on:
   push:
     # only trigger CI when push on following branches
     branches:
-      - 'master'
+      - master
+      - alpha
+      - beta
+      - feat/matrix_workflow
   # this is to manually trigger the worklow
   workflow_dispatch:
     inputs:
@@ -15,19 +18,16 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      # do every matrix combination, don't stop on errors
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        debian: [bullseye, bookworm]
+        database: [0, 1]
+
     steps:
-    
-      - name: Free disk space
-        run: |
-          df -h
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf "/usr/local/share/boost"
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-          sudo apt-get autoclean -y 2>&1
-          docker rmi $(docker image ls -aq) 2>&1
-          df -h
-    
+
       - name: Check Out Repo
         # Check out the repo, using current branch
         # https://github.com/marketplace/actions/checkout
@@ -36,14 +36,21 @@ jobs:
       - name: BRANCH name
         # adding infos in the $GITHUB_ENV file and summary
         # secret DOCKER_HUB_REPO is optional (default=jeedom)
+        id: config_tags
+        env:
+          DOCKER_HUB_REPO: ${{ secrets.DOCKER_HUB_REPO }}
+          TAG_SUFFIX: ${{ matrix.database && 'http-' || '' }}${{ matrix.debian }}
+          DEBIAN: ${{ matrix.debian }}
+          DATABASE: ${{ matrix.database }}
         run: |
-          export DOCKER_HUB_REPO=${{ secrets.DOCKER_HUB_REPO }}
-          bash install/OS_specific/Docker/init_workflow.sh
+          bash .github/scripts/init_workflow.sh
 
       - name: Set up QEMU
         # https://github.com/marketplace/actions/docker-setup-qemu
         # set up more platforms (default = all)
         uses: docker/setup-qemu-action@v4
+        with:
+          platforms: linux/amd64,linux/arm64 # ,linux/arm/v7
 
       - name: Login to Docker Hub
         # https://github.com/marketplace/actions/docker-login
@@ -66,92 +73,22 @@ jobs:
         id: cache
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-${{ matrix.debian }}
           restore-keys: |
+            ${{ runner.os }}-buildx-${{ matrix.debian }}
+
+      - name: Build and push Jeedom on Debian:${{ matrix.debian }} ${{ matrix.database && 'with' || 'without' }} internal DB
             ${{ runner.os }}-buildx-
-
-      - name: Build and push Jeedom on Debian:Bookworm without internal DB
         # https://github.com/marketplace/actions/build-and-push-docker-images
         uses: docker/build-push-action@v7
-        continue-on-error: true
         with:
           context: ./
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64 # ,linux/arm/v7
           push: true
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
           build-args: |
-            "VERSION=${{ env.GITHUB_BRANCH }}"
-            "DEBIAN=bookworm"
-            "DATABASE=0"
-          tags: "${{ env.JEEDOM_REPO }}/jeedom:${{ env.JEEDOM_SHORT_VERSION}}-http-bookworm"
-
-      - name: Clean docker image
-        run: |
-          docker stop $(docker ps -aq) 2>&1
-          docker rm $(docker ps -aq) 2>&1
-          docker rmi $(docker image ls -aq) 2>&1
-      
-      - name: Build and push Jeedom on DockerHub
-        # https://github.com/marketplace/actions/build-and-push-docker-images
-        uses: docker/build-push-action@v7
-        continue-on-error: true
-        with:
-          context: ./
-          file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64 # ,linux/arm/v7
-          push: true
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
-          build-args: "VERSION=${{ env.GITHUB_BRANCH }}"
-          tags: "${{ env.JEEDOM_TAGS }}"
-          
-      - name: Clean docker image
-        run: |
-          docker stop $(docker ps -aq) 2>&1
-          docker rm $(docker ps -aq) 2>&1
-          docker rmi $(docker image ls -aq) 2>&1
-
-      - name: Build and push Jeedom on Debian:Buster with DB
-        # https://github.com/marketplace/actions/build-and-push-docker-images
-        uses: docker/build-push-action@v7
-        continue-on-error: true
-        with:
-          context: ./
-          file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64 # ,linux/arm/v7
-          push: true
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
-          build-args: |
-            "VERSION=${{ env.GITHUB_BRANCH }}"
-            "DEBIAN=buster"
-            "DATABASE=1"
-          tags: "${{ env.JEEDOM_REPO }}/jeedom:${{ env.JEEDOM_SHORT_VERSION}}-buster"
-          
-      - name: Clean docker image
-        run: |
-          docker stop $(docker ps -aq) 2>&1
-          docker rm $(docker ps -aq) 2>&1
-          docker rmi $(docker image ls -aq) 2>&1
-      
-      - name: Build and push Jeedom on Debian:Bookworm with DB
-        # https://github.com/marketplace/actions/build-and-push-docker-images
-        uses: docker/build-push-action@v7
-        continue-on-error: true
-        with:
-          context: ./
-          file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64 # ,linux/arm/v7
-          push: true
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
-          build-args: |
-            "VERSION=${{ env.GITHUB_BRANCH }}"
-            "DEBIAN=bookworm"
-            "DATABASE=1"
-          tags: "${{ env.JEEDOM_REPO }}/jeedom:${{ env.JEEDOM_SHORT_VERSION}}-bookworm"
-
-      - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}
+            "VERSION=${{ steps.config_tags.outputs.GITHUB_BRANCH }}"
+            "DEBIAN=${{ matrix.debian }}"
+            "DATABASE=${{ matrix.database }}"
+          tags: "${{ steps.config_tags.outputs.JEEDOM_TAGS }}"


### PR DESCRIPTION

## Description
Le workflow qui build les images docker officielles pour Jeedom est en erreur depuis pas loin d'un an. Aucune mise à jour d'image officielle sur le docker hub. J'ai vu et reproduis l'erreur suivante:
`
 ERROR: (*service).Write failed: rpc error: code = Unknown desc = write /tmp/.buildx-cache/ingest/7959d578df551b1881fed6c332ba59b129715148492d5afa7eeaa53454ebad95/data: no space left on device`

Probablement c'était la cause de ce step pour supprimer toute sorte de fichiers temporaires sur le runner github mais le step bloque le build avec une autre erreur
```
 docker: 'docker rmi' requires at least 1 argument
Usage:  docker rmi [OPTIONS] IMAGE [IMAGE...]
See 'docker rmi --help' for more information
```
Le workflow actuel tente de générer plusieurs images dans un unique job constitué de nombreux steps. Je propose une autre approche, qui consiste à utiliser une matrice pour générer plusieurs images en parallèle dans des runners github distincts.
```
      matrix:
        debian: [bullseye, bookworm]
        database: [0, 1]
```
Le job génère 4 images en parallèle (produit cartésien):
* bullseye
* bullseye http (sans la database)
* bookworm
* bookworm http (sans database)
Le moment venu, on pourra facilement ajouter debien:trixie dans la liste et générer 2 images supplémentaires (lorsque le script d'install et le Dockerfile seront compatibles) il suffit d'ajouter trixie dans la matrice.

J'ai aussi déplacé le script dans .github/scripts, c'est un script uniquement dédié à la pipeline CI/CD il n'a pas de rapport avec l'installation de Jeedom, même sous Docker (oui c'est moi qui l'avait créé à cet endroit à l'époque...)
[install/OS_specific/Docker/init_workflow.sh → .github/scripts/init_workflow.sh](https://github.com/jeedom/core/compare/master...pifou25:jeedom-core:feat/matrix_workflow#diff-c478243e9269cc1699fb72e7afafa69a0f53b328a14dd51a162ffaf7caa99ef2)

lien vers le dernier run du workflow pour preuve de test:
https://github.com/pifou25/jeedom-core/actions/runs/20413543962

J'ai fait la PR sur master (default branch) car c'est celle-ci qui génère l'image officielle, sinon ça serait une image beta ou alpha.

On peut aussi copier / cherry-pick ce commit sur alpha si besoin ? pour générer une future image 4.6-trixie :) 

### Suggested changelog entry
Restauration du pipeline pour générer l'image Docker officielle

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement

## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have checked there is no other PR open for the same change.
- [ ] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [ ] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [ ] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.
