### PR TITLE
fix: resolve 3 bugs in proxy configuration in jsonrpcClient

### DIFF
--- a/core/class/jsonrpcClient.class.php
+++ b/core/class/jsonrpcClient.class.php
@@ -138,21 +138,22 @@ class jsonrpcClient {
 				curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
 				curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
 			}
-			if(config::byKey('proxyEnabled')) {
-				if(config::byKey('proxyAddress') == ''){ 
-				// throw new Exception(__('renseigne l\'adresse', __FILE__));
-				$this->error = 'Erreur address ';
-			} else if (config::byKey('proxyPort') == ''){
-			// throw new Exception(__('renseigne le port', __FILE__));
-			} else {
-				curl_setopt($ch, CURLOPT_PROXY, config::byKey('proxyAddress'));
-				curl_setopt($ch, CURLOPT_PROXYPORT, config::byKey('proxyPort'));
-				if(!empty(config::byKey('proxyLogin') || config::byKey('proxyPassword'))){
-					curl_setopt($ch, CURLOPT_PROXYUSERPWD, 'proxyLogin:proxyPassword');
+			if (config::byKey('proxyEnabled') == 1) {
+				$proxyAddress = config::byKey('proxyAddress');
+				$proxyPort = config::byKey('proxyPort');
+				if ($proxyAddress != '' && $proxyPort != '') {
+					curl_setopt($ch, CURLOPT_PROXY, $proxyAddress);
+					curl_setopt($ch, CURLOPT_PROXYPORT, $proxyPort);
+					$proxyLogin = config::byKey('proxyLogin');
+					$proxyPassword = config::byKey('proxyPassword');
+					if (!empty($proxyLogin) || !empty($proxyPassword)) {
+						curl_setopt($ch, CURLOPT_PROXYUSERPWD, $proxyLogin . ':' . $proxyPassword);
+					}
+				} else {
+					$this->error = 'Proxy enabled but address or port is missing';
+					log::add('connection', 'error', $this->error);
 				}
-				log::add('Connection', 'debug', $ch);
-			} 
-		}
+			}
 			$response = curl_exec($ch);
 			$http_status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 			$nbRetry++;


### PR DESCRIPTION
> Suite à la PR #3235  (sur alpha), rebasée sur `develop` comme demandé.

## Problème

Le bloc proxy dans `core/class/jsonrpcClient.class.php` (méthode `send()`) contient 3 bugs qui peuvent provoquer l'échec des appels JSON-RPC même lorsqu'aucun proxy n'est configuré.

### Bug 1 — `empty()` évalue un booléen au lieu des valeurs config

```php
// Avant (cassé) : || est évalué avant empty()
if(!empty(config::byKey('proxyLogin') || config::byKey('proxyPassword')))
// Après (corrigé)
if (!empty(config::byKey('proxyLogin')) || !empty(config::byKey('proxyPassword')))
```

### Bug 2 — Credentials proxy en dur au lieu des valeurs config

```php
// Avant (cassé) : envoie la string littérale "proxyLogin:proxyPassword"
curl_setopt($ch, CURLOPT_PROXYUSERPWD, 'proxyLogin:proxyPassword');
// Après (corrigé)
curl_setopt($ch, CURLOPT_PROXYUSERPWD, config::byKey('proxyLogin') . ':' . config::byKey('proxyPassword'));
```

### Bug 3 — Pas de gestion d'erreur quand le port proxy est vide

Quand `proxyPort` est vide, le `throw` est commenté et aucune erreur n'est levée. Le code continue et curl tente d'utiliser un proxy partiellement configuré.

## Correction supplémentaire

- Utilisation de `config::byKey('proxyEnabled') == 1` (comparaison stricte) au lieu de `config::byKey('proxyEnabled')` pour éviter l'activation du bloc proxy avec des valeurs truthy inattendues
- Suppression de `log::add('Connection', 'debug', $ch)` (logger une ressource curl n'a pas de sens)
- Indentation et structure de code corrigées

## Impact

Les utilisateurs sans proxy configuré peuvent subir des échecs d'appels JSON-RPC si `proxyEnabled` retourne une valeur truthy inattendue. Le seul contournement actuel est de commenter manuellement le bloc proxy après chaque mise à jour Jeedom.

## Fichier modifié

- `core/class/jsonrpcClient.class.php` — méthode `send()`, bloc de configuration proxy