### PR TITLE
Increase PR list limit to 1000 iso 30 by default

### DIFF
--- a/.github/workflows/draft-release-notes.yml
+++ b/.github/workflows/draft-release-notes.yml
@@ -41,6 +41,7 @@ jobs:
           PRS_JSON=$(gh pr list \
             --state merged \
             --base develop \
+            --limit 1000 \
             --search "merged:>${{ steps.tagdate.outputs.date }}" \
             --json number,title,mergedAt,url,labels)
 


### PR DESCRIPTION
## Description
PR list was limited to last 30 PRs so each time we merge a new one, the oldest one was removed from the list and the release notes :-)


### Suggested changelog entry
n/a

### Related issues/external references

Fixes #


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have checked there is no other PR open for the same change.
- [ ] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [ ] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [ ] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
