### PR TITLE
fix: prevent a possible SQL injection in setComponentOrder

### DIFF
--- a/core/ajax/view.ajax.php
+++ b/core/ajax/view.ajax.php
@@ -164,12 +164,20 @@ try {
 		}
 		unautorizedInDemo();
 		$components = json_decode(init('components'), true);
-		$sql = '';
+		$allowedTypes = array('cmd', 'eqLogic', 'scenario');
 		foreach ($components as $component) {
 			if (!isset($component['viewZone_id']) || !is_numeric($component['viewZone_id']) || !is_numeric($component['id']) || !is_numeric($component['viewOrder']) || (isset($component['object_id']) && !is_numeric($component['object_id']))) {
 				continue;
 			}
-			$sql .= 'UPDATE viewData SET `order`= ' . $component['viewOrder'] . '  WHERE link_id=' . $component['id'] . ' AND type="' . $component['type'] . '" AND  viewZone_id=' . $component['viewZone_id'] . ';';
+			if (!isset($component['type']) || !in_array($component['type'], $allowedTypes)) {
+				continue;
+			}
+			DB::Prepare('UPDATE viewData SET `order`= :viewOrder WHERE link_id= :id AND type= :type AND viewZone_id= :viewZone_id', array(
+				'viewOrder' => $component['viewOrder'],
+				'id' => $component['id'],
+				'type' => $component['type'],
+				'viewZone_id' => $component['viewZone_id'],
+			), DB::FETCH_TYPE_ROW);
 			if ($component['type'] == 'eqLogic') {
 				unset($component['type']);
 				$eqLogic = eqLogic::byId($component['id']);
@@ -187,9 +195,6 @@ try {
 				utils::a2o($scenario, $component);
 				$scenario->save(true);
 			}
-		}
-		if ($sql != '') {
-			DB::Prepare($sql, array(), DB::FETCH_TYPE_ROW);
 		}
 		ajax::success();
 	}

--- a/tests/integration/support/AjaxIntegrationTestCase.php
+++ b/tests/integration/support/AjaxIntegrationTestCase.php
@@ -1,0 +1,180 @@
+<?php
+
+/* This file is part of Jeedom.
+*
+* Jeedom is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* Jeedom is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Jeedom. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use PHPUnit\Framework\TestCase;
+
+abstract class AjaxIntegrationTestCase extends TestCase {
+
+	/** @var callable[] */
+	private $cleanupStack = array();
+
+	/** @var int|null */
+	private $authenticatedUserId = null;
+
+	protected function tearDown(): void {
+		foreach (array_reverse($this->cleanupStack) as $callback) {
+			try {
+				$callback();
+			} catch (\Throwable $e) {
+				fwrite(STDERR, "Cleanup failed: " . $e->getMessage() . "\n");
+			}
+		}
+		$this->cleanupStack = [];
+		$this->authenticatedUserId = null;
+	}
+
+	protected function givenAdminIsLoggedIn(): void {
+		$admin = new user();
+		$admin->setLogin('test_admin_' . bin2hex(random_bytes(4)));
+		$admin->setPassword(sha512('test_password_' . bin2hex(random_bytes(4))));
+		$admin->setProfils('admin');
+		$admin->setEnable(1);
+		$admin->save();
+
+		$this->registerCleanup(function () use ($admin) {
+			$admin->remove();
+		});
+		$this->authenticatedUserId = (int)$admin->getId();
+	}
+
+	/**
+	 * Creates a view + zone + viewData ready to be targeted by setComponentOrder.
+	 * The link_id intentionally points to a non-existent id so that the
+	 * eqLogic::byId() branch of the handler is short-circuited: we only test
+	 * the order UPDATE query, not the side-effects.
+	 */
+	protected function givenAViewDataWith(string $type, int $initialOrder = 5): object {
+		$view = new view();
+		$view->setName('test_view_' . bin2hex(random_bytes(4)));
+		$view->save();
+		$this->registerCleanup(function () use ($view) {
+			$view->remove();
+		});
+
+		$viewZone = new viewZone();
+		$viewZone->setView_id($view->getId());
+		$viewZone->setName('test_zone');
+		$viewZone->save();
+
+		$fakeLinkId = 987654321;
+		$viewData = new viewData();
+		$viewData->setviewZone_id($viewZone->getId());
+		$viewData->setType($type);
+		$viewData->setLink_id($fakeLinkId);
+		$viewData->setOrder($initialOrder);
+		$viewData->save();
+
+		return (object)[
+			'viewId'       => (int)$view->getId(),
+			'viewZoneId'   => (int)$viewZone->getId(),
+			'viewDataId'   => (int)$viewData->getId(),
+			'linkId'       => $fakeLinkId,
+			'initialOrder' => $initialOrder,
+		];
+	}
+
+	protected function whenSetComponentOrderIsCalledWith(array $components): array {
+		return $this->callAjaxEndpoint('view.ajax.php', [
+			'action'     => 'setComponentOrder',
+			'components' => json_encode($components),
+		]);
+	}
+
+	protected function thenResponseIsJsonSuccess(array $response): void {
+		$this->assertSame(
+			0,
+			$response['exitCode'],
+			"Subprocess exited non-zero.\nStdout: {$response['body']}\nStderr: {$response['stderr']}"
+		);
+		$this->assertNotNull(
+			$response['json'],
+			"Expected JSON response.\nStdout: {$response['body']}\nStderr: {$response['stderr']}"
+		);
+		$this->assertSame(
+			'ok',
+			$response['json']['state'] ?? null,
+			"Expected state=ok.\nBody: {$response['body']}"
+		);
+	}
+
+	protected function thenViewDataOrderIs(int $viewDataId, int $expectedOrder): void {
+		$row = DB::Prepare(
+			'SELECT `order` FROM viewData WHERE id = :id',
+			['id' => $viewDataId],
+			DB::FETCH_TYPE_ROW
+		);
+		$this->assertIsArray($row, "viewData id={$viewDataId} not found");
+		$this->assertSame(
+			$expectedOrder,
+			(int)$row['order'],
+			"viewData.order was modified unexpectedly"
+		);
+	}
+
+	protected function thenTableStillExists(string $table): void {
+		$row = DB::Prepare(
+			'SHOW TABLES LIKE :table',
+			['table' => $table],
+			DB::FETCH_TYPE_ROW
+		);
+		$this->assertNotEmpty($row, "Table '{$table}' no longer exists");
+	}
+
+	private function registerCleanup(callable $callback): void {
+		$this->cleanupStack[] = $callback;
+	}
+
+	private function callAjaxEndpoint(string $ajaxFile, array $postData): array {
+		$this->assertNotNull(
+			$this->authenticatedUserId,
+			'Call givenAdminIsLoggedIn() before calling any when...()'
+		);
+
+		$payload = json_encode([
+			'file'    => $ajaxFile,
+			'post'    => $postData,
+			'user_id' => $this->authenticatedUserId,
+		]);
+
+		$runner = __DIR__ . '/ajax_runner.php';
+		$descriptors = [
+			0 => ['pipe', 'r'],
+			1 => ['pipe', 'w'],
+			2 => ['pipe', 'w'],
+		];
+		$process = proc_open('php ' . escapeshellarg($runner), $descriptors, $pipes);
+		if (!is_resource($process)) {
+			$this->fail('Failed to spawn ajax_runner.php subprocess');
+		}
+
+		fwrite($pipes[0], $payload);
+		fclose($pipes[0]);
+		$stdout = stream_get_contents($pipes[1]);
+		$stderr = stream_get_contents($pipes[2]);
+		fclose($pipes[1]);
+		fclose($pipes[2]);
+		$exitCode = proc_close($process);
+
+		return [
+			'body'     => $stdout,
+			'stderr'   => $stderr,
+			'exitCode' => $exitCode,
+			'json'     => json_decode($stdout, true),
+		];
+	}
+}

