### PR TITLE
fix: randText function

### DIFF
--- a/core/class/scenarioExpression.class.php
+++ b/core/class/scenarioExpression.class.php
@@ -223,7 +223,9 @@ class scenarioExpression {
 		if (is_array($result)) {
 			$nbr = mt_rand(0, count($result) - 1);
 			return $result[$nbr];
-		} else {
+		}
+		return $result;
+    }
 			return $result;
 		}
 	}

--- a/core/class/scenarioExpression.class.php
+++ b/core/class/scenarioExpression.class.php
@@ -221,13 +221,12 @@ class scenarioExpression {
 			$result = $_aValue;
 		}
 		if (is_array($result)) {
-			$nbr = mt_rand(0, count($result) - 1);
-			return $result[$nbr];
+			if (count($result) === 0) {
+				return '';
+			}
+			return $result[array_rand($result)];
 		}
 		return $result;
-    }
-			return $result;
-		}
 	}
 
 	public static function scenario($_scenario) {

--- a/core/class/scenarioExpression.class.php
+++ b/core/class/scenarioExpression.class.php
@@ -213,18 +213,18 @@ class scenarioExpression {
 		$_sValue = self::setTags($_sValue);
 		$_aValue = explode(";", $_sValue);
 		try {
-			$result = evaluate($_aValue);
+			$result = evaluate($_sValue);
 			if (is_string($result)) {
 				$result = $_aValue;
 			}
 		} catch (Exception $e) {
 			$result = $_aValue;
 		}
-		if (is_array($_aValue)) {
-			$nbr = mt_rand(0, count($_aValue) - 1);
-			return $_aValue[$nbr];
+		if (is_array($result)) {
+			$nbr = mt_rand(0, count($result) - 1);
+			return $result[$nbr];
 		} else {
-			return $_aValue;
+			return $result;
 		}
 	}
 


### PR DESCRIPTION
## Description
Fix randText qui brise sous php8. La fonction utilise incorrectement evaluate en lui passant un array alors qu'elle attend un string.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have checked there is no other PR open for the same change.
- [ ] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [X] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [ ] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.
