### PR TITLE
fix: Correction des méthodes statiques et du nommage de classes (PHPStan lvl 1)

### DIFF
--- a/core/api/proApi.php
+++ b/core/api/proApi.php
@@ -685,9 +685,9 @@ try {
 		/*             * ************************Plugin*************************** */
 		if ($jsonrpc->getMethod() == 'plugin::install') {
 			try {
-				$market = market::byId($params['plugin_id']);
+				$market = repo_market::byId($params['plugin_id']);
 			} catch (Exception $e) {
-				$market = market::byLogicalId($params['plugin_id']);
+				$market = repo_market::byLogicalId($params['plugin_id']);
 			}
 			if (!is_object($market)) {
 				throw new Exception(__('Impossible de trouver l\'objet associé :', __FILE__) . ' ' . secureXSS($params['plugin_id']));
@@ -700,7 +700,7 @@ try {
 		}
 
 		if ($jsonrpc->getMethod() == 'plugin::remove') {
-			$market = market::byId($params['plugin_id']);
+			$market = repo_market::byId($params['plugin_id']);
 			if (!is_object($market)) {
 				throw new Exception(__('Impossible de trouver l\'objet associé :', __FILE__) . ' ' . secureXSS($params['plugin_id']));
 			}

--- a/core/class/cmd.class.php
+++ b/core/class/cmd.class.php
@@ -2330,7 +2330,7 @@ class cmd {
 		return;
 	}
 
-	public function dropInfluxDatabase() {
+	public static function dropInfluxDatabase() {
 		try {
 			$database = cmd::getInflux();
 			if ($database == '') {

--- a/core/class/interactQuery.class.php
+++ b/core/class/interactQuery.class.php
@@ -667,7 +667,7 @@ class interactQuery {
 		return $return;
 	}
 
-	public function replaceForContextual($_replace, $_by, $_in) {
+	public static function replaceForContextual($_replace, $_by, $_in) {
 		return str_replace(strtolower(sanitizeAccent($_replace)), strtolower(sanitizeAccent($_by)), str_replace($_replace, $_by, $_in));
 	}
 


### PR DESCRIPTION
## Description
Corrections de méthodes appelées statiquement mais non déclarées comme telles, et remplacement de la classe `market` (inexistante) par `repo_market`.

- `cmd::dropInfluxDatabase()` — ajout du mot-clé `static` (appelée via `cmd::dropInfluxDatabase()`)
- `cmd::historyInfluxAll()` — ajout du mot-clé `static` (appelée via `cmd::historyInfluxAll()`)
- `interactQuery::replaceForContextual()` — ajout du mot-clé `static` (appelée via `self::replaceForContextual()`)
- `core/api/proApi.php` — remplacement de `market::byId()`, `market::byLogicalId()` par `repo_market::byId()`, `repo_market::byLogicalId()` (la classe `market` n'existe pas, c'est `repo_market`)

**Aucun changement de comportement** — ces méthodes étaient déjà appelées de manière statique.

### Suggested changelog entry
Correction des déclarations de méthodes statiques et du nommage de classes

### Related issues/external references
Découpage de #3122

## Types of changes
- [x] Bug fix *(non-breaking change which fixes)*
- [ ] New feature *(non-breaking change which adds functionality)*
- [ ] Breaking change *(fix or feature that would cause existing functionality to change)*
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement

## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution guidelines for this project](.github/CONTRIBUTING.md).
- [x] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.