--- a/tests/integration/support/ajax_runner.php
+++ b/tests/integration/support/ajax_runner.php
@@ -1,0 +1,56 @@
+<?php
+
+/* This file is part of Jeedom.
+*
+* Jeedom is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* Jeedom is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Jeedom. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+$payload = json_decode(file_get_contents('php://stdin'), true);
+if (!is_array($payload)) {
+	fwrite(STDERR, "Invalid JSON payload on stdin\n");
+	exit(1);
+}
+
+require_once __DIR__ . '/../../../core/php/core.inc.php';
+
+$_SERVER['REQUEST_METHOD'] = 'POST';
+$_SERVER['HTTP_HOST']      = 'localhost';
+$_SERVER['SERVER_NAME']    = 'localhost';
+$_SERVER['REMOTE_ADDR']    = '127.0.0.1';
+$_POST    = $payload['post'] ?? [];
+$_GET     = $payload['get']  ?? [];
+$_REQUEST = array_merge($_GET, $_POST);
+
+if (isset($payload['user_id'])) {
+	$user = user::byId($payload['user_id']);
+	if (!is_object($user)) {
+		fwrite(STDERR, "User {$payload['user_id']} not found\n");
+		exit(1);
+	}
+	$sessionId = bin2hex(random_bytes(32));
+	session_id($sessionId);
+	@session_start();
+	$_SESSION['user'] = $user;
+	$_SESSION['ip']   = '127.0.0.1';
+	@session_write_close();
+	$_COOKIE[session_name()] = $sessionId;
+}
+
+$ajaxFile = __DIR__ . '/../../../core/ajax/' . basename($payload['file']);
+if (!is_file($ajaxFile)) {
+	fwrite(STDERR, "Ajax file not found: {$ajaxFile}\n");
+	exit(1);
+}
+
+include $ajaxFile;

--- a/tests/integration/viewAjaxSqlInjectionTest.php
+++ b/tests/integration/viewAjaxSqlInjectionTest.php
@@ -1,0 +1,100 @@
+<?php
+
+/* This file is part of Jeedom.
+*
+* Jeedom is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* Jeedom is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Jeedom. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+require_once __DIR__ . '/support/AjaxIntegrationTestCase.php';
+
+class viewAjaxSqlInjectionTest extends AjaxIntegrationTestCase {
+
+	public function testValidComponentTypeUpdatesTheOrder(): void {
+		$this->givenAdminIsLoggedIn();
+		$component = $this->givenAViewDataWith('eqLogic', 5);
+
+		$response = $this->whenSetComponentOrderIsCalledWith([[
+			'viewZone_id' => $component->viewZoneId,
+			'id'          => $component->linkId,
+			'viewOrder'   => 42,
+			'type'        => 'eqLogic',
+		]]);
+
+		$this->thenResponseIsJsonSuccess($response);
+		$this->thenViewDataOrderIs($component->viewDataId, 42);
+	}
+
+	public function testSqlInjectionPayloadInTypeFieldIsRejected(): void {
+		$this->givenAdminIsLoggedIn();
+		$component = $this->givenAViewDataWith('eqLogic', 5);
+
+		$response = $this->whenSetComponentOrderIsCalledWith([[
+			'viewZone_id' => $component->viewZoneId,
+			'id'          => $component->linkId,
+			'viewOrder'   => 999,
+			'type'        => 'eqLogic"; DROP TABLE viewData; --',
+		]]);
+
+		$this->thenResponseIsJsonSuccess($response);
+		$this->thenTableStillExists('viewData');
+		$this->thenViewDataOrderIs($component->viewDataId, $component->initialOrder);
+	}
+
+	public function testUnionBasedSqlInjectionIsRejected(): void {
+		$this->givenAdminIsLoggedIn();
+		$component = $this->givenAViewDataWith('eqLogic', 5);
+
+		$response = $this->whenSetComponentOrderIsCalledWith([[
+			'viewZone_id' => $component->viewZoneId,
+			'id'          => $component->linkId,
+			'viewOrder'   => 999,
+			'type'        => 'eqLogic" UNION SELECT password FROM user --',
+		]]);
+
+		$this->thenResponseIsJsonSuccess($response);
+		$this->thenViewDataOrderIs($component->viewDataId, $component->initialOrder);
+	}
+
+	public function testUnknownComponentTypeIsRejected(): void {
+		$this->givenAdminIsLoggedIn();
+		// Fixture type matches the injected type so the vulnerable WHERE would hit this row.
+		$component = $this->givenAViewDataWith('arbitrary_string', 5);
+
+		$response = $this->whenSetComponentOrderIsCalledWith([[
+			'viewZone_id' => $component->viewZoneId,
+			'id'          => $component->linkId,
+			'viewOrder'   => 999,
+			'type'        => 'arbitrary_string',
+		]]);
+
+		$this->thenResponseIsJsonSuccess($response);
+		$this->thenViewDataOrderIs($component->viewDataId, $component->initialOrder);
+	}
+
+	public function testMissingComponentTypeIsRejected(): void {
+		$this->givenAdminIsLoggedIn();
+		// Fixture type is empty so the vulnerable code — which concatenates a
+		// null into type="" — would match this row and bump its order.
+		$component = $this->givenAViewDataWith('', 5);
+
+		$response = $this->whenSetComponentOrderIsCalledWith([[
+			'viewZone_id' => $component->viewZoneId,
+			'id'          => $component->linkId,
+			'viewOrder'   => 999,
+		]]);
+
+		$this->thenResponseIsJsonSuccess($response);
+		$this->thenViewDataOrderIs($component->viewDataId, $component->initialOrder);
+	}
+}


### PR DESCRIPTION
## Description

En auditant `core/ajax/view.ajax.php`, j'ai remarqué que le handler `setComponentOrder` concatène le champ `type` envoyé par le client directement dans une requête SQL, sans validation — contrairement aux autres champs (`viewZone_id`, `id`, `viewOrder`) qui passent par `is_numeric()`.

Un admin peut donc injecter du SQL arbitraire. Testé localement : un payload avec `type = 'eqLogic"; DROP TABLE viewData; --'` exécute réellement le `DROP TABLE` et fait disparaître la table.

### Corrections apportées

- Whitelist stricte sur le champ `type` (`cmd`, `eqLogic`, `scenario`) — les autres valeurs provoquent un `continue`.
- La concaténation SQL multi-statements est remplacée par un prepared statement exécuté à chaque itération. Légèrement plus lent mais trivialement sûr, et ça évite d'envoyer plusieurs `UPDATE` en un seul appel.

### Tests

J'ai ajouté une suite d'intégration `tests/integration/viewAjaxSqlInjectionTest.php` qui invoque l'endpoint AJAX réel via un sous-processus PHP authentifié comme admin. 5 tests couvrant : type valide (happy path), payload `DROP TABLE`, injection UNION, type inconnu, type manquant. 4 des 5 échouent sur `develop` sans la correction.

La plomberie (`tests/integration/support/`) est factorisée pour être réutilisée sur d'autres endpoints AJAX plus tard.

### Suggested changelog entry

* **Sécurité** : correction d'une injection SQL dans la gestion de l'ordre des composants de vue (`core/ajax/view.ajax.php`)

### Related issues/external references

N/A


## Types of changes
- [x] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [x] I grant the project the right to include and distribute the code under the GNU.
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.
