### PR TITLE
fix(core): prevent null select in scenario templates after async load

### DIFF
--- a/core/template/scenario/remove_inat.default.html
+++ b/core/template/scenario/remove_inat.default.html
@@ -11,6 +11,7 @@
     },
     success: function (scenarios) {
       let select = document.querySelector('.expressionAttr[data-uid="#uid#"][data-l1key="options"][data-l2key="scenario_id"]')
+      if (!select) return
       let currentScenario = document.querySelector('.scenarioAttr[data-l1key=id]')?.jeeValue() // Get current scenario number (if available)
       let hasSelected = false
       let newOption

--- a/core/template/scenario/scenario.default.html
+++ b/core/template/scenario/scenario.default.html
@@ -28,6 +28,7 @@
     },
     success: function (scenarios) {
       const select = document.querySelector('.expressionAttr[data-uid="#uid#"][data-l1key="options"][data-l2key="scenario_id"]')
+      if (!select) return
 
       const groupedScenarios = {}
       for (let i in scenarios) {


### PR DESCRIPTION
## 🐛 Bug

Scenario templates use async loading (`allOrderedByGroupObjectName`) and manipulate a `<select>` element.

If the DOM changes (modal closed, navigation, reload), the `<select>` may no longer exist when the AJAX response returns.

This causes a JS error:
- select is null
- appendChild fails

## ✅ Fix

- Re-query the DOM inside the async callback
- Add guard:

```js
if (!select) return;
```