### PR TITLE
Enhance search log filter with term support

### DIFF
--- a/desktop/js/log.js
+++ b/desktop/js/log.js
@@ -37,28 +37,24 @@ if (!jeeFrontEnd.log) {
 
 //searching
 document.getElementById('in_searchLogFilter')?.addEventListener('keyup', function(event) {
-  var search = event.target.value
-  if (search == '') {
+  var raw = event.target.value
+  if (raw == '') {
     jeeP.logListButtons.seen()
     return
   }
-  var not = search.startsWith(":not(")
-  if (not) {
-    search = search.replace(':not(', '')
-  }
-  search = jeedomUtils.normTextLower(search)
+
+  // Découpe sur la virgule → liste de termes (avec support :not par terme)
+  var terms = raw.split(',').map(t => t.trim()).filter(t => t.length > 0)
+
   jeeP.logListButtons.unseen()
-  var match, text
   jeeP.logListButtons.forEach(_bt => {
-    match = false
-    text = jeedomUtils.normTextLower(_bt.textContent)
-    if (text.includes(search)) {
-      match = true
-    }
-    if (not) match = !match
-    if (match) {
-      _bt.seen()
-    }
+    var text = jeedomUtils.normTextLower(_bt.textContent)
+    var match = terms.some(term => {
+      var not = term.startsWith(':not(')
+      var search = jeedomUtils.normTextLower(not ? term.slice(5, -1) : term)
+      return not ? !text.includes(search) : text.includes(search)
+    })
+    if (match) _bt.seen()
   })
 })
 


### PR DESCRIPTION
Titre : Refactor search functionality to support multiple terms and :not filter.

## Description

The log filter input (`in_searchLogFilter`) previously supported only a single search term at a time, requiring users to retype their query to switch between logs.

This refactor allows multiple comma-separated terms to be entered simultaneously (e.g. `ai_assistant,jee_mcp`), so several logs can be highlighted at once. The existing `:not()` syntax is preserved and now works per-term, meaning it can be mixed with positive terms in the same query.

No changes to the PHP side or the rest of the JS page were required.

### Suggested changelog entry

> Log filter now supports multiple comma-separated terms and per-term `:not()` exclusion.

### Related issues/external references

Fixes #

## Types of changes

- [ ] Bug fix
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change
- [ ] Documentation improvement

## PR checklist

- [ ] I have checked there is no other PR open for the same change.
- [ ] I have read the contribution guidelines.
- [x] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.
