### PR TITLE
Use Composer dependency for PHPStan

### DIFF
--- a/.github/workflows/phpstan.yaml
+++ b/.github/workflows/phpstan.yaml
@@ -2,28 +2,30 @@ name: PHPStan
 
 on:
   push:
-    branches: [ alpha ]
+    branches: [ develop ]
   pull_request:
-    branches: [ alpha ]
+    branches: [ develop ]
 
 jobs:
   phpstan:
     runs-on: ubuntu-latest
+    # define every php version to test
+    strategy:
+      # do not stop at first fail
+      fail-fast: false
+      matrix:
+        php: [7.4, 8.2]
+
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup PHP 7.4 for dependencies
+      - name: Setup PHP ${{ matrix.php }} for dependencies
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: ${{ matrix.php }}
 
       - name: Install Dependencies
         run: composer update --ignore-platform-reqs
-
-      - name: Setup PHP 8.2 for PHPStan
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: 8.2
 
       - name: Restore PHPStan cache
         id: cache-phpstan
@@ -32,16 +34,12 @@ jobs:
           path: phpstan.phar
           key: phpstan-1
 
-      - name: Download PHPStan
-        if: steps.cache-phpstan.outputs.cache-hit != 'true'
-        run: wget https://github.com/phpstan/phpstan/releases/latest/download/phpstan.phar
-
       - name: Run PHPStan
-        run: php phpstan.phar analyse --configuration phpstan.neon
+        run: vendor/bin/phpstan analyse --configuration phpstan.neon
 
   update-baseline:
     needs: phpstan
-    if: github.event_name == 'push' && github.ref == 'refs/heads/alpha'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -50,9 +48,7 @@ jobs:
 
       - name: Delete existing branch if exists
         run: |
-          if git ls-remote --heads origin update-phpstan-baseline | grep update-phpstan-baseline; then
-            git push origin --delete update-phpstan-baseline
-          fi
+          git ls-remote --exit-code --heads origin update-phpstan-baseline && git push origin --delete update-phpstan-baseline
 
       - name: Setup PHP 7.4 for dependencies
         uses: shivammathur/setup-php@v2
@@ -62,19 +58,11 @@ jobs:
       - name: Install Dependencies
         run: composer update --ignore-platform-reqs
 
-      - name: Setup PHP 8.2 for PHPStan
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: 8.2
-
-      - name: Download PHPStan
-        run: wget https://github.com/phpstan/phpstan/releases/latest/download/phpstan.phar
-
       - name: Generate new baseline
         id: generate-baseline
         run: |
           cp phpstan-baseline.neon phpstan-baseline.neon.old
-          php phpstan.phar analyse --configuration phpstan.neon --generate-baseline
+          vendor/bin/phpstan analyse --configuration phpstan.neon --generate-baseline
           if ! diff -q phpstan-baseline.neon phpstan-baseline.neon.old > /dev/null; then
             echo "baseline_changed=true" >> $GITHUB_OUTPUT
           fi
@@ -87,10 +75,10 @@ jobs:
           title: '[CI] Update PHPStan baseline'
           body: |
             Mise à jour automatique du baseline PHPStan suite à la correction d'erreurs.
-            
+
             Cette PR a été générée automatiquement par le workflow CI/CD.
           branch: update-phpstan-baseline
-          base: alpha
+          base: develop
           delete-branch: true
           add-paths: |
             phpstan-baseline.neon

--- a/composer.json
+++ b/composer.json
@@ -16,5 +16,8 @@
     "platform": {
       "php": "7.4"
     }
+  },
+  "require-dev": {
+    "phpstan/phpstan": "^2.1"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "be46045c22daf0366a838f96eed56caf",
+    "content-hash": "6f406f5b318ce2f2efbbed9597706668",
     "packages": [
         {
             "name": "abbadon1334/sun-position-spa-php",
@@ -1856,18 +1856,72 @@
             "time": "2024-09-25T14:11:13+00:00"
         }
     ],
-    "packages-dev": [],
+    "packages-dev": [
+        {
+            "name": "phpstan/phpstan",
+            "version": "2.1.48",
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/231397213efb7c0a066ee024b5c3c87f2d3adfa0",
+                "reference": "231397213efb7c0a066ee024b5c3c87f2d3adfa0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-15T20:24:19+00:00"
+        }
+    ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": ">=7.4"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/docs/fr_FR/static-analysis/phpstan.md
+++ b/docs/fr_FR/static-analysis/phpstan.md
@@ -2,12 +2,7 @@
 
 ## Installation locale
 
-1. Télécharger PHPStan :
-```bash
-wget https://github.com/phpstan/phpstan/releases/latest/download/phpstan.phar
-```
-
-2. Mettre à jour les dépendances :
+Mettre à jour les dépendances :
 ```bash
 composer update --ignore-platform-reqs
 ```
@@ -43,7 +38,7 @@ Notes importantes :
 
 ### Lancer l'analyse
 ```bash
-php phpstan.phar analyse --configuration phpstan.neon
+vendor/bin/phpstan analyse --configuration phpstan.neon
 ```
 
 ### Types d'erreurs courantes et solutions
@@ -102,7 +97,7 @@ $resultat = codeProblematiqueQuiNeDoitPasEtreModifie();
 ### Générer un nouveau baseline
 Si de nombreuses erreurs existantes doivent être ignorées :
 ```bash
-php phpstan.phar analyse --configuration phpstan.neon --generate-baseline
+vendor/bin/phpstan analyse --configuration phpstan.neon --generate-baseline
 ```
 
 ## Intégration continue


### PR DESCRIPTION
From pull request #3110 by @pifou25 

## Description

Fixes #3106 

Mais aussi, l'action était ambigue avec la double utilisation de php7.4 et 8.2 dans le même job. Alors j'ai séparé en mode matrice pour jouer 2 fois le job, une fois en php7.4 et l'autre en php8.2
<img width="655" height="216" alt="image" src="https://github.com/user-attachments/assets/c0613f68-60e0-41b9-893b-9ca51e569c82" />
Pour la partie baseline, j'ai appliqué le même pattern matriciel, mais je ne sais pas si c'est opportun ?

### Suggested changelog entry

* Migrer PHPStan vers une dépendance Composer

### Related issues/external references

Fixes #3106 


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement
- [x] CI/CD et/ou Tests uniquement, pas d'impact sur le core

## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [x] I grant the project the right to include and distribute the code under the GNU.
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.
