### PR TITLE
improve Dockerfile build sequence

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+/vendor
+/docs

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,18 +44,18 @@ RUN apt -o Dpkg::Options::="--force-confdef" -y install software-properties-comm
   php libapache2-mod-php php-json php-mysql php-curl php-gd php-imap php-xml php-opcache php-soap php-xmlrpc \
   php-common php-dev php-zip php-ssh2 php-mbstring php-ldap php-yaml php-snmp && apt -y remove brltty
 
-COPY install/install.sh /tmp/
-RUN sh /tmp/install.sh -s 1 -v ${VERSION} -w ${WEBSERVER_HOME} -d ${DATABASE} -i docker
-RUN sh /tmp/install.sh -s 2 -v ${VERSION} -w ${WEBSERVER_HOME} -d ${DATABASE} -i docker
-RUN sh /tmp/install.sh -s 3 -v ${VERSION} -w ${WEBSERVER_HOME} -d ${DATABASE} -i docker
-RUN sh /tmp/install.sh -s 4 -v ${VERSION} -w ${WEBSERVER_HOME} -d ${DATABASE} -i docker
-RUN sh /tmp/install.sh -s 5 -v ${VERSION} -w ${WEBSERVER_HOME} -d ${DATABASE} -i docker
+COPY --chown=root:root --chmod=550 install/install.sh /root/
+RUN sh /root/install.sh -s 1 -v ${VERSION} -w ${WEBSERVER_HOME} -d ${DATABASE} -i docker
+RUN sh /root/install.sh -s 2 -v ${VERSION} -w ${WEBSERVER_HOME} -d ${DATABASE} -i docker
+RUN sh /root/install.sh -s 3 -v ${VERSION} -w ${WEBSERVER_HOME} -d ${DATABASE} -i docker
+RUN sh /root/install.sh -s 4 -v ${VERSION} -w ${WEBSERVER_HOME} -d ${DATABASE} -i docker
+RUN sh /root/install.sh -s 5 -v ${VERSION} -w ${WEBSERVER_HOME} -d ${DATABASE} -i docker
 COPY . ${WEBSERVER_HOME}
-RUN sh /tmp/install.sh -s 7 -v ${VERSION} -w ${WEBSERVER_HOME} -d ${DATABASE} -i docker
-RUN sh /tmp/install.sh -s 8 -v ${VERSION} -w ${WEBSERVER_HOME} -d ${DATABASE} -i docker
-RUN sh /tmp/install.sh -s 9 -v ${VERSION} -w ${WEBSERVER_HOME} -d ${DATABASE} -i docker
-RUN sh /tmp/install.sh -s 10 -v ${VERSION} -w ${WEBSERVER_HOME} -d ${DATABASE} -i docker
-RUN sh /tmp/install.sh -s 11 -v ${VERSION} -w ${WEBSERVER_HOME} -d ${DATABASE} -i docker
+RUN sh /root/install.sh -s 7 -v ${VERSION} -w ${WEBSERVER_HOME} -d ${DATABASE} -i docker
+RUN sh /root/install.sh -s 8 -v ${VERSION} -w ${WEBSERVER_HOME} -d ${DATABASE} -i docker
+RUN sh /root/install.sh -s 9 -v ${VERSION} -w ${WEBSERVER_HOME} -d ${DATABASE} -i docker
+RUN sh /root/install.sh -s 10 -v ${VERSION} -w ${WEBSERVER_HOME} -d ${DATABASE} -i docker
+RUN sh /root/install.sh -s 11 -v ${VERSION} -w ${WEBSERVER_HOME} -d ${DATABASE} -i docker
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* 
 RUN echo >${WEBSERVER_HOME}/initialisation
 

--- a/install/OS_specific/Docker/init.sh
+++ b/install/OS_specific/Docker/init.sh
@@ -81,10 +81,15 @@ if [ -f ${WEBSERVER_HOME}/core/config/common.config.php ]; then
 else
 	echo 'Start jeedom installation'
 	JEEDOM_INSTALL=0
-	rm -rf /root/install.sh
-	wget https://raw.githubusercontent.com/jeedom/core/${VERSION}/install/install.sh -O /root/install.sh
-	chmod +x /root/install.sh
-	/root/install.sh -s 6 -v ${VERSION} -w ${WEBSERVER_HOME}
+
+	# do not re-install jeedom
+	if [ ! -f ${WEBSERVER_HOME}/core/config/common.config.sample.php ]; then
+		echo 'download again Jeedom'
+		/root/install.sh -s 6 -v ${VERSION} -w ${WEBSERVER_HOME}
+		# jeedom installation : install composer
+		/root/install.sh -s 10 -v ${VERSION} -w ${WEBSERVER_HOME} -i docker
+	fi
+
 	if [ $(which mysqld | wc -l) -ne 0 ]; then
 		chown -R mysql:mysql /var/lib/mysql
 		mysql_install_db --user=mysql --basedir=/usr/ --ldata=/var/lib/mysql/

