### PR TITLE
Fix: scenario expression execute without scenario

### DIFF
--- a/core/class/scenarioExpression.class.php
+++ b/core/class/scenarioExpression.class.php
@@ -1380,7 +1380,7 @@ class scenarioExpression {
 		return;
 	}
 
-	public function execute(&$scenario = null) {
+	public function execute(?scenario &$scenario = null) {
 		if ($scenario !== null && !$scenario->getDo()) {
 			return;
 		}
@@ -1480,9 +1480,7 @@ class scenarioExpression {
 					}
 					die();
 				} elseif ($this->getExpression() == 'log') {
-					if ($scenario !== null) {
-						$scenario->setLog('Log : ' . $options['message']);
-					}
+					$this->setLog($scenario, 'Log : ' . $options['message']);
 					return;
 				} elseif ($this->getExpression() == 'event') {
 					$cmd = cmd::byId(trim(str_replace('#', '', $options['cmd'])));
@@ -1681,6 +1679,9 @@ class scenarioExpression {
 					$this->setLog($scenario, __('Suppression de la variable', __FILE__) . ' ' . $options['name']);
 					return;
 				} elseif ($this->getExpression() == 'ask') {
+					if ($scenario == null || !is_object($scenario)) {
+						return;
+					}
 					$dataStore = new dataStore();
 					$dataStore->setType('scenario');
 					$dataStore->setKey($options['variable']);
@@ -1696,11 +1697,9 @@ class scenarioExpression {
 					}
 					$options_cmd = array('title' => $options['question'], 'message' => $options['question'], 'answer' => $answer, 'timeout' => $limit, 'variable' => $options['variable']);
 
-					if ($scenario !== null) {
-						$tags = $scenario->getTags();
+					$tags = $scenario->getTags();
 						if (isset($tags['#profile#']) === true) {
-							$this->setOptions('cmd', str_replace('#profile#', $tags['#profile#'], $this->getOptions('cmd')));
-						}
+						$this->setOptions('cmd', str_replace('#profile#', $tags['#profile#'], $this->getOptions('cmd')));
 					}
 
 					$cmd = cmd::byId(str_replace('#', '', $this->getOptions('cmd')));
@@ -1758,13 +1757,16 @@ class scenarioExpression {
 					jeedom::rebootSystem();
 					return;
 				} elseif ($this->getExpression() == 'scenario_return') {
-					$this->setLog($scenario, __('Demande de retour d\'information :', __FILE__) . ' ' . $options['message']);
-					if ($scenario->getReturn() === true) {
-						$scenario->setReturn($options['message']);
-					} else {
-						$scenario->setReturn($scenario->getReturn() . ' ' . $options['message']);
+					if ($scenario !== null) {
+						$this->setLog($scenario, __('Demande de retour d\'information :', __FILE__) . ' ' . $options['message']);
+						if ($scenario->getReturn() === true) {
+							$scenario->setReturn($options['message']);
+						} else {
+							$scenario->setReturn($scenario->getReturn() . ' ' . $options['message']);
+						}
+						return;
 					}
-					return;
+					die();
 				} elseif ($this->getExpression() == 'remove_inat') {
 					if (isset($options['scenario_id']) && intval($options['scenario_id']) != 0) {
 						$targetScenario = scenario::byId($options['scenario_id']);
@@ -1920,6 +1922,9 @@ class scenarioExpression {
 						}
 					}
 				} elseif ($this->getExpression() == 'tag') {
+					if ($scenario == null || !is_object($scenario)) {
+						return;
+					}
 					$tags = $scenario->getTags();
 					$options['value'] = self::setTags($options['value'], $scenario);
 					try {
@@ -1950,7 +1955,9 @@ class scenarioExpression {
 							}
 							$result = call_user_func_array('userFunction::' . $functionName, $arguments);
 							$this->setLog($scenario, 'userFunction: ' . $stringFunction . ' : ' . json_encode($result));
-							$scenario->persistLog();
+							if ($scenario !== null) {
+								$scenario->persistLog();
+							}
 							return;
 						}
 					}

--- a/core/class/scenarioExpression.class.php
+++ b/core/class/scenarioExpression.class.php
@@ -1677,7 +1677,10 @@ class scenarioExpression {
 						$result = $options['value'];
 					}
 				} elseif ($this->getExpression() == 'delete_variable') {
-					scenario::removeData($options['name']);
+					$dataStore = dataStore::byTypeLinkIdKey('scenario', -1, $options['name']);
+					if (is_object($dataStore)) {
+						$dataStore->remove();
+					}
 					$this->setLog($scenario, __('Suppression de la variable', __FILE__) . ' ' . $options['name']);
 					return;
 				} elseif ($this->getExpression() == 'ask') {

--- a/core/class/scenarioExpression.class.php
+++ b/core/class/scenarioExpression.class.php
@@ -1677,7 +1677,7 @@ class scenarioExpression {
 						$result = $options['value'];
 					}
 				} elseif ($this->getExpression() == 'delete_variable') {
-					$scenario->removeData($options['name']);
+					scenario::removeData($options['name']);
 					$this->setLog($scenario, __('Suppression de la variable', __FILE__) . ' ' . $options['name']);
 					return;
 				} elseif ($this->getExpression() == 'ask') {

--- a/core/class/scenarioExpression.class.php
+++ b/core/class/scenarioExpression.class.php
@@ -1682,9 +1682,6 @@ class scenarioExpression {
 					$this->setLog($scenario, __('Suppression de la variable', __FILE__) . ' ' . $options['name']);
 					return;
 				} elseif ($this->getExpression() == 'ask') {
-					if ($scenario == null || !is_object($scenario)) {
-						return;
-					}
 					$dataStore = new dataStore();
 					$dataStore->setType('scenario');
 					$dataStore->setKey($options['variable']);
@@ -1700,9 +1697,11 @@ class scenarioExpression {
 					}
 					$options_cmd = array('title' => $options['question'], 'message' => $options['question'], 'answer' => $answer, 'timeout' => $limit, 'variable' => $options['variable']);
 
-					$tags = $scenario->getTags();
+					if ($scenario !== null) {
+						$tags = $scenario->getTags();
 						if (isset($tags['#profile#']) === true) {
-						$this->setOptions('cmd', str_replace('#profile#', $tags['#profile#'], $this->getOptions('cmd')));
+							$this->setOptions('cmd', str_replace('#profile#', $tags['#profile#'], $this->getOptions('cmd')));
+						}
 					}
 
 					$cmd = cmd::byId(str_replace('#', '', $this->getOptions('cmd')));
@@ -1738,7 +1737,8 @@ class scenarioExpression {
 						$dataStore->setValue($value);
 						$dataStore->save();
 					}
-					event::add('scenario::ask', array('scenario_id' => $scenario->getId(), 'variable' => $options['variable'], 'value' => $value));
+					// TODO: deactivate now because not used and not documented and this cause issue in case scenarion does not exist; approache for new events should be reviewed globally in a new issue
+					// event::add('scenario::ask', array('scenario_id' => $scenario->getId(), 'variable' => $options['variable'], 'value' => $value));
 					$this->setLog($scenario, __('Réponse', __FILE__) . ' ' . $value);
 					return;
 				} elseif ($this->getExpression() == 'jeedom_poweroff') {

--- a/core/class/scenarioExpression.class.php
+++ b/core/class/scenarioExpression.class.php
@@ -1478,7 +1478,7 @@ class scenarioExpression {
 						$scenario->setDo(false);
 						return;
 					}
-					die();
+					return;
 				} elseif ($this->getExpression() == 'log') {
 					$this->setLog($scenario, 'Log : ' . $options['message']);
 					return;
@@ -1769,7 +1769,7 @@ class scenarioExpression {
 						}
 						return;
 					}
-					die();
+					return;
 				} elseif ($this->getExpression() == 'remove_inat') {
 					if (isset($options['scenario_id']) && intval($options['scenario_id']) != 0) {
 						$targetScenario = scenario::byId($options['scenario_id']);

--- a/core/js/scenario.class.js
+++ b/core/js/scenario.class.js
@@ -562,6 +562,7 @@ jeedom.scenario.autoCompleteCondition = [
 ]
 /* Actions Autocomplete */
 jeedom.scenario.autoCompleteAction = [
+  'ask',
   'setColoredIcon',
   'report',
   'exportHistory',
@@ -583,7 +584,6 @@ jeedom.scenario.autoCompleteAction = [
 ]
 /* Actions Autocomplete only for scenarios*/
 jeedom.scenario.autoCompleteActionScOnly = [
-  'ask',
   'stop',
   'log',
   'scenario_return',

--- a/core/js/scenario.class.js
+++ b/core/js/scenario.class.js
@@ -563,7 +563,6 @@ jeedom.scenario.autoCompleteCondition = [
 /* Actions Autocomplete */
 jeedom.scenario.autoCompleteAction = [
   'setColoredIcon',
-  'tag',
   'report',
   'exportHistory',
   'sleep',
@@ -574,7 +573,6 @@ jeedom.scenario.autoCompleteAction = [
   'gotodesign',
   'message',
   'equipement',
-  'ask',
   'jeedom_poweroff',
   'alert',
   'popup',
@@ -585,10 +583,12 @@ jeedom.scenario.autoCompleteAction = [
 ]
 /* Actions Autocomplete only for scenarios*/
 jeedom.scenario.autoCompleteActionScOnly = [
+  'ask',
   'stop',
   'log',
   'scenario_return',
-  'icon'
+  'icon',
+  'tag'
 ]
 
 jeedom.scenario.setAutoComplete = function(_params) {


### PR DESCRIPTION
## Description
Protect usage of variable $scenrio when functions used outside scenario + adapt autocomplete to not propose function that doesn't work outside scenario

This PR is the follow up of https://github.com/jeedom/core/pull/3226 (and so expression `delete_variable` wasn't cover in this PR)


### Suggested changelog entry
- Correction de bug lors de l'utilisation de function en dehors de scenario
- suppression des fonctions `ask` & `tag` de l'auto-completion en dehors des scenarios


### Related issues/external references

Fixes https://github.com/jeedom/core/issues/3227


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have checked there is no other PR open for the same change.
- [X] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [X] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [X] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.

