### PR TITLE
fix: prevent a possible SQL injection in archive process

### DIFF
--- a/core/class/history.class.php
+++ b/core/class/history.class.php
@@ -322,12 +322,18 @@ class history {
 					continue;
 				}
 				$mode = $cmd->getConfiguration('historizeMode', 'avg');
+				if (!in_array($mode, array('avg', 'min', 'max', 'none'))) {
+					$mode = 'avg';
+				}
 				$values = array(
 					'cmd_id' => $sensors['cmd_id'],
 					'archivePackage' => config::byKey('historyArchivePackage') * 3600,
 					'archiveTime' => $archiveDatetime
 				);
-				$round = (is_numeric($cmd->getConfiguration('historizeRound'))) ? $cmd->getConfiguration('historizeRound') : 2;
+				$round = (is_numeric($cmd->getConfiguration('historizeRound'))) ? intval($cmd->getConfiguration('historizeRound')) : 2;
+				if ($round < 0 || $round > 12) {
+					$round = 2;
+				}
 				$sql = 'REPLACE INTO historyArch(cmd_id,`datetime`,value) SELECT cmd_id,MIN(`datetime`),' . $mode . '(CAST(value AS DECIMAL(12,' . $round . '))) as value
                 FROM history
                 WHERE `datetime` <= :archiveTime

--- a/core/class/history.class.php
+++ b/core/class/history.class.php
@@ -322,7 +322,7 @@ class history {
 					continue;
 				}
 				$mode = $cmd->getConfiguration('historizeMode', 'avg');
