### PR TITLE
Fix erreur directive Content Security Policy fonts.googleapis.com

### DIFF
--- a/install/apache_security_unsecure
+++ b/install/apache_security_unsecure
@@ -1,8 +1,7 @@
 <Directory /var/www/html>
 Options -Indexes -ExecCGI -FollowSymLinks
 AllowOverride All
-</Directory>
-
+:q:
 <IfModule mod_headers.c>
 Header set X-Content-Type-Options "nosniff"
 Header set X-Frame-Options "sameorigin"
@@ -10,5 +9,15 @@ Header set X-XSS-Protection "1; mode=block"
 Header unset X-Powered-By
 Header set Referrer-Policy: strict-origin-when-cross-origin
 Header set Permissions-Policy "accelerometer=(),battery=(),fullscreen=(self),geolocation=(),camera=(),ambient-light-sensor=(self),autoplay=(self)"
-Header set Content-Security-Policy-Report-Only "default-src 'self' file: data: blob: filesystem:;script-src-attr 'self' 'unsafe-inline' 'unsafe-eval' *;script-src 'self' 'unsafe-inline' 'unsafe-eval' *;script-src-elem 'self' 'unsafe-inline' 'unsafe-eval' *;img-src 'self' * data:;style-src 'self' 'unsafe-inline';style-src-attr 'self' 'unsafe-inline';worker-src blob:;frame-src 'self' * data:;"
+Header set Content-Security-Policy "\
+default-src 'self' file: data: blob: filesystem:;\
+script-src-attr 'self' 'unsafe-inline' 'unsafe-eval' *.google.com *.google.fr *.googleapis.com *.openstreetmap.org;\
+script-src 'self' 'unsafe-inline' 'unsafe-eval' *.google.com *.google.fr *.openstreetmap.org;\
+script-src-elem 'self' 'unsafe-inline' 'unsafe-eval' *.google.com *.google.fr *.openstreetmap.org;\
+img-src 'self' * data:;\
+style-src 'self' 'unsafe-inline' fonts.googleapis.com;\
+style-src-attr 'self' 'unsafe-inline';\
+font-src 'self' fonts.gstatic.com data:;\
+worker-src blob:;\
+frame-src 'self' *.jeedom.com *.google.com *.google.fr *.googleapis.com *.openstreetmap.org data:;"
 </IfModule>


### PR DESCRIPTION
La configuration d’origine (ancienne) ne contenait pas fonts.gstatic.com, alors que ce domaine est utilisé par certains plugins, par exemple zwavejs via
plugins/zwavejs/resources/zwave-js-ui/node_modules/workbox-recipes/build/workbox-recipes.dev.js
et
plugins/zwavejs/resources/zwave-js-ui/node_modules/workbox-recipes/googleFontsCache.js.

ce qui produisait l'erreur suivante dans le centre de messages:<<Erreur de directive Content Security Policy sur la ressource "https://fonts.googleapis.com/css?...">>

<!-- Provide a general summary of your changes in the title above. J’ai modifié deux lignes dans la CSP Apache en ajoutant les FQDN des serveurs hébergeant les ressources réellement utilisées par certains plugins (notamment zwavejs) : style-src 'self' 'unsafe-inline' fonts.googleapis.com;\ font-src 'self' fonts.gstatic.com data:;\ --> 

<!-- Please target the `beta` branch when submitting your pull request, unless your change **only** applies to Jeedom 4.x. Cette modification des réglages CSP Apache est applicable à plusieurs versions de Jeedom (au moins sur les deux dernières années), et ne concerne pas uniquement Jeedom 5.4.x. -->

Description
<!-- This PR updates the Apache CSP template `install/apache_security_unsecure`. The original CSP was missing `fonts.gstatic.com`, which is required when `fonts.googleapis.com` is used. Some plugins (e.g. zwavejs through workbox-recipes googleFontsCache) rely on Google Fonts, and the missing domain causes fonts to be blocked by CSP, potentially leading to UI issues and browser console errors (such as `Failed to execute 'replaceWith' on 'Element': Invalid or unexpected token`). The change is minimal and only adds the required domains, keeping the policy as restrictive as possible. -->
Suggested changelog entry

<!-- Apache security template: update CSP to allow Google Fonts resources required by some plugins. -->
Related issues/external references

Fixes #

Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

 [X] Bug fix (non-breaking change which fixes)

 [  ] New feature (non-breaking change which adds functionality)

 [  ] Breaking change (fix or feature that would cause existing functionality to change)

 [  ] This change is only breaking for integrators, not for external standards or end-users.

 [  ] Documentation improvement

PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

 [  ]  I have checked there is no other PR open for the same change.

 [  ]  I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](https://github.com/jeedom/core/compare/.github/CONTRIBUTING.md)
).

 [X]  I grant the project the right to include and distribute the code under the GNU.

 [  ] I have added tests to cover my changes. (not applicable: Apache CSP template change)

 [  ] I have verified that the code complies with the projects coding standards.

 [  ] [Required for new sniffs] I have added MD documentation for the sniff. (not applicable)