### PR TITLE
fix: scenario self execute mixing tags

### DIFF
--- a/core/class/scenarioExpression.class.php
+++ b/core/class/scenarioExpression.class.php
@@ -1551,11 +1551,7 @@ class scenarioExpression {
 					event::add('changeTheme', $options['theme']);
 					return;
 				} elseif ($this->getExpression() == 'scenario') {
-					if ($scenario !== null && $this->getOptions('scenario_id') == $scenario->getId()) {
-						$actionScenario = &$scenario;
-					} else {
-						$actionScenario = scenario::byId($this->getOptions('scenario_id'));
-					}
+					$actionScenario = scenario::byId($this->getOptions('scenario_id'));
 					if (!is_object($actionScenario)) {
 						throw new Exception($GLOBALS['JEEDOM_SCLOG_TEXT']['unfoundScenario']['txt'] . $this->getOptions('scenario_id'));
 					}

--- a/core/class/scenarioExpression.class.php
+++ b/core/class/scenarioExpression.class.php
@@ -1579,8 +1579,9 @@ class scenarioExpression {
 								$actionScenario->addTag('trigger', 'other');
 								$actionScenario->addTag('trigger_message', $GLOBALS['JEEDOM_SCLOG_TEXT']['startCausedBy']['txt']);
 							}
-							$this->setLog($scenario, $GLOBALS['JEEDOM_SCLOG_TEXT']['launchScenario']['txt'] . $actionScenario->getName() . ' ' . __('options :', __FILE__) . ' ' . json_encode($actionScenario->getTags()));
 							$forceSync = ($this->getOptions('action') == 'startsync');
+							$launchScenarioLogKey = ($forceSync) ? 'launchScenarioSync' : 'launchScenario';
+							$this->setLog($scenario, $GLOBALS['JEEDOM_SCLOG_TEXT'][$launchScenarioLogKey]['txt'] . $actionScenario->getName() . ' ' . __('options :', __FILE__) . ' ' . json_encode($actionScenario->getTags()));
 							return $actionScenario->launch($forceSync);
 						case 'stop':
 							$this->setLog($scenario, __('Arrêt forcé du scénario :', __FILE__) . ' ' . $actionScenario->getName());

--- a/core/class/scenarioExpression.class.php
+++ b/core/class/scenarioExpression.class.php
@@ -1557,6 +1557,7 @@ class scenarioExpression {
 					}
 					switch ($this->getOptions('action')) {
 						case 'start':
+						case 'startsync':
 							if ($this->getOptions('tags') != '' && !is_array($this->getOptions('tags'))) {
 								$tags = array();
 								$args = arg2array($this->getOptions('tags'));
@@ -1579,34 +1580,8 @@ class scenarioExpression {
 								$actionScenario->addTag('trigger_message', $GLOBALS['JEEDOM_SCLOG_TEXT']['startCausedBy']['txt']);
 							}
 							$this->setLog($scenario, $GLOBALS['JEEDOM_SCLOG_TEXT']['launchScenario']['txt'] . $actionScenario->getName() . ' ' . __('options :', __FILE__) . ' ' . json_encode($actionScenario->getTags()));
-							return $actionScenario->launch();
-							break;
-						case 'startsync':
-							if ($this->getOptions('tags') != '' && !is_array($this->getOptions('tags'))) {
-								$tags = array();
-								$args = arg2array($this->getOptions('tags'));
-								foreach ($args as $key => $value) {
-									$value = trim($value);
-									$tags['#' . trim(trim($key), '#') . '#'] = trim(self::setTags($value, $scenario), '"');
-								}
-								$actionScenario->setTags($tags);
-							}
-							if (is_array($this->getOptions('tags'))) {
-								$actionScenario->setTags($this->getOptions('tags'));
-							}
-							$this->setLog($scenario, $GLOBALS['JEEDOM_SCLOG_TEXT']['launchScenario']['txt'] . $actionScenario->getName() . ' ' . __('options :', __FILE__) . ' ' . json_encode($actionScenario->getTags()));
-							if ($scenario !== null) {
-								$actionScenario->addTag('trigger', 'scenario');
-								$actionScenario->addTag('trigger_message', $GLOBALS['JEEDOM_SCLOG_TEXT']['startByScenario']['txt'] . $scenario->getHumanName());
-								$actionScenario->addTag('trigger_name', trim($scenario->getHumanName(), '#'));
-								$actionScenario->addTag('trigger_id', $scenario->getId());
-								return $actionScenario->launch(true);
-							} else {
-								$actionScenario->addTag('trigger', 'other');
-								$actionScenario->addTag('trigger_message', $GLOBALS['JEEDOM_SCLOG_TEXT']['startCausedBy']['txt']);
-								return $actionScenario->launch(true);
-							}
-							break;
+							$forceSync = ($this->getOptions('action') == 'startsync');
+							return $actionScenario->launch($forceSync);
 						case 'stop':
 							$this->setLog($scenario, __('Arrêt forcé du scénario :', __FILE__) . ' ' . $actionScenario->getName());
 							$actionScenario->stop();

--- a/core/class/scenarioExpression.class.php
+++ b/core/class/scenarioExpression.class.php
@@ -1569,18 +1569,17 @@ class scenarioExpression {
 							if (is_array($this->getOptions('tags'))) {
 								$actionScenario->setTags($this->getOptions('tags'));
 							}
-							$this->setLog($scenario, $GLOBALS['JEEDOM_SCLOG_TEXT']['launchScenario']['txt'] . $actionScenario->getName() . ' ' . __('options :', __FILE__) . ' ' . json_encode($actionScenario->getTags()));
 							if ($scenario !== null) {
 								$actionScenario->addTag('trigger', 'scenario');
 								$actionScenario->addTag('trigger_message', $GLOBALS['JEEDOM_SCLOG_TEXT']['startByScenario']['txt'] . $scenario->getHumanName());
 								$actionScenario->addTag('trigger_name', trim($scenario->getHumanName(), '#'));
 								$actionScenario->addTag('trigger_id', $scenario->getId());
-								return $actionScenario->launch();
 							} else {
 								$actionScenario->addTag('trigger', 'other');
 								$actionScenario->addTag('trigger_message', $GLOBALS['JEEDOM_SCLOG_TEXT']['startCausedBy']['txt']);
-								return $actionScenario->launch();
 							}
+							$this->setLog($scenario, $GLOBALS['JEEDOM_SCLOG_TEXT']['launchScenario']['txt'] . $actionScenario->getName() . ' ' . __('options :', __FILE__) . ' ' . json_encode($actionScenario->getTags()));
+							return $actionScenario->launch();
 							break;
 						case 'startsync':
 							if ($this->getOptions('tags') != '' && !is_array($this->getOptions('tags'))) {


### PR DESCRIPTION
## Description
- fix: $actionScenario should always be a new instance to avoid corruption of current one, see: https://community.jeedom.com/t/tag-transfere-entre-2-commandes-de-lancement-scenario-differentes/148458
- fix: ensure logging occurs before launching actionScenario with correct tags
- Unified the logic for the `start` and `startsync` actions, eliminating duplicate code and handling both cases with a single code path
-  Updated the logging to use different log keys (`launchScenario` or `launchScenarioSync`) depending on whether the scenario is started synchronously or asynchronously.

### Suggested changelog entry
Correction du passage de tags lors de l’exécution d'un scénario sur lui-même

### Related issues/external references

Fixes #


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have checked there is no other PR open for the same change.
- [X] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [X] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [X] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.