### PR TITLE
fix: Suppression des arguments superflus dans les appels de méthodes (PHPStan lvl 1)

### DIFF
--- a/core/ajax/cache.ajax.php
+++ b/core/ajax/cache.ajax.php
@@ -28,7 +28,7 @@ try {
 
 	if (init('action') == 'set') {
 		unautorizedInDemo();
-		cache::set(init('key'), init('value'), init('lifetime', 0), init('options', null));
+		cache::set(init('key'), init('value'), init('lifetime', 0));
 		ajax::success();
 	}
 

--- a/core/ajax/cmd.ajax.php
+++ b/core/ajax/cmd.ajax.php
@@ -472,7 +472,7 @@ try {
 				$data[] = $info_history;
 			}
 		} else {
-			$histories = history::getHistoryFromCalcul(jeedom::fromHumanReadable(init('id')), $dateStart, $dateEnd, init('allowZero', false), init('groupingType'), init('addFirstPreviousValue', false));
+			$histories = history::getHistoryFromCalcul(jeedom::fromHumanReadable(init('id')), $dateStart, $dateEnd, init('allowZero', false), init('groupingType'));
 			if (is_array($histories)) {
 				foreach ($histories as $datetime => $value) {
 					$info_history = array();

--- a/core/ajax/interact.ajax.php
+++ b/core/ajax/interact.ajax.php
@@ -30,7 +30,7 @@ try {
 		$results = utils::o2a(interactDef::all());
 		foreach ($results as &$result) {
 			$result['nbInteractQuery'] = count(interactQuery::byInteractDefId($result['id']));
-			$result['nbEnableInteractQuery'] = count(interactQuery::byInteractDefId($result['id'], true));
+			$result['nbEnableInteractQuery'] = count(interactQuery::byInteractDefId($result['id']));
 			if (isset($result['link_type']) && $result['link_type'] == 'cmd' && $result['link_id'] != '') {
 				$link_id = '';
 				foreach (explode('&&', $result['link_id']) as $cmd_id) {
@@ -49,7 +49,7 @@ try {
 	if (init('action') == 'byId') {
 		$result = utils::o2a(interactDef::byId(init('id')));
 		$result['nbInteractQuery'] = count(interactQuery::byInteractDefId($result['id']));
-		$result['nbEnableInteractQuery'] = count(interactQuery::byInteractDefId($result['id'], true));
+		$result['nbEnableInteractQuery'] = count(interactQuery::byInteractDefId($result['id']));
 		ajax::success(jeedom::toHumanReadable($result));
 	}
 

--- a/core/ajax/listener.ajax.php
+++ b/core/ajax/listener.ajax.php
@@ -43,7 +43,7 @@ try {
 	}
 
 	if (init('action') == 'all') {
-		$listeners = utils::o2a(listener::all(true));
+		$listeners = utils::o2a(listener::all());
 		foreach ($listeners as &$listener) {
 			$listener['event_str'] = '';
 			foreach ($listener['event'] as $event) {

--- a/core/ajax/object.ajax.php
+++ b/core/ajax/object.ajax.php
@@ -231,7 +231,7 @@ try {
 		if (!isConnect('admin')) {
 			throw new Exception(__('401 - Accès non autorisé', __FILE__));
 		}
-		ajax::success(jeeObject::getUISelectList(init('none'), true));
+		ajax::success(jeeObject::getUISelectList(init('none')));
 	}
 
 	if (init('action') == 'getSummaryHtml') {

--- a/core/ajax/queue.ajax.php
+++ b/core/ajax/queue.ajax.php
@@ -43,7 +43,7 @@ try {
 	}
 
 	if (init('action') == 'all') {
-		$queues = queue::all(true);
+		$queues = queue::all();
 		foreach ($queues as $queue) {
 			$queue->refresh();
 		}

--- a/core/ajax/report.ajax.php
+++ b/core/ajax/report.ajax.php
@@ -61,7 +61,7 @@ try {
 		foreach (ls($path, '*') as $value) {
 			unlink($path . $value);
 		}
-		ajax::success($return);
+		ajax::success();
 	}
 
 	throw new Exception(__('Aucune méthode correspondante à :', __FILE__) . ' ' . init('action'));

--- a/core/ajax/user.ajax.php
+++ b/core/ajax/user.ajax.php
@@ -345,7 +345,8 @@ try {
 
 	if (init('action') == 'removeBanIp') {
 		unautorizedInDemo();
-		ajax::success(user::removeBanIp());
+        user::removeBanIp();
+		ajax::success();
 	}
 
 	if (init('action') == 'supportAccess') {

--- a/core/api/jeeApi.php
+++ b/core/api/jeeApi.php
@@ -416,7 +416,7 @@ try {
 		if (is_object($_USER_GLOBAL) && $_USER_GLOBAL->getProfils() != 'admin') {
 			throw new Exception(__('Vous n\'êtes pas autorisé à effectuer cette action', __FILE__) . ' ' . $jsonrpc->getMethod(), -32001);
 		}
-		jeedom::update($params['options'], 0);
+		jeedom::update($params['options']);
 		$jsonrpc->makeSuccess('ok');
 	}
 
@@ -1276,7 +1276,7 @@ try {
 			throw new Exception(__('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
 		}
 		unautorizedInDemo();
-		jeedom::update('', 0);
+		jeedom::update('');
 		$jsonrpc->makeSuccess('ok');
 	}
 

--- a/core/api/proApi.php
+++ b/core/api/proApi.php
@@ -622,7 +622,7 @@ try {
 		}
 
 		if ($jsonrpc->getMethod() == 'backup::restoreMarket') {
-			repo_market::backup_restore($params['backup'], true);
+			repo_market::backup_restore($params['backup']);
 			$jsonrpc->makeSuccess();
 		}
 
@@ -728,7 +728,7 @@ try {
 		}
 
 		if ($jsonrpc->getMethod() == 'update::update') {
-			jeedom::update('', 0);
+			jeedom::update('');
 			$jsonrpc->makeSuccess('ok');
 		}
 

--- a/core/class/update.class.php
+++ b/core/class/update.class.php
@@ -515,7 +515,7 @@ class update {
 				return;
 			}
 			if (config::byKey('core::repo::provider') == 'default') {
-				$this->setRemoteVersion(self::getLastAvailableVersion(true));
+				$this->setRemoteVersion(self::getLastAvailableVersion());
 			} else {
 				$class = 'repo_' . config::byKey('core::repo::provider');
 				if (!method_exists($class, 'versionCore') || config::byKey(config::byKey('core::repo::provider') . '::enable') != 1) {


### PR DESCRIPTION
## Description
Suppression des arguments passés en trop lors d'appels de méthodes. Ces paramètres n'existent pas dans la signature des fonctions appelées et sont donc ignorés silencieusement par PHP. **Aucun changement de comportement.**

Exemples :
- `cache::set()` appelé avec 4 args au lieu de 3
- `history::getHistoryFromCalcul()` avec un 6e argument inexistant
- `interactQuery::byInteractDefId()` avec un 2e argument inexistant
- `listener::all()`, `queue::all()`, `jeeObject::getUISelectList()` avec des arguments en trop
- `jeedom::update()` avec un 2e argument inexistant
- `repo_market::backup_restore()` avec un 2e argument inexistant
- `update::getLastAvailableVersion()` avec un argument inexistant
- `ajax::success($return)` remplacé par `ajax::success()` quand `$return` n'est pas défini
- `user::removeBanIp()` : retour void utilisé comme argument de `ajax::success()`

### Suggested changelog entry
Nettoyage des arguments superflus dans les appels de méthodes (PHPStan)

### Related issues/external references
Découpage de #3122

## Types of changes
- [x] Bug fix *(non-breaking change which fixes)*
- [ ] New feature *(non-breaking change which adds functionality)*
- [ ] Breaking change *(fix or feature that would cause existing functionality to change)*
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement

## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution guidelines for this project](.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.