### PR TITLE
Refactor: improve error handling in GitHub repo class

### DIFF
--- a/core/repo/github.repo.php
+++ b/core/repo/github.repo.php
@@ -22,19 +22,19 @@ require_once __DIR__ . '/../../core/php/core.inc.php';
 
 class repo_github {
 	/*     * *************************Attributs****************************** */
-	
+
 	public static $_name = 'Github';
-	
+
 	public static $_scope = array(
 		'plugin' => true,
 		'backup' => false,
 		'hasConfiguration' => true,
 		'core' => true,
 	);
-	
-	
+
+
 	/*     * ***********************Méthodes statiques*************************** */
-	
+
 	public static function getConfigurationOption(){
 		return array(
 			'parameters_for_add' => array(
@@ -79,7 +79,7 @@ class repo_github {
 			),
 		);
 	}
-	
+
 	public static function checkUpdate(&$_update) {
 		if (is_array($_update)) {
 			if (count($_update) < 1) {
@@ -123,7 +123,7 @@ class repo_github {
 		$request_http->setHeader($headers);
 		return json_decode($request_http->exec(10, 1), true);
 	}
-	
+
 	public static function downloadObject($_update) {
 		$token = $_update->getConfiguration('token',config::byKey('github::token','core',''));
 		$branch = self::getBranchInfo($_update);
@@ -141,29 +141,41 @@ class repo_github {
 		$url = 'https://api.github.com/repos/' . $_update->getConfiguration('user') . '/' . $_update->getConfiguration('repository') . '/zipball/' . $_update->getConfiguration('version', 'master');
 		log::add('update', 'alert', __('Téléchargement de', __FILE__) . ' ' . $_update->getLogicalId() . '...');
 		if ($token == '') {
-			$result = shell_exec('curl -s -L ' . $url . ' > ' . $tmp);
+			exec('curl -s -f -L -o ' . escapeshellarg($tmp) . ' ' . escapeshellarg($url) . ' 2>&1', $output, $return_code);
 		} else {
-			$result = shell_exec('curl -s -H "Authorization: token ' . $token . '" -L ' . $url . ' > ' . $tmp);
+			exec('curl -s -f -L -H "Authorization: token ' . escapeshellarg($token) . '" -o ' . escapeshellarg($tmp) . ' ' . escapeshellarg($url) . ' 2>&1', $output, $return_code);
 		}
-		log::add('update', 'alert', $result);
-		
+		if ($return_code !== 0 || !file_exists($tmp) || filesize($tmp) == 0) {
+			$error_msg = __('Erreur lors du téléchargement', __FILE__);
+			if (!empty($output)) {
+				$error_msg .= ': ' . implode("\n", $output);
+			}
+			if (!file_exists($tmp)) {
+				$error_msg .= ' - ' . __('Fichier non créé', __FILE__);
+			} elseif (filesize($tmp) == 0) {
+				$error_msg .= ' - ' . __('Fichier vide', __FILE__);
+			}
+			log::add('update', 'error', $error_msg);
+			throw new Exception($error_msg);
+		}
+		log::add('update', 'info', __('Téléchargement réussi', __FILE__) . ' (' . round(filesize($tmp) / 1024 / 1024, 2) . ' MB)');
+
 		if (!isset($branch['commit']) || !isset($branch['commit']['sha'])) {
 			return array('path' => $tmp);
 		}
 		return array('localVersion' => $branch['commit']['sha'], 'path' => $tmp);
 	}
-	
+
 	public static function deleteObjet($_update) {
-		
 	}
-	
+
 	public static function objectInfo($_update) {
 		return array(
 			'doc' => 'https://github.com/' . $_update->getConfiguration('user') . '/' . $_update->getConfiguration('repository') . '/blob/' . $_update->getConfiguration('version', 'master') . '/doc/' . config::byKey('language', 'core', 'fr_FR') . '/index.asciidoc',
 			'changelog' => 'https://github.com/' . $_update->getConfiguration('user') . '/' . $_update->getConfiguration('repository') . '/commits/' . $_update->getConfiguration('version', 'master'),
 		);
 	}
-	
+
 	public static function downloadCore($_path) {
 		$url = 'https://api.github.com/repos/' . config::byKey('github::core::user', 'core', 'jeedom') . '/' . config::byKey('github::core::repository', 'core', 'core') . '/zipball/' . config::byKey('github::core::branch', 'core', 'stable');
 		echo __('Téléchargement de', __FILE__) . ' ' . $url . '...';
@@ -174,15 +186,14 @@ class repo_github {
 		}
 		return;
 	}
-	
+
 	public static function versionCore() {
 		$url = 'https://raw.githubusercontent.com/'.config::byKey('github::core::user', 'core', 'jeedom').'/'.config::byKey('github::core::repository', 'core', 'core').'/' . config::byKey('github::core::branch', 'core', 'stable') . '/core/config/version';
 		$request_http = new com_http($url);
 		return trim($request_http->exec(30));
 	}
-	
+
 	/*     * *********************Methode d'instance************************* */
-	
+
 	/*     * **********************Getteur Setteur*************************** */
-	
 }


### PR DESCRIPTION
## Description
Fix PHP Fatal error in github repo on log because $result is always null

### Suggested changelog entry
- Correction d'un bug sous Debian 12 lors de l'installation d'un plugin via github

### Related issues/external references

Fixes https://community.jeedom.com/t/bug-4-5-3-installation-plugin-github/147851


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have checked there is no other PR open for the same change.
- [X] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [X] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [X] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.
