### PR TITLE
Fix PHPStan workflow on branch deletion

### DIFF
--- a/.github/workflows/phpstan.yaml
+++ b/.github/workflows/phpstan.yaml
@@ -48,7 +48,9 @@ jobs:
 
       - name: Delete existing branch if exists
         run: |
-          git ls-remote --exit-code --heads origin update-phpstan-baseline && git push origin --delete update-phpstan-baseline
+          if git ls-remote --heads origin update-phpstan-baseline | grep -q update-phpstan-baseline; then
+            git push origin --delete update-phpstan-baseline
+          fi
 
       - name: Setup PHP 7.4 for dependencies
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
## Summary
- Le step **Delete existing branch if exists** du job `update-baseline` (workflow `phpstan.yaml`) échoue quand la branche distante `update-phpstan-baseline` n'existe pas.
- `git ls-remote --exit-code` retourne **2** sans match ; combiné à `bash -e` du runner, ça fait échouer tout le step.
- Remplacement par une condition `if … | grep -q …; then … fi` : la suppression n'est tentée que si la branche existe, et l'absence ne fait plus échouer le job.

Exemple de run en échec : https://github.com/jeedom/core/actions/runs/24553629700/job/71784850770

## Test plan
- [ ] Le workflow PHPStan se termine avec succès sur le prochain push vers `develop` quand la branche `update-phpstan-baseline` n'existe pas.
- [ ] La suppression fonctionne toujours quand la branche existe (cas d'une PR baseline déjà ouverte).