### PR TITLE
feat: improve "do not remove log" feature

### DIFF
--- a/core/class/log.class.php
+++ b/core/class/log.class.php
@@ -187,16 +187,15 @@ class log extends AbstractLogger {
 	/**
 	 * Check authorisation to emptying log file
 	 */
-	public static function authorizeClearLog($_log, $_subPath = '') {
+	public static function authorizeClearLog(string $_log, string $_subPath = ''): bool {
 		$path = self::getPathToLog($_subPath . $_log);
-		return !((strpos($_log, '.htaccess') !== false)
-			|| (!file_exists($path) || !is_file($path)));
+		return !((strpos($_log, '.htaccess') !== false) || (!file_exists($path) || !is_file($path)));
 	}
 
 	/**
 	 * Empty log file
 	 */
-	public static function clear($_log) {
+	public static function clear(string $_log) {
 		if (self::authorizeClearLog($_log)) {
 			$path = self::getPathToLog($_log);
 			com_shell::execute(system::getCmdSudo() . 'chmod 664 ' . $path . '> /dev/null 2>&1;' . system::getCmdSudo() . 'chown -R ' . system::get('www-uid') . ':' . system::get('www-gid') . ' ' . $path . ' > /dev/null 2>&1;' . system::getCmdSudo() . ' cat /dev/null > ' . $path);
@@ -205,66 +204,106 @@ class log extends AbstractLogger {
 		return;
 	}
 
-	public static function clearAll() {
+	public static function clearAll(): void {
 		foreach (ls(self::getPathToLog(''), '*', false, array('files')) as $log)
 			self::clear($log);
+		return;
+	}
+
+	private static function getActiveDaemonPluginIdsSortedByLength(): array {
+		static $activePluginsWithDaemon = null;
+		if ($activePluginsWithDaemon === null) {
+			$activePluginsWithDaemon = [];
+			foreach (plugin::listPlugin(true) as $plugin) {
+				if ($plugin->getHasOwnDeamon() == 0) continue;
+				$activePluginsWithDaemon[] = $plugin->getId();
+			}
+			usort($activePluginsWithDaemon, function ($a, $b) {
+				return strlen($b) - strlen($a);
+			});
+		}
+
+		return $activePluginsWithDaemon;
+	}
+
+	private static function canRemoveLog(string $_log): bool {
+		if (strpos($_log, 'nginx.error') !== false || strpos($_log, 'http.error') !== false) {
+			return false;
+		}
+
+		if (substr($_log, -9) === '_packages' || substr($_log, -7) === '_update') {
+			return true;
+		}
+
+		// if a new core log is added to the codebase, add it here to prevent a plugin with the same name from protecting it by mistake.
+		static $coreLogNames = [
+			'api',
+			'apipro',
+			'backup',
+			'cmd',
+			'connection',
+			'cron',
+			'cron_execution',
+			'debug_translate',
+			'design',
+			'event',
+			'expression',
+			'history',
+			'http.com',
+			'interact',
+			'jeedom',
+			'jeedomAlert',
+			'jeeEvent',
+			'listener',
+			'listener_execution',
+			'market',
+			'monitoring_cloud',
+			'network',
+			'plugin',
+			'queue',
+			'report',
+			'scenario',
+			'starting',
+			'tts',
+			'update',
+		];
+		if (in_array($_log, $coreLogNames)) {
+			return true;
+		}
+
+		$plugins = self::getActiveDaemonPluginIdsSortedByLength();
+		foreach ($plugins as $plugin) {
+			if (strpos($_log, $plugin) === 0) {
+				if ($_log !== $plugin) {
+					return false;
+				}
+				return true;
+			}
+		}
+
 		return true;
 	}
 
 	/**
 	 * Delete log file
 	 */
-	public static function remove($_log) {
-		if (strpos($_log, 'nginx.error') !== false || strpos($_log, 'http.error') !== false) {
+	public static function remove(string $_log) {
+		if (!self::canRemoveLog($_log)) {
 			self::clear($_log);
 			return;
 		}
-		static $activePlugins = null;
-		if ($activePlugins === null) {
-			// TODO: si un nouveau log core est ajouté dans le codebase, l'ajouter ici pour éviter qu'un plugin homonyme ne le protège par erreur.
-			$coreLogNames = [
-				'api', 'apipro', 'backup', 'cmd', 'connection', 'cron', 'debug_translate',
-				'design', 'event', 'expression', 'history', 'http.com', 'interact', 'jeedom',
-				'jeedomAlert', 'jeeEvent', 'listener', 'market', 'monitoring_cloud', 'network',
-				'plugin', 'queue', 'report', 'scenario', 'starting', 'tts', 'update',
-			];
-			$activePlugins = [];
-			foreach (plugin::listPlugin(true) as $plugin) {
-				$plugin_id = $plugin->getId();
-				if (!in_array($plugin_id, $coreLogNames)) {
-					$activePlugins[] = [
-						'id'        => $plugin_id,
-						'hasDaemon' => ($plugin->getHasOwnDeamon() == 1),
-					];
-				}
-			}
-			usort($activePlugins, function ($a, $b) {
-				return strlen($b['id']) - strlen($a['id']);
-			});
-		}
-		foreach ($activePlugins as $plugin) {
-			if (strpos($_log, $plugin['id']) === 0) {
-				if ($_log !== $plugin['id'] && $plugin['hasDaemon']) {
-					self::clear($_log);
-					return;
-				}
-				break;
-			}
-		}
+
 		if (self::authorizeClearLog($_log)) {
 			$path = self::getPathToLog($_log);
 			com_shell::execute(system::getCmdSudo() . 'chmod 664 ' . $path . ' > /dev/null 2>&1;' . system::getCmdSudo() . 'chown -R ' . system::get('www-uid') . ':' . system::get('www-gid') . ' ' . $path . ' > /dev/null 2>&1;' . system::getCmdSudo() . ' cat /dev/null > ' . $path . ';rm ' . $path . ' 2>&1 > /dev/null');
-
-
-
 			return true;
 		}
 	}
 
-	public static function removeAll() {
+	public static function removeAll(): void {
 		foreach (ls(self::getPathToLog(''), '*', false, array('files')) as $log)
 			self::remove($log);
-		return true;
+		return;
 	}
 
 	/**

--- a/core/class/log.class.php
+++ b/core/class/log.class.php
@@ -219,17 +219,36 @@ class log extends AbstractLogger {
 			self::clear($_log);
 			return;
 		}
-		if (endsWith($_log, 'd') || endsWith($_log, 'd_1') || endsWith($_log, 'd_2') || endsWith($_log, 'd_3')) {
-			self::clear($_log);
-			return;
+		static $activePlugins = null;
+		if ($activePlugins === null) {
+			// TODO: si un nouveau log core est ajouté dans le codebase, l'ajouter ici pour éviter qu'un plugin homonyme ne le protège par erreur.
+			$coreLogNames = [
+				'api', 'apipro', 'backup', 'cmd', 'connection', 'cron', 'debug_translate',
+				'design', 'event', 'expression', 'history', 'http.com', 'interact', 'jeedom',
+				'jeedomAlert', 'jeeEvent', 'listener', 'market', 'monitoring_cloud', 'network',
+				'plugin', 'queue', 'report', 'scenario', 'starting', 'tts', 'update',
+			];
+			$activePlugins = [];
+			foreach (plugin::listPlugin(true) as $plugin) {
+				$plugin_id = $plugin->getId();
+				if (!in_array($plugin_id, $coreLogNames)) {
+					$activePlugins[] = [
+						'id'        => $plugin_id,
+						'hasDaemon' => ($plugin->getHasOwnDeamon() == 1),
+					];
+				}
+			}
+			usort($activePlugins, function ($a, $b) {
+				return strlen($b['id']) - strlen($a['id']);
+			});
 		}
-		foreach (plugin::listPlugin(true) as $plugin) {
-			$plugin_id = $plugin->getId();
-			if (method_exists($plugin_id, 'logProtect')) {
-				if (in_array($_log, $plugin_id::logProtect(), true)) {
+		foreach ($activePlugins as $plugin) {
+			if (strpos($_log, $plugin['id']) === 0) {
+				if ($_log !== $plugin['id'] && $plugin['hasDaemon']) {
 					self::clear($_log);
 					return;
 				}
+				break;
 			}
 		}
 		if (self::authorizeClearLog($_log)) {

--- a/core/class/log.class.php
+++ b/core/class/log.class.php
@@ -223,6 +223,15 @@ class log extends AbstractLogger {
 			self::clear($_log);
 			return;
 		}
+		foreach (plugin::listPlugin(true) as $plugin) {
+			$plugin_id = $plugin->getId();
+			if (method_exists($plugin_id, 'logProtect')) {
+				if (in_array($_log, $plugin_id::logProtect(), true)) {
+					self::clear($_log);
+					return;
+				}
+			}
+		}
 		if (self::authorizeClearLog($_log)) {
 			$path = self::getPathToLog($_log);
 			com_shell::execute(system::getCmdSudo() . 'chmod 664 ' . $path . ' > /dev/null 2>&1;' . system::getCmdSudo() . 'chown -R ' . system::get('www-uid') . ':' . system::get('www-gid') . ' ' . $path . ' > /dev/null 2>&1;' . system::getCmdSudo() . ' cat /dev/null > ' . $path . ';rm ' . $path . ' 2>&1 > /dev/null');


### PR DESCRIPTION
## Description

edit by @Mips2648 : the below description is not relevant anymore, see comment https://github.com/jeedom/core/pull/3245#issuecomment-4207039632

Adds a `logProtect()` plugin hook in `log::remove()` so that plugins can
declare log files that should be **cleared** (emptied) instead of **deleted**.

## Why?

The list of protected logs in `log::remove()` is currently hard-coded in the
Core (`nginx.error`, `http.error`, logs ending with `d`/`d_1`/`d_2`/`d_3`).
A plugin with a log file like `myplugin_events` or `myplugin_audit` has no way
to prevent its permanent deletion when `log::remove()` is called.

## How?

Exact same pattern as `backupExclude()` already used in `install/backup.php`:
- `plugin::listPlugin(true)` + `method_exists()` + static call
- No new mechanism, no database change, no migration

Plugins that want to protect a log file simply declare:

```php
public static function logProtect(): array {
    return ['myplugin_events', 'myplugin_audit'];
}
```

## Impact

- **Fully backward-compatible**: plugins without `logProtect()` are unaffected
- `log::removeAll()` is automatically covered (it calls `self::remove()`)
- Same performance cost as `backupExclude()` in backup.php (already accepted)

## Files changed

- `core/class/log.class.php` — +9 lines in `remove()`

### Suggested changelog entry
<!-- Please provide a short description of the change for the changelog. -->

Les plugins peuvent désormais déclarer une méthode statique `logProtect(): array` pour protéger des fichiers de log contre la suppression. Les logs listés seront vidés (`log::clear`) au lieu d'être supprimés définitivement lors d'un appel à `log::remove()`.

### Related issues/external references

Fixes #


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [x] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
