### PR TITLE
fix: remove Access-Control-Allow-Credentials with Allow-Origin: *

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -4,7 +4,6 @@ Options -Indexes -ExecCGI -FollowSymLinks
 
 <IfModule mod_headers.c>
     Header set Access-Control-Allow-Origin "*"
-    Header set Access-Control-Allow-Credentials true
     Header add Access-Control-Allow-Headers "origin, x-requested-with, content-type"
     Header add Access-Control-Allow-Methods "PUT, GET, POST, DELETE, OPTIONS"
     ServerSignature Off

--- a/install/nginx_default
+++ b/install/nginx_default
@@ -71,7 +71,6 @@ server {
                 fastcgi_read_timeout 300;
                 if ($request_method = 'GET') {
                         add_header 'Access-Control-Allow-Origin' '*';
-                        add_header 'Access-Control-Allow-Credentials' 'true';
                         add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
                         add_header 'Access-Control-Allow-Headers' 'DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
                 }

--- a/tests/corsHeadersTest.php
+++ b/tests/corsHeadersTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/* This file is part of Jeedom.
+*
+* Jeedom is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* Jeedom is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Jeedom. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression test: `Access-Control-Allow-Credentials: true` combined with
+ * `Access-Control-Allow-Origin: *` is rejected by all modern browsers, so the
+ * credentials directive is dead code that misleads reviewers about the
+ * intended cross-origin policy. It must not reappear in the shipped config.
+ */
+class corsHeadersTest extends TestCase {
+
+	public function testHtaccessHasNoAllowCredentials() {
+		$path = __DIR__ . '/../.htaccess';
+		$this->assertFileExists($path);
+		$content = file_get_contents($path);
+		$this->assertDoesNotMatchRegularExpression(
+			'/Access-Control-Allow-Credentials/i',
+			$content,
+			'.htaccess must not emit Access-Control-Allow-Credentials with Allow-Origin: *'
+		);
+	}
+
+	public function testNginxDefaultHasNoAllowCredentials() {
+		$path = __DIR__ . '/../install/nginx_default';
+		$this->assertFileExists($path);
+		$content = file_get_contents($path);
+		$this->assertDoesNotMatchRegularExpression(
+			'/Access-Control-Allow-Credentials/i',
+			$content,
+			'nginx_default must not emit Access-Control-Allow-Credentials with Allow-Origin: *'
+		);
+	}
+
+	public function testJeeApiHasNoAllowCredentials() {
+		$path = __DIR__ . '/../core/api/jeeApi.php';
+		$this->assertFileExists($path);
+		$content = file_get_contents($path);
+		$this->assertDoesNotMatchRegularExpression(
+			'/Access-Control-Allow-Credentials/i',
+			$content,
+			'jeeApi.php must not emit Access-Control-Allow-Credentials with Allow-Origin: *'
+		);
+	}
+}


### PR DESCRIPTION
## Description

`.htaccess` et `install/nginx_default` combinent `Access-Control-Allow-Origin: *` avec `Access-Control-Allow-Credentials: true`. La spec CORS interdit cette combinaison : les navigateurs rejettent la réponse, donc la directive `Allow-Credentials` n'a aucun effet et induit en erreur sur la politique cross-origin réelle.

`core/api/jeeApi.php` ne l'avait déjà pas, et l'API s'authentifie par `apikey` en paramètre — aucun usage légitime de credentials cross-origin n'est cassé.

### Corrections apportées

- Retrait de la ligne `Access-Control-Allow-Credentials` dans `.htaccess` et `install/nginx_default`.

### Tests

Ajout de `tests/corsHeadersTest.php` qui vérifie l'absence du header dans les trois fichiers concernés. Les tests échouent sur `develop` avant fix, passent après.

### Suggested changelog entry

* **Security**: removed `Access-Control-Allow-Credentials: true` from Apache/Nginx configs, ineffective when combined with `Allow-Origin: *`.

### Related issues/external references

N/A


## Types of changes
- [x] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [x] I grant the project the right to include and distribute the code under the GNU.
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.