### PR TITLE
Fix implicit globals and remove dead code in core/js

### DIFF
--- a/core/js/core.js
+++ b/core/js/core.js
@@ -31,7 +31,7 @@ function getTemplate(_folder, _version, _filename, _replace) {
     success: function(data) {
       if (isset(_replace) && _replace != null) {
         var reg = null;
-        for (i in _replace) {
+        for (var i in _replace) {
           reg = new RegExp(i, "g");
           data = data.replace(reg, _replace[i]);
         }

--- a/core/js/private.class.js
+++ b/core/js/private.class.js
@@ -274,7 +274,6 @@ jeedom.private.checkAndGetParams = function(_params, _paramsSpecifics, _paramsRe
   var params = domUtils.extend({}, jeedom.private.default_params, _paramsSpecifics, _params || {});
 
   //Convert all objects in params to json
-  var param = null;
   for (var attr in params) {
     params[attr] = (typeof params[attr] == 'object') ? JSON.stringify(params[attr]) : params[attr];
   }

--- a/core/js/view.class.js
+++ b/core/js/view.class.js
@@ -48,7 +48,7 @@ jeedom.view.toHtml = function(_params) {
   var paramsRequired = ['id', 'version'];
   var paramsSpecifics = {
     pre_success: function(data) {
-      result = jeedom.view.handleViewAjax({
+      var result = jeedom.view.handleViewAjax({
         view: data.result
       });
       result.raw = data.result;
@@ -135,7 +135,7 @@ jeedom.view.handleViewAjax = function(_params) {
       for (var j in viewZone.viewData) {
         viewData = viewZone.viewData[j];
         configuration = JSON.stringify(viewData.configuration);
-        option = configuration.replace(/"/g, "'");
+        var option = configuration.replace(/"/g, "'");
         result.html += '<div class="viewZoneData hidden" data-cmdId="'+viewData.link_id+'" data-option="'+option+'" data-el="'+div_id+'" data-height="'+viewZone.configuration.height+'" data-dateRange="'+viewZone.configuration.dateRange+'"></div>';
       }
       result.html += '</div>';


### PR DESCRIPTION
## Summary

Three pre-existing minor bugs in `core/js/` found while auditing the codebase. Each is a one-line change that does not modify the surrounding declaration style (still using `var` to match the existing code).

## Changes

- **`core/js/core.js`** — `for (i in _replace)` was leaking `i` as an implicit global on `window`. Now declared with `var i`.
- **`core/js/view.class.js`** (toHtml `pre_success`) — `result = jeedom.view.handleViewAjax(...)` was leaking `result` as implicit global. Now declared with `var result`.
- **`core/js/view.class.js`** (handleViewAjax graph zone loop) — `option = configuration.replace(...)` was leaking `option` as implicit global. Now declared with `var option`.
- **`core/js/private.class.js`** — `var param = null;` declared but never read. Removed (dead code).

Found via ESLint static analysis. Net diff: +3 / -4 lines across 3 files.

## Why this matters

Implicit globals via assignment without declaration silently pollute `window` and can collide with other scripts. They also break under `"use strict"` mode (which is already declared in some Jeedom files like `desktop/js/log.js`).

## Test plan

- [ ] Load a view page that calls `jeedom.view.toHtml` — verify rendering unchanged
- [ ] Load a view containing a graph zone — verify graph data attributes correctly populated
- [ ] Trigger any code path calling `jeedomUtils.getTemplateFileContent` with the `_replace` parameter — verify replacements still work

This PR is the first in a series (see #3297 discussion) splitting the previously-too-large optimization PR into focused changes.