### PR TITLE
Fix aléatoire du vidage des logs et préservation des Inodes

### DIFF
--- a/core/class/log.class.php
+++ b/core/class/log.class.php
@@ -168,7 +168,8 @@ class log extends AbstractLogger {
 		$sudo = system::getCmdSudo();
 		$tmpFile = tempnam(jeedom::getTmpFolder(), 'log_chunk_');
 		if ($tmpFile === false) {
-			$tmpFile = jeedom::getTmpFolder() . '/log_chunk.tmp';
+			log::add('jeedom', "error", 'Failed to create temporary file in chunkLog() for:' . basename($rawPath));
+			return;
 		}
 		$tmpFile = escapeshellarg($tmpFile);
 		$maxSizeLog = (int)self::getConfig('maxSizeLog', 10);

--- a/core/class/log.class.php
+++ b/core/class/log.class.php
@@ -171,8 +171,8 @@ class log extends AbstractLogger {
 			$tmpFile = jeedom::getTmpFolder() . '/log_chunk.tmp';
 		}
 		$tmpFile = escapeshellarg($tmpFile);
-		$maxSizeLog = self::getConfig('maxSizeLog', 10);
-		$maxSizeLog = (int)max(1, min($maxSizeLog, 10));
+		$maxSizeLog = (int)self::getConfig('maxSizeLog', 10);
+		$maxSizeLog = max(1, $maxSizeLog);
 		$shellPath = escapeshellarg($rawPath);
 
 		$user = system::get('www-uid');

--- a/core/class/log.class.php
+++ b/core/class/log.class.php
@@ -176,7 +176,8 @@ class log extends AbstractLogger {
 		$shellPath = escapeshellarg($rawPath);
 
 		try {
-			com_shell::execute("{$sudo} tail -c {$maxSizeLog}M {$shellPath} | tail -n {$maxLineLog} > {$tmpFile} && {$sudo} cat {$tmpFile} > {$shellPath}");
+			$bashCmd = "tail -c {$maxSizeLog}M {$shellPath} | tail -n {$maxLineLog} > {$tmpFile} && cat {$tmpFile} > {$shellPath}";
+			com_shell::execute("{$sudo} bash -o pipefail -c \"{$bashCmd}\"");
 		} catch (\Exception $e) {
 			log::add('jeedom', "error", "Caught exception in chunkLog(): " . $e->getMessage());
 		} finally {

--- a/core/class/log.class.php
+++ b/core/class/log.class.php
@@ -155,46 +155,42 @@ class log extends AbstractLogger {
 		}
 	}
 
-	public static function chunkLog($_path) {
+	private static function chunkLog(string $_path) {
 		if (strpos($_path, '.htaccess') !== false || !file_exists($_path)) {
 			return;
 		}
-		
+
 		$maxLineLog = self::getConfig('maxLineLog');
 		if ($maxLineLog < self::DEFAULT_MAX_LINE) {
 			$maxLineLog = self::DEFAULT_MAX_LINE;
 		}
-	
+
 		$sudo = system::getCmdSudo();
 		$user = system::get('www-uid');
 		$group = system::get('www-gid');
 		$tmpFile = $_path . '.tmp';
-	
+
 		try {
-			// 1. Correction des droits
 			com_shell::execute($sudo . 'chmod 664 ' . $_path . ' > /dev/null 2>&1');
 			com_shell::execute($sudo . 'chown ' . $user . ':' . $group . ' ' . $_path . ' > /dev/null 2>&1');
-	
-			// 2. Nettoyage sécurisé des lignes (évite la race condition)
-			// On extrait vers un fichier temporaire d'abord pour ne pas vider la source avant lecture
+
+			// Extract to a temporary file first to avoid emptying the source before reading
 			com_shell::execute($sudo . 'tail -n ' . (int)$maxLineLog . ' ' . $_path . ' > ' . $tmpFile);
-			
-			// On réinjecte dans l'original (cat préserve l'Inode pour les démons)
+
+			// Reinject into the original (cat preserves the Inode for daemons)
 			if (file_exists($tmpFile)) {
 				com_shell::execute($sudo . 'cat ' . $tmpFile . ' > ' . $_path . ' && ' . $sudo . 'rm -f ' . $tmpFile);
 			}
 		} catch (\Exception $e) {
-			// Gestion d'erreur silencieuse conforme à l'existant
 		}
 
-		// 3. Vérification de la taille critique (10Mo)
-		clearstatcache(true, $_path); // Indispensable pour rafraîchir filesize()
+		clearstatcache(true, $_path);
 		if (file_exists($_path) && filesize($_path) > (1024 * 1024 * 10)) {
-			// truncate est la seule méthode sûre pour vider un fichier sans détruire l'Inode
+			// use truncate to empty file without destroying Inode
 			com_shell::execute($sudo . 'truncate -s 0 ' . $_path);
 		}
 	}
-	
+
 	public static function getPathToLog($_log = 'core') {
 		return __DIR__ . '/../../log/' . $_log;
 	}

--- a/core/class/log.class.php
+++ b/core/class/log.class.php
@@ -181,14 +181,14 @@ class log extends AbstractLogger {
 			com_shell::execute("{$sudo} bash -o pipefail -c \"{$bashCmd}\"");
 		} catch (\Exception $e) {
 			log::add('jeedom', "error", "Caught exception in chunkLog(): " . $e->getMessage());
+
+			clearstatcache(true, $rawPath);
+			if (file_exists($rawPath) && filesize($rawPath) > (1024 * 1024 * $maxSizeLog)) {
+				// use truncate to empty file without destroying Inode
+				com_shell::execute("{$sudo} truncate -s 0 {$shellPath}");
+			}
 		} finally {
 			com_shell::execute("{$sudo} rm -f {$tmpFile}");
-		}
-
-		clearstatcache(true, $rawPath);
-		if (file_exists($rawPath) && filesize($rawPath) > (1024 * 1024 * $maxSizeLog)) {
-			// use truncate to empty file without destroying Inode
-			com_shell::execute("{$sudo} truncate -s 0 {$shellPath}");
 		}
 	}
 

--- a/core/class/log.class.php
+++ b/core/class/log.class.php
@@ -155,8 +155,8 @@ class log extends AbstractLogger {
 		}
 	}
 
-	private static function chunkLog(string $path) {
-		if (strpos($path, '.htaccess') !== false || !file_exists($path)) {
+	private static function chunkLog(string $rawPath) {
+		if (strpos($rawPath, '.htaccess') !== false || !file_exists($rawPath)) {
 			return;
 		}
 
@@ -166,28 +166,33 @@ class log extends AbstractLogger {
 		}
 
 		$sudo = system::getCmdSudo();
-		$tmpFile = jeedom::getTmpFolder() . '/log.tmp';
-		$maxSizeLog = (int)self::getConfig('maxSizeLog', '10');
-		$path = escapeshellarg($path);
+		$tmpFile = tempnam(jeedom::getTmpFolder(), 'log_chunk_');
+		if ($tmpFile === false) {
+			$tmpFile = jeedom::getTmpFolder() . '/log_chunk.tmp';
+		}
+		$tmpFile = escapeshellarg($tmpFile);
+		$maxSizeLog = self::getConfig('maxSizeLog', 10);
+		$maxSizeLog = (int)max(1, min($maxSizeLog, 10));
+		$shellPath = escapeshellarg($rawPath);
 
 		$user = system::get('www-uid');
 		$group = system::get('www-gid');
 
 		try {
-			com_shell::execute("{$sudo} chmod 664 {$path} > /dev/null 2>&1");
-			com_shell::execute("{$sudo} chown {$user}:{$group} {$path} > /dev/null 2>&1");
+			com_shell::execute("{$sudo} chmod 664 {$shellPath} > /dev/null 2>&1");
+			com_shell::execute("{$sudo} chown {$user}:{$group} {$shellPath} > /dev/null 2>&1");
 
-			com_shell::execute("{$sudo} tail -c {$maxSizeLog}M {$path} | tail -n {$maxLineLog} > {$tmpFile} && {$sudo} cat {$tmpFile} > {$path}");
+			com_shell::execute("{$sudo} tail -c {$maxSizeLog}M {$shellPath} | tail -n {$maxLineLog} > {$tmpFile} && {$sudo} cat {$tmpFile} > {$shellPath}");
 		} catch (\Exception $e) {
 			log::add('jeedom', "error", "Caught exception in chunkLog(): " . $e->getMessage());
 		} finally {
 			com_shell::execute("{$sudo} rm -f {$tmpFile}");
 		}
 
-		clearstatcache(true, $path);
-		if (file_exists($path) && filesize($path) > (1024 * 1024 * $maxSizeLog)) {
+		clearstatcache(true, $rawPath);
+		if (file_exists($rawPath) && filesize($rawPath) > (1024 * 1024 * $maxSizeLog)) {
 			// use truncate to empty file without destroying Inode
-			com_shell::execute("{$sudo} truncate -s 0 {$path}");
+			com_shell::execute("{$sudo} truncate -s 0 {$shellPath}");
 		}
 	}
 

--- a/core/class/log.class.php
+++ b/core/class/log.class.php
@@ -177,8 +177,7 @@ class log extends AbstractLogger {
 		$shellPath = escapeshellarg($rawPath);
 
 		try {
-			$bashCmd = "tail -c {$maxSizeLog}M {$shellPath} | tail -n {$maxLineLog} > {$tmpFile} && cat {$tmpFile} > {$shellPath}";
-			com_shell::execute("{$sudo} bash -o pipefail -c \"{$bashCmd}\"");
+			com_shell::execute("{$sudo} tail -c {$maxSizeLog}M {$shellPath} | tail -n {$maxLineLog} > {$tmpFile} && {$sudo} cat {$tmpFile} > {$shellPath}");
 		} catch (\Exception $e) {
 			log::add('jeedom', "error", "Caught exception in chunkLog(): " . $e->getMessage());
 

--- a/core/class/log.class.php
+++ b/core/class/log.class.php
@@ -156,30 +156,45 @@ class log extends AbstractLogger {
 	}
 
 	public static function chunkLog($_path) {
-		if (strpos($_path, '.htaccess') !== false) {
+		if (strpos($_path, '.htaccess') !== false || !file_exists($_path)) {
 			return;
 		}
+		
 		$maxLineLog = self::getConfig('maxLineLog');
 		if ($maxLineLog < self::DEFAULT_MAX_LINE) {
 			$maxLineLog = self::DEFAULT_MAX_LINE;
 		}
+	
+		$sudo = system::getCmdSudo();
+		$user = system::get('www-uid');
+		$group = system::get('www-gid');
+		$tmpFile = $_path . '.tmp';
+	
 		try {
-			com_shell::execute(system::getCmdSudo() . 'chmod 664 ' . $_path . ' > /dev/null 2>&1;' . system::getCmdSudo() . 'chown -R ' . system::get('www-uid') . ':' . system::get('www-gid') . ' ' . $_path . ' > /dev/null 2>&1;' . system::getCmdSudo() . ' echo "$(tail -n ' . $maxLineLog . ' ' . $_path . ')" > ' . $_path);
+			// 1. Correction des droits
+			com_shell::execute($sudo . 'chmod 664 ' . $_path . ' > /dev/null 2>&1');
+			com_shell::execute($sudo . 'chown ' . $user . ':' . $group . ' ' . $_path . ' > /dev/null 2>&1');
+	
+			// 2. Nettoyage sécurisé des lignes (évite la race condition)
+			// On extrait vers un fichier temporaire d'abord pour ne pas vider la source avant lecture
+			com_shell::execute($sudo . 'tail -n ' . (int)$maxLineLog . ' ' . $_path . ' > ' . $tmpFile);
+			
+			// On réinjecte dans l'original (cat préserve l'Inode pour les démons)
+			if (file_exists($tmpFile)) {
+				com_shell::execute($sudo . 'cat ' . $tmpFile . ' > ' . $_path . ' && ' . $sudo . 'rm -f ' . $tmpFile);
+			}
 		} catch (\Exception $e) {
+			// Gestion d'erreur silencieuse conforme à l'existant
 		}
-		@chown($_path, system::get('www-uid'));
-		@chgrp($_path, system::get('www-gid'));
-		if (filesize($_path) > (1024 * 1024 * 10)) {
-			com_shell::execute(system::getCmdSudo() . 'truncate -s 0 ' . $_path);
-		}
-		if (filesize($_path) > (1024 * 1024 * 10)) {
-			com_shell::execute(system::getCmdSudo() . 'cat /dev/null > ' . $_path);
-		}
-		if (filesize($_path) > (1024 * 1024 * 10)) {
-			com_shell::execute(system::getCmdSudo() . ' rm -f ' . $_path);
+
+		// 3. Vérification de la taille critique (10Mo)
+		clearstatcache(true, $_path); // Indispensable pour rafraîchir filesize()
+		if (file_exists($_path) && filesize($_path) > (1024 * 1024 * 10)) {
+			// truncate est la seule méthode sûre pour vider un fichier sans détruire l'Inode
+			com_shell::execute($sudo . 'truncate -s 0 ' . $_path);
 		}
 	}
-
+	
 	public static function getPathToLog($_log = 'core') {
 		return __DIR__ . '/../../log/' . $_log;
 	}

--- a/core/class/log.class.php
+++ b/core/class/log.class.php
@@ -155,39 +155,39 @@ class log extends AbstractLogger {
 		}
 	}
 
-	private static function chunkLog(string $_path) {
-		if (strpos($_path, '.htaccess') !== false || !file_exists($_path)) {
+	private static function chunkLog(string $path) {
+		if (strpos($path, '.htaccess') !== false || !file_exists($path)) {
 			return;
 		}
 
-		$maxLineLog = self::getConfig('maxLineLog');
+		$maxLineLog = (int)self::getConfig('maxLineLog', self::DEFAULT_MAX_LINE);
 		if ($maxLineLog < self::DEFAULT_MAX_LINE) {
 			$maxLineLog = self::DEFAULT_MAX_LINE;
 		}
 
 		$sudo = system::getCmdSudo();
+		$tmpFile = jeedom::getTmpFolder() . '/log.tmp';
+		$maxSizeLog = (int)self::getConfig('maxSizeLog', '10');
+		$path = escapeshellarg($path);
+
 		$user = system::get('www-uid');
 		$group = system::get('www-gid');
-		$tmpFile = $_path . '.tmp';
 
 		try {
-			com_shell::execute($sudo . 'chmod 664 ' . $_path . ' > /dev/null 2>&1');
-			com_shell::execute($sudo . 'chown ' . $user . ':' . $group . ' ' . $_path . ' > /dev/null 2>&1');
+			com_shell::execute("{$sudo} chmod 664 {$path} > /dev/null 2>&1");
+			com_shell::execute("{$sudo} chown {$user}:{$group} {$path} > /dev/null 2>&1");
 
-			// Extract to a temporary file first to avoid emptying the source before reading
-			com_shell::execute($sudo . 'tail -n ' . (int)$maxLineLog . ' ' . $_path . ' > ' . $tmpFile);
-
-			// Reinject into the original (cat preserves the Inode for daemons)
-			if (file_exists($tmpFile)) {
-				com_shell::execute($sudo . 'cat ' . $tmpFile . ' > ' . $_path . ' && ' . $sudo . 'rm -f ' . $tmpFile);
-			}
+			com_shell::execute("{$sudo} tail -c {$maxSizeLog}M {$path} | tail -n {$maxLineLog} > {$tmpFile} && {$sudo} cat {$tmpFile} > {$path}");
 		} catch (\Exception $e) {
+			log::add('jeedom', "error", "Caught exception in chunkLog(): " . $e->getMessage());
+		} finally {
+			com_shell::execute("{$sudo} rm -f {$tmpFile}");
 		}
 
-		clearstatcache(true, $_path);
-		if (file_exists($_path) && filesize($_path) > (1024 * 1024 * 10)) {
+		clearstatcache(true, $path);
+		if (file_exists($path) && filesize($path) > (1024 * 1024 * $maxSizeLog)) {
 			// use truncate to empty file without destroying Inode
-			com_shell::execute($sudo . 'truncate -s 0 ' . $_path);
+			com_shell::execute("{$sudo} truncate -s 0 {$path}");
 		}
 	}
 

--- a/core/class/log.class.php
+++ b/core/class/log.class.php
@@ -175,13 +175,7 @@ class log extends AbstractLogger {
 		$maxSizeLog = max(1, $maxSizeLog);
 		$shellPath = escapeshellarg($rawPath);
 
-		$user = system::get('www-uid');
-		$group = system::get('www-gid');
-
 		try {
-			com_shell::execute("{$sudo} chmod 664 {$shellPath} > /dev/null 2>&1");
-			com_shell::execute("{$sudo} chown {$user}:{$group} {$shellPath} > /dev/null 2>&1");
-
 			com_shell::execute("{$sudo} tail -c {$maxSizeLog}M {$shellPath} | tail -n {$maxLineLog} > {$tmpFile} && {$sudo} cat {$tmpFile} > {$shellPath}");
 		} catch (\Exception $e) {
 			log::add('jeedom', "error", "Caught exception in chunkLog(): " . $e->getMessage());


### PR DESCRIPTION
Cette PR corrige deux problèmes critiques dans la fonction chunkLog :

Correction d'une Race Condition (Vidage aléatoire) : Dans la version actuelle, l'instruction echo "$(tail ...)" > $_path utilise une redirection shell > directement sur le fichier source. Le shell tronque le fichier avant que le tail ne puisse lire les données. Selon la charge CPU/Disque, le fichier peut ainsi se retrouver totalement vide. La solution implémentée utilise un fichier temporaire pour garantir que la lecture est terminée avant de modifier la source.

Préservation des Inodes (Compatibilité démons) : L'utilisation de rm ou de certaines manipulations shell recréent un nouveau fichier (nouvel Inode). Cela casse l'écriture des logs pour les démons (processus persistants) qui gardent un descripteur de fichier ouvert sur l'ancien Inode.

Le remplacement de la donnée se fait désormais via cat tmp > original, ce qui écrase le contenu sans changer l'Inode.

Les commandes destructives comme rm ont été remplacées par truncate -s 0, qui vide le fichier "en place".

Rafraîchissement du cache PHP : Ajout de clearstatcache() avant le test de taille, car PHP met en cache les résultats de filesize(), ce qui rendait les tests if erronés après une modification par commande système.