### PR TITLE
Fix: issue displaying history if grouping type is set

### DIFF
--- a/core/ajax/cmd.ajax.php
+++ b/core/ajax/cmd.ajax.php
@@ -246,12 +246,12 @@ try {
 	}
 
 	if (init('action') == 'byEqLogic') {
-        if (init('typeCmd')) {
-            ajax::success(utils::o2a(cmd::byEqLogicId(init('eqLogic_id'), init('typeCmd'))));
-        } else {
-            ajax::success(utils::o2a(cmd::byEqLogicId(init('eqLogic_id'))));
-        }
-     }
+		if (init('typeCmd')) {
+			ajax::success(utils::o2a(cmd::byEqLogicId(init('eqLogic_id'), init('typeCmd'))));
+		} else {
+			ajax::success(utils::o2a(cmd::byEqLogicId(init('eqLogic_id'))));
+		}
+	}
 
 	if (init('action') == 'getCmd') {
 		$cmd = cmd::byId(init('id'));
@@ -422,6 +422,9 @@ try {
 			}
 			$return['derive'] = $derive;
 			$groupingType = init('groupingType');
+			if (is_array($groupingType)) {
+				$groupingType = implode('::', array_values($groupingType));
+			}
 			if ($groupingType == '') {
 				$groupingType = $cmd->getDisplay('groupingType');
 			}
@@ -497,7 +500,7 @@ try {
 	if (init('action') == 'getLastHistory') {
 		$cmd = cmd::byId(init('id'));
 		$_time = date('Y-m-d H:i:s', strtotime(init('time')));
-		if(is_object($cmd)){
+		if (is_object($cmd)) {
 			ajax::success($cmd->getLastHistory($_time));
 		} else {
 			throw new Exception(__('Nombre maximum de niveaux d’éléments affichés dans les graphiques de liens', __FILE__) . ' ' . init('id'));

--- a/core/ajax/cmd.ajax.php
+++ b/core/ajax/cmd.ajax.php
@@ -423,7 +423,11 @@ try {
 			$return['derive'] = $derive;
 			$groupingType = init('groupingType');
 			if (is_array($groupingType)) {
-				$groupingType = implode('::', array_values($groupingType));
+				if (isset($groupingType['function']) && isset($groupingType['time'])) {
+					$groupingType = $groupingType['function'] . '::' . $groupingType['time'];
+				} else {
+					$groupingType = implode('::', array_values($groupingType));
+				}
 			}
 			if ($groupingType == '') {
 				$groupingType = $cmd->getDisplay('groupingType');


### PR DESCRIPTION
Fixes https://community.jeedom.com/t/historique-dune-info-genere-uncaught-typeerror-haystack-dans-http-error/148400

Source : https://github.com/jeedom/core/blob/master/core/js/history.class.js#L1886

`cmd_option.groupingType` is set as an array on lines [413](https://github.com/jeedom/core/blob/master/core/js/history.class.js#L413) & [682](https://github.com/jeedom/core/blob/master/core/js/history.class.js#L682) but a string is required for `$cmd->getHistory()`.

### Suggested changelog entry

>- **Historique** : correction de la sélection de plage de dates *(Zoom)* avec groupement

