### PR TITLE
Exclude `install/update/*.img.gz` from backup archive

### DIFF
--- a/install/backup.php
+++ b/install/backup.php
@@ -146,6 +146,7 @@ try {
 		'python_venv',
 		'resources/venv',
 		'/vendor',
+		'install/update/*.img.gz',
 		config::byKey('backup::path'),
 	);
 


### PR DESCRIPTION
Exclude  Smart/Atlas system image files from `install/update` to avoid unnecessary backup size.