### PR TITLE
Dispatch events with both CustomEvent and jQuery

### DIFF
--- a/core/js/jeedom.class.js
+++ b/core/js/jeedom.class.js
@@ -81,15 +81,12 @@ jeedom.changes = function() {
           object_summary_update.push(data.result[i].option)
           continue
         }
+        
+        // Dispatch à la fois en natif (dispatchEvent) et jQuery (rétrocompatibilité)
         if (isset(data.result[i].option)) {
-          if (['scenario::update', 'ui::update', 'jeedom::gotoplan', 'jeedom::alert', 'jeedom::alertPopup', 'jeedom::coloredIcons', 'message::refreshMessageNumber', 'update::refreshUpdateNumber', 'notify', 'checkThemechange', 'changeTheme'].includes(data.result[i].name)) {
-            document.body.dispatchEvent(new CustomEvent(data.result[i].name, { detail: data.result[i].option }))
-          } else {
-            if (typeof jQuery === 'function') {
-              $('body').trigger(data.result[i].name, data.result[i].option)
-            } else {
-              document.body.dispatchEvent(new CustomEvent(data.result[i].name, { detail: data.result[i].option }))
-            }
+          document.body.dispatchEvent(new CustomEvent(data.result[i].name, { detail: data.result[i].option }))
+          if (typeof jQuery === 'function') {
+            $('body').trigger(data.result[i].name, data.result[i].option)
           }
         } else {
           document.body.dispatchEvent(new CustomEvent(data.result[i].name))


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

<!--
Please target the `beta` branch when submitting your pull request, unless your change **only** applies to Jeedom 4.x.
-->

## Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
-->

Problem
Currently, only core Jeedom events (hardcoded list) can use [dispatchEvent] (native CustomEvent). Plugins are forced to use jQuery only.

Solution
Removed the restricted event list. All events (core and plugins) now use :
- [dispatchEvent] : for all events (native standard)
- jQuery [trigger] : maintained for events with data (backward compatibility, like before)

Events are now dispatched using both the native CustomEvent API and jQuery's trigger for backward compatibility. This ensures that all listeners, regardless of implementation, receive the events.

### Suggested changelog entry
<!-- Please provide a short description of the change for the changelog. -->

Support natif des CustomEvent pour les plugins

### Related issues/external references

Fixes #

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [x] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