--- a/install/OS_specific/Docker/init.sh
+++ b/install/OS_specific/Docker/init.sh
@@ -83,12 +83,13 @@ else
 	JEEDOM_INSTALL=0
 
 	# do not re-install jeedom
-	if [ ! -f ${WEBSERVER_HOME}/core/config/common.config.sample.php ]; then
+	if [ ! -f ${WEBSERVER_HOME}/core/php/core.inc.php ]; then
 		echo 'download again Jeedom'
-		/root/install.sh -s 6 -v ${VERSION} -w ${WEBSERVER_HOME}
-		# jeedom installation : install composer
-		/root/install.sh -s 10 -v ${VERSION} -w ${WEBSERVER_HOME} -i docker
-	fi
+		if ! /root/install.sh -s 6 -v ${VERSION} -w ${WEBSERVER_HOME}; then
+			echo "ERROR: step 6 failed, aborting"
+			exit 1
+		fi
+ 	fi
 
 	if [ $(which mysqld | wc -l) -ne 0 ]; then
 		chown -R mysql:mysql /var/lib/mysql
@@ -108,6 +109,15 @@ else
 		sed -i "s/#HOST#/localhost/g" ${WEBSERVER_HOME}/core/config/common.config.php
 		/root/install.sh -s 10 -v ${VERSION} -w ${WEBSERVER_HOME}
 		/root/install.sh -s 11 -v ${VERSION} -w ${WEBSERVER_HOME}
+	fi
+fi
+
+# check that vendor directory exists
+if [ ! -d ${WEBSERVER_HOME}/vendor ]; then
+	# jeedom installation : install composer
+	if ! /root/install.sh -s 10 -v ${VERSION} -w ${WEBSERVER_HOME} -i docker; then
+		echo "ERROR: step 10 failed, aborting"
+		exit 1
 	fi
 fi
 

--- a/install/install.sh
+++ b/install/install.sh
@@ -331,9 +331,6 @@ step_10_jeedom_installation() {
   export COMPOSER_ALLOW_SUPERUSER=1
   cd ${WEBSERVER_HOME}
   composer install --no-ansi --no-dev --no-interaction --no-plugins --no-progress --no-scripts --optimize-autoloader
-  mkdir -p /tmp/jeedom
-  chmod 777 -R /tmp/jeedom
-  chown www-data:www-data -R /tmp/jeedom
 
   if [ "${INSTALLATION_TYPE}" != "docker" ];then
     php ${WEBSERVER_HOME}/install/install.php mode=force
@@ -349,6 +346,9 @@ step_10_jeedom_installation() {
 step_11_jeedom_post() {
   echo "---------------------------------------------------------------------"
   echo "${YELLOW}Starting step 11 - Jeedom post-install${NORMAL}"
+  mkdir -p /tmp/jeedom
+  chmod 777 -R /tmp/jeedom
+  chown www-data:www-data -R /tmp/jeedom
   if [ $(crontab -l | grep jeedom | wc -l) -ne 0 ];then
     (echo crontab -l | grep -v "jeedom") | crontab -
 


### PR DESCRIPTION
## Description

Pour éviter de recopier les sources lorsque ce n'est pas nécessaire, au démarrage du conteneur: le step (6) dans Dockerfile `COPY . ${WEBSERVER_HOME}` fait déjà la copie des fichiers dans le répertoire courant.
Pourtant je l'ai quand même laissé post-install dans le init.sh pour un cas particulier :

`docker run -p 80:80 -v /home/pifou/jeedom:/var/www/html --rm --name jeedom_server jeedom`
Avec l'option -v je map le répertoire de l'host sur celui du container. Du coup ça permet de persister Jeedom sur l'host, et ça marche lors de l'arrêt / mise à jour / relance du container, on ne perd rien. Mais au 1er lancement, si mon rep /home/pifou/jeedom est vide sur l'host, il est vide aussi dans le container, malgré que je pensais y avoir copié les sources (lors du build). Dans ce cas uniquement, on doit recopier les sources au démarrage du conteneur, cela est normal.

Dans le cas de l'utilisation d'un volume nommé, c'est différent, le répertoire n'existe pas et il est bien initialisé avec les données de l'image du conteneur (le volume persistant sera créé dans `/var/lib/docker`) :
`docker run -p 80:80 -v jeedom_data:/var/www/html --rm --name jeedom_server jeedom`

Le fichier `.dockerignore` permet à l'instruction `COPY . ` de savoir ce qu'il faut ignorer - ne pas copier dans l'image.

Le step 10 (install composer) se fait aussi au build de l'image, pas au démarrage de l'application. Donc dans le Dockerfile également.

### Suggested changelog entry

* Ne pas écraser notre répertoire source Jeedom lors d'une mise à jour de l'image Docker.