-				if (!in_array($mode, array('avg', 'min', 'max', 'none'))) {
+				if (!in_array($mode, array('avg', 'min', 'max'))) {
 					$mode = 'avg';
 				}
 				$values = array(

--- a/tests/integration/historyArchiveSqlInjectionTest.php
+++ b/tests/integration/historyArchiveSqlInjectionTest.php
@@ -1,0 +1,189 @@
+<?php
+
+/* This file is part of Jeedom.
+*
+* Jeedom is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* Jeedom is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Jeedom. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use PHPUnit\Framework\TestCase;
+
+class historyArchiveSqlInjectionTest extends TestCase {
+
+	/** @var callable[] */
+	private $cleanupStack = array();
+
+	/** @var mixed */
+	private $savedArchiveTime;
+
+	/** @var mixed */
+	private $savedArchivePackage;
+
+	protected function setUp(): void {
+		$this->savedArchiveTime = config::byKey('historyArchiveTime');
+		$this->savedArchivePackage = config::byKey('historyArchivePackage');
+	}
+
+	protected function tearDown(): void {
+		foreach (array_reverse($this->cleanupStack) as $callback) {
+			try {
+				$callback();
+			} catch (\Throwable $e) {
+				fwrite(STDERR, "Cleanup failed: " . $e->getMessage() . "\n");
+			}
+		}
+		$this->cleanupStack = array();
+		config::save('historyArchiveTime', $this->savedArchiveTime);
+		config::save('historyArchivePackage', $this->savedArchivePackage);
+	}
+
+	public function testLegitimateHistorizeModeArchivesData(): void {
+		$cmdId = $this->givenAHistorizedNumericCmd('avg', 2);
+		$this->givenAHistoryRowOlderThanArchiveTime($cmdId, 42.5);
+
+		history::archive();
+
+		$this->thenRowExistsInHistoryArch($cmdId);
+	}
+
+	public function testMaliciousHistorizeModeFallsBackToDefault(): void {
+		$cmdId = $this->givenAHistorizedNumericCmd('AVG(value)); DROP TABLE historyArch; --', 2);
+		$this->givenAHistoryRowOlderThanArchiveTime($cmdId, 10.0);
+
+		history::archive();
+
+		$this->thenTableStillExists('historyArch');
+		$this->thenRowExistsInHistoryArch($cmdId);
+	}
+
+	public function testUnionBasedSqlInjectionIsNeutralized(): void {
+		$cmdId = $this->givenAHistorizedNumericCmd('MAX(value) UNION SELECT 1,NOW(),password FROM user --', 2);
+		$this->givenAHistoryRowOlderThanArchiveTime($cmdId, 7.0);
+
+		history::archive();
+
+		$this->thenRowExistsInHistoryArch($cmdId);
+	}
+
+	public function testOutOfRangeHistorizeRoundIsBounded(): void {
+		$cmdId = $this->givenAHistorizedNumericCmd('avg', 99);
+		$this->givenAHistoryRowOlderThanArchiveTime($cmdId, 3.14);
+
+		history::archive();
+
+		$this->thenRowExistsInHistoryArch($cmdId);
+	}
+
+	public function testNegativeHistorizeRoundIsBounded(): void {
+		$cmdId = $this->givenAHistorizedNumericCmd('avg', -5);
+		$this->givenAHistoryRowOlderThanArchiveTime($cmdId, 2.71);
+
+		history::archive();
+
+		$this->thenRowExistsInHistoryArch($cmdId);
+	}
+
+	public function testEmptyHistorizeModeDoesNotBreakArchive(): void {
+		$cmdId = $this->givenAHistorizedNumericCmd('', 2);
+		$this->givenAHistoryRowOlderThanArchiveTime($cmdId, 1.23);
+
+		history::archive();
+
+		$this->thenRowExistsInHistoryArch($cmdId);
+	}
+
+	/**
+	 * Insert an eqLogic + a numeric, historized cmd directly via SQL.
+	 * Going through DB::Prepare instead of `new eqLogic()/save()` avoids pulling
+	 * in a plugin class and lets us exercise the vulnerable code path with a
+	 * minimal fixture. subType=numeric has canBeSmooth=true which reaches the
+	 * REPLACE INTO historyArch(...) branch where the injection lives.
+	 *
+	 * @param string     $historizeMode  value stored into cmd.configuration.historizeMode
+	 * @param int|string $historizeRound value stored into cmd.configuration.historizeRound
+	 * @return int the newly inserted cmd id
+	 */
+	private function givenAHistorizedNumericCmd(string $historizeMode, $historizeRound): int {
+		$eqLogicName = 'test_hist_inj_' . bin2hex(random_bytes(4));
+		DB::Prepare(
+			'INSERT INTO eqLogic (name, eqType_name, isEnable, isVisible, configuration) VALUES (:name, "core", 1, 1, "{}")',
+			array('name' => $eqLogicName),
+			DB::FETCH_TYPE_ROW
+		);
+		$eqLogicId = (int) DB::getLastInsertId();
+		$this->registerCleanup(function () use ($eqLogicId) {
+			DB::Prepare('DELETE FROM eqLogic WHERE id = :id', array('id' => $eqLogicId), DB::FETCH_TYPE_ROW);
+		});
+
+		$configuration = json_encode(array(
+			'historizeMode' => $historizeMode,
+			'historizeRound' => $historizeRound,
+		));
+		$cmdName = 'test_cmd_' . bin2hex(random_bytes(4));
+		DB::Prepare(
+			'INSERT INTO cmd (eqLogic_id, name, type, subType, eqType, isHistorized, configuration) VALUES (:eqLogic_id, :name, "info", "numeric", "core", 1, :configuration)',
+			array('eqLogic_id' => $eqLogicId, 'name' => $cmdName, 'configuration' => $configuration),
+			DB::FETCH_TYPE_ROW
+		);
+		$cmdId = (int) DB::getLastInsertId();
+		$this->registerCleanup(function () use ($cmdId) {
+			DB::Prepare('DELETE FROM cmd WHERE id = :id', array('id' => $cmdId), DB::FETCH_TYPE_ROW);
+		});
+
+		return $cmdId;
+	}
+
+	/**
+	 * Insert one row in history with a datetime older than the archive window
+	 * so that history::archive() picks it up. Default archiveTime is -1 hour,
+	 * so -3 hours is safely in range.
+	 */
+	private function givenAHistoryRowOlderThanArchiveTime(int $cmdId, float $value): void {
+		$datetime = date('Y-m-d H:i:s', strtotime('-3 hours'));
+		DB::Prepare(
+			'REPLACE INTO history SET cmd_id=:cmd_id, `datetime`=:datetime, value=:value',
+			array('cmd_id' => $cmdId, 'datetime' => $datetime, 'value' => $value),
+			DB::FETCH_TYPE_ROW
+		);
+		$this->registerCleanup(function () use ($cmdId) {
+			DB::Prepare('DELETE FROM history WHERE cmd_id=:cmd_id', array('cmd_id' => $cmdId), DB::FETCH_TYPE_ROW);
+			DB::Prepare('DELETE FROM historyArch WHERE cmd_id=:cmd_id', array('cmd_id' => $cmdId), DB::FETCH_TYPE_ROW);
+		});
+	}
+
+	private function thenRowExistsInHistoryArch(int $cmdId): void {
+		$row = DB::Prepare(
+			'SELECT COUNT(*) as cnt FROM historyArch WHERE cmd_id=:cmd_id',
+			array('cmd_id' => $cmdId),
+			DB::FETCH_TYPE_ROW
+		);
+		$this->assertGreaterThan(
+			0,
+			(int) $row['cnt'],
+			"Row was not archived for cmd_id={$cmdId} - archive may have failed (injection attempt caused SQL error)"
+		);
+	}
+
+	private function thenTableStillExists(string $table): void {
+		$row = DB::Prepare(
+			'SHOW TABLES LIKE :table',
+			array('table' => $table),
+			DB::FETCH_TYPE_ROW
+		);
+		$this->assertNotEmpty($row, "Table '{$table}' no longer exists");
+	}
+
+	private function registerCleanup(callable $callback): void {
+		$this->cleanupStack[] = $callback;
+	}
+}


### PR DESCRIPTION
## Description

En auditant `core/class/history.class.php`, j'ai remarqué que la méthode `archive()` concatène directement dans la requête SQL deux valeurs provenant de la configuration d'une commande :

- `historizeMode` — interpolé comme nom de fonction d'agrégation (`AVG`, `MIN`, …)
- `historizeRound` — interpolé comme nombre de décimales dans `DECIMAL(12, N)`

Ces deux valeurs sont modifiables par un administrateur via la configuration de commande (stockée en JSON dans la colonne `configuration` de la table `cmd`). Il s'agit donc d'une injection SQL de second ordre : un admin peut sauvegarder un payload dans la configuration, puis attendre que le cron d'archivage (appelé depuis `history::archive()`) l'exécute.

La requête vulnérable :
```sql
REPLACE INTO historyArch(cmd_id,`datetime`,value)
  SELECT cmd_id, MIN(`datetime`), <mode>(CAST(value AS DECIMAL(12, <round>))) as value
  FROM history
  WHERE `datetime` <= :archiveTime AND cmd_id = :cmd_id AND `value` IS NOT NULL
  GROUP BY UNIX_TIMESTAMP(`datetime`) DIV :archivePackage
```

### Corrections apportées

- **Whitelist stricte sur `historizeMode`** — seules les valeurs `avg`, `min`, `max`, `none` sont acceptées (cohérent avec le `<select>` exposé dans `desktop/modal/cmd.configure.php` et avec le `switch` de `history.class.php:1060`). Toute autre valeur retombe sur `avg`.
- **Normalisation de `historizeRound`** — `intval()` puis bornage dans `[0, 12]` (la limite haute correspond à la précision maximale d'un `DECIMAL(12, N)` MySQL sans dépasser la largeur totale). Toute valeur hors de cette plage retombe sur `2`.

### Tests

J'ai ajouté `tests/integration/historyArchiveSqlInjectionTest.php` qui appelle directement `history::archive()` (pas besoin de sous-processus AJAX contrairement à #3267, vu qu'on est sur une méthode statique). 6 tests couvrant : mode légitime (baseline), payload `DROP TABLE`, injection `UNION SELECT`, `round` hors plage (99), `round` négatif (-5), et mode vide.

4 des 6 tests échouent sur `develop` sans la correction :
- Les 4 tests "malveillants" provoquent une erreur de syntaxe SQL — l'exception est avalée silencieusement par le `catch` interne et la ligne n'est jamais archivée.
- Le test "mode vide" passe dans les deux cas car une chaîne vide produit du SQL syntaxiquement valide (`(CAST(...))` sans fonction englobante) ; je l'ai gardé comme test de régression fonctionnelle.

Le setup des fixtures passe par des `INSERT` directs dans `eqLogic` / `cmd` / `history` pour éviter toute dépendance à un plugin (contrairement à `tests/pluginTest.php` qui s'appuie sur `virtual`).

### Suggested changelog entry

* **Sécurité** : correction d'une injection SQL de second ordre dans l'archivage de l'historique (`core/class/history.class.php`)

### Related issues/external references

N/A


## Types of changes
- [x] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [x] I grant the project the right to include and distribute the code under the GNU.
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.