### PR TITLE
Add ESLint CI workflow with baseline (mirrors PHPStan setup)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,25 @@
+{
+  "parserOptions": {
+    "ecmaVersion": 2022,
+    "sourceType": "script"
+  },
+  "env": {
+    "browser": true,
+    "jquery": true,
+    "es2022": true
+  },
+  "rules": {
+    "no-const-assign": "error",
+    "no-redeclare": "error",
+    "no-dupe-args": "error",
+    "no-dupe-keys": "error",
+    "no-dupe-class-members": "error",
+    "no-unreachable": "error",
+    "no-self-assign": "error",
+    "no-self-compare": "error",
+    "no-unsafe-negation": "error",
+    "no-unsafe-finally": "error",
+    "no-undef": "off",
+    "no-unused-vars": "off"
+  }
+}

--- a/.github/scripts/eslint-baseline-check.js
+++ b/.github/scripts/eslint-baseline-check.js
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+/**
+ * ESLint baseline checker for Jeedom core.
+ *
+ * Runs ESLint on JS sources, compares results against eslint-baseline.json,
+ * and fails if a new violation appears (i.e. a new {file, ruleId, message}
+ * tuple not present in the baseline). Allows existing violations to
+ * disappear (e.g. when a fix lands).
+ *
+ * Usage:
+ *   node .github/scripts/eslint-baseline-check.js           # check
+ *   node .github/scripts/eslint-baseline-check.js --update  # regenerate baseline
+ */
+
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const BASELINE_PATH = path.join(ROOT, 'eslint-baseline.json');
+const TARGETS = ['core/js', 'desktop/js'];
+
+function runEslint() {
+  const eslintBin = path.join(ROOT, 'node_modules', '.bin', 'eslint');
+  const result = spawnSync(eslintBin, ['-f', 'json', ...TARGETS], {
+    cwd: ROOT,
+    encoding: 'utf8',
+    maxBuffer: 50 * 1024 * 1024
+  });
+  if (result.error) {
+    console.error('Failed to spawn ESLint:', result.error);
+    process.exit(2);
+  }
+  // ESLint exits non-zero when it finds errors; that's fine, we still parse stdout.
+  if (!result.stdout) {
+    console.error('ESLint produced no output. stderr:', result.stderr);
+    process.exit(2);
+  }
+  return JSON.parse(result.stdout);
+}
+
+function normalize(report) {
+  const entries = [];
+  for (const file of report) {
+    const rel = path.relative(ROOT, file.filePath).replace(/\\/g, '/');
+    for (const msg of file.messages || []) {
+      if (msg.severity !== 2) continue;
+      entries.push({
+        file: rel,
+        ruleId: msg.ruleId,
+        message: msg.message
+      });
+    }
+  }
+  entries.sort((a, b) =>
+    (a.file + (a.ruleId || '') + a.message).localeCompare(
+      b.file + (b.ruleId || '') + b.message
+    )
+  );
+  return entries;
+}
+
+function tupleKey(e) {
+  return `${e.file}|${e.ruleId || ''}|${e.message}`;
+}
+
+function loadBaseline() {
+  if (!fs.existsSync(BASELINE_PATH)) return [];
+  return JSON.parse(fs.readFileSync(BASELINE_PATH, 'utf8'));
+}
+
+function main() {
+  const update = process.argv.includes('--update');
+  const current = normalize(runEslint());
+
+  if (update) {
+    fs.writeFileSync(BASELINE_PATH, JSON.stringify(current, null, 2) + '\n');
+    console.log(`Baseline updated: ${current.length} entries written to eslint-baseline.json`);
+    return;
+  }
+
+  const baseline = loadBaseline();
+  const baselineKeys = new Set(baseline.map(tupleKey));
+  const currentKeys = new Set(current.map(tupleKey));
+
+  const added = current.filter(e => !baselineKeys.has(tupleKey(e)));
+  const removed = baseline.filter(e => !currentKeys.has(tupleKey(e)));
+
+  console.log(`Baseline: ${baseline.length} entries`);
+  console.log(`Current:  ${current.length} entries`);
+  console.log(`Removed:  ${removed.length} entries (fixes welcome)`);
+  console.log(`Added:    ${added.length} entries`);
+
+  if (added.length > 0) {
+    console.error('\nNew ESLint violations not present in baseline:');
+    for (const e of added) {
+      console.error(`  ${e.file}: [${e.ruleId}] ${e.message}`);
+    }
+    console.error(
+      '\nFix these violations or, if intentional, regenerate the baseline:\n' +
+      '  npm run lint:baseline'
+    );
+    process.exit(1);
+  }
+
+  console.log('\nNo new violations. ');
+}
+
+main();

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -1,0 +1,75 @@
+name: ESLint
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+
+jobs:
+  eslint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci || npm install
+
+      - name: Run ESLint baseline check
+        run: npm run lint:check
+
+  update-baseline:
+    needs: eslint
+    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Delete existing branch if exists
+        run: |
+          if git ls-remote --heads origin update-eslint-baseline | grep -q update-eslint-baseline; then
+            git push origin --delete update-eslint-baseline
+          fi
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci || npm install
+
+      - name: Regenerate baseline
+        id: regen
+        run: |
+          cp eslint-baseline.json eslint-baseline.json.old
+          npm run lint:baseline
+          if ! diff -q eslint-baseline.json eslint-baseline.json.old > /dev/null; then
+            echo "baseline_changed=true" >> $GITHUB_OUTPUT
+          fi
+          rm -f eslint-baseline.json.old
+
+      - name: Create Pull Request
+        if: steps.regen.outputs.baseline_changed == 'true'
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: '[skip ci] Update ESLint baseline'
+          title: '[CI] Update ESLint baseline'
+          body: |
+            Mise à jour automatique du baseline ESLint suite à la correction d'erreurs.
+
+            Cette PR a été générée automatiquement par le workflow CI.
+          branch: update-eslint-baseline
+          base: develop
+          delete-branch: true
+          add-paths: |
+            eslint-baseline.json

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ tmp/*
 .env
 .phpstan.cache
 phpstan.phar
+node_modules/

--- a/eslint-baseline.json
+++ b/eslint-baseline.json
@@ -1,0 +1,877 @@
+[
+  {
+    "file": "core/js/cmd.class.js",
+    "ruleId": "no-redeclare",
+    "message": "'dateString' is already defined."
+  },
+  {
+    "file": "core/js/cmd.class.js",
+    "ruleId": "no-redeclare",
+    "message": "'durationString' is already defined."
+  },
+  {
+    "file": "core/js/cmd.class.js",
+    "ruleId": "no-redeclare",
+    "message": "'el' is already defined."
+  },
+  {
+    "file": "core/js/cmd.class.js",
+    "ruleId": "no-redeclare",
+    "message": "'refresh' is already defined."
+  },
+  {
+    "file": "core/js/cmd.class.js",
+    "ruleId": "no-redeclare",
+    "message": "'result' is already defined."
+  },
+  {
+    "file": "core/js/core.js",
+    "ruleId": "no-redeclare",
+    "message": "'hashes' is already defined."
+  },
+  {
+    "file": "core/js/core.js",
+    "ruleId": "no-redeclare",
+    "message": "'path' is already defined."
+  },
+  {
+    "file": "core/js/eqLogic.class.js",
+    "ruleId": "no-redeclare",
+    "message": "'packer' is already defined."
+  },
+  {
+    "file": "core/js/eqLogic.class.js",
+    "ruleId": "no-redeclare",
+    "message": "'topMargin' is already defined."
+  },
+  {
+    "file": "core/js/history.class.js",
+    "ruleId": "no-redeclare",
+    "message": "'i' is already defined."
+  },
+  {
+    "file": "core/js/history.class.js",
+    "ruleId": "no-redeclare",
+    "message": "'i' is already defined."
+  },
+  {
+    "file": "core/js/history.class.js",
+    "ruleId": "no-redeclare",
+    "message": "'mathMax' is already defined."
+  },
+  {
+    "file": "core/js/history.class.js",
+    "ruleId": "no-redeclare",
+    "message": "'mathMax' is already defined."
+  },
+  {
+    "file": "core/js/history.class.js",
+    "ruleId": "no-redeclare",
+    "message": "'mathMax' is already defined."
+  },
+  {
+    "file": "core/js/history.class.js",
+    "ruleId": "no-redeclare",
+    "message": "'mathMax' is already defined."
+  },
+  {
+    "file": "core/js/history.class.js",
+    "ruleId": "no-redeclare",
+    "message": "'mathMin' is already defined."
+  },
+  {
+    "file": "core/js/history.class.js",
+    "ruleId": "no-redeclare",
+    "message": "'mathMin' is already defined."
+  },
+  {
+    "file": "core/js/history.class.js",
+    "ruleId": "no-redeclare",
+    "message": "'mathMin' is already defined."
+  },
+  {
+    "file": "core/js/history.class.js",
+    "ruleId": "no-redeclare",
+    "message": "'max' is already defined."
+  },
+  {
+    "file": "core/js/history.class.js",
+    "ruleId": "no-redeclare",
+    "message": "'min' is already defined."
+  },
+  {
+    "file": "core/js/history.class.js",
+    "ruleId": "no-redeclare",
+    "message": "'opacity' is already defined."
+  },
+  {
+    "file": "core/js/history.class.js",
+    "ruleId": "no-redeclare",
+    "message": "'options' is already defined."
+  },
+  {
+    "file": "core/js/history.class.js",
+    "ruleId": "no-redeclare",
+    "message": "'series' is already defined."
+  },
+  {
+    "file": "core/js/history.class.js",
+    "ruleId": "no-redeclare",
+    "message": "'series' is already defined."
+  },
+  {
+    "file": "core/js/history.class.js",
+    "ruleId": "no-redeclare",
+    "message": "'split' is already defined."
+  },
+  {
+    "file": "core/js/history.class.js",
+    "ruleId": "no-redeclare",
+    "message": "'unit' is already defined."
+  },
+  {
+    "file": "core/js/log.class.js",
+    "ruleId": "no-redeclare",
+    "message": "'isAuto' is already defined."
+  },
+  {
+    "file": "core/js/object.class.js",
+    "ruleId": "no-redeclare",
+    "message": "'updated' is already defined."
+  },
+  {
+    "file": "core/js/plugin.template.js",
+    "ruleId": "no-redeclare",
+    "message": "'_cmd' is already defined."
+  },
+  {
+    "file": "core/js/plugin.template.js",
+    "ruleId": "no-redeclare",
+    "message": "'group' is already defined."
+  },
+  {
+    "file": "core/js/plugin.template.js",
+    "ruleId": "no-redeclare",
+    "message": "'group' is already defined."
+  },
+  {
+    "file": "core/js/plugin.template.js",
+    "ruleId": "no-redeclare",
+    "message": "'i' is already defined."
+  },
+  {
+    "file": "core/js/scenario.class.js",
+    "ruleId": "no-redeclare",
+    "message": "'tile' is already defined."
+  },
+  {
+    "file": "core/js/timeline.class.js",
+    "ruleId": "no-redeclare",
+    "message": "'values' is already defined."
+  },
+  {
+    "file": "core/js/view.class.js",
+    "ruleId": "no-redeclare",
+    "message": "'j' is already defined."
+  },
+  {
+    "file": "desktop/js/administration.js",
+    "ruleId": "no-redeclare",
+    "message": "'el' is already defined."
+  },
+  {
+    "file": "desktop/js/administration.js",
+    "ruleId": "no-redeclare",
+    "message": "'icon' is already defined."
+  },
+  {
+    "file": "desktop/js/administration.js",
+    "ruleId": "no-redeclare",
+    "message": "'objectSummary' is already defined."
+  },
+  {
+    "file": "desktop/js/administration.js",
+    "ruleId": "no-redeclare",
+    "message": "'objectSummary' is already defined."
+  },
+  {
+    "file": "desktop/js/backup.js",
+    "ruleId": "no-redeclare",
+    "message": "'i' is already defined."
+  },
+  {
+    "file": "desktop/js/dashboard.js",
+    "ruleId": "no-redeclare",
+    "message": "'arHeights' is already defined."
+  },
+  {
+    "file": "desktop/js/dashboard.js",
+    "ruleId": "no-redeclare",
+    "message": "'checkbox' is already defined."
+  },
+  {
+    "file": "desktop/js/dashboard.js",
+    "ruleId": "no-redeclare",
+    "message": "'id_object' is already defined."
+  },
+  {
+    "file": "desktop/js/dashboard.js",
+    "ruleId": "no-redeclare",
+    "message": "'objectContainer' is already defined."
+  },
+  {
+    "file": "desktop/js/database.js",
+    "ruleId": "no-redeclare",
+    "message": "'col' is already defined."
+  },
+  {
+    "file": "desktop/js/database.js",
+    "ruleId": "no-redeclare",
+    "message": "'i' is already defined."
+  },
+  {
+    "file": "desktop/js/database.js",
+    "ruleId": "no-redeclare",
+    "message": "'value' is already defined."
+  },
+  {
+    "file": "desktop/js/display.js",
+    "ruleId": "no-redeclare",
+    "message": "'eqLogics' is already defined."
+  },
+  {
+    "file": "desktop/js/history.js",
+    "ruleId": "no-redeclare",
+    "message": "'currentId' is already defined."
+  },
+  {
+    "file": "desktop/js/history.js",
+    "ruleId": "no-redeclare",
+    "message": "'currentId' is already defined."
+  },
+  {
+    "file": "desktop/js/history.js",
+    "ruleId": "no-redeclare",
+    "message": "'currentId' is already defined."
+  },
+  {
+    "file": "desktop/js/history.js",
+    "ruleId": "no-redeclare",
+    "message": "'endDate' is already defined."
+  },
+  {
+    "file": "desktop/js/history.js",
+    "ruleId": "no-redeclare",
+    "message": "'m_startDate' is already defined."
+  },
+  {
+    "file": "desktop/js/history.js",
+    "ruleId": "no-redeclare",
+    "message": "'num' is already defined."
+  },
+  {
+    "file": "desktop/js/history.js",
+    "ruleId": "no-redeclare",
+    "message": "'options' is already defined."
+  },
+  {
+    "file": "desktop/js/history.js",
+    "ruleId": "no-redeclare",
+    "message": "'startDate' is already defined."
+  },
+  {
+    "file": "desktop/js/history.js",
+    "ruleId": "no-redeclare",
+    "message": "'type' is already defined."
+  },
+  {
+    "file": "desktop/js/interact.js",
+    "ruleId": "no-redeclare",
+    "message": "'el' is already defined."
+  },
+  {
+    "file": "desktop/js/interact.js",
+    "ruleId": "no-redeclare",
+    "message": "'i' is already defined."
+  },
+  {
+    "file": "desktop/js/interact.js",
+    "ruleId": "no-redeclare",
+    "message": "'i' is already defined."
+  },
+  {
+    "file": "desktop/js/interact.js",
+    "ruleId": "no-redeclare",
+    "message": "'i' is already defined."
+  },
+  {
+    "file": "desktop/js/interact.js",
+    "ruleId": "no-redeclare",
+    "message": "'i' is already defined."
+  },
+  {
+    "file": "desktop/js/interact.js",
+    "ruleId": "no-redeclare",
+    "message": "'i' is already defined."
+  },
+  {
+    "file": "desktop/js/interact.js",
+    "ruleId": "no-redeclare",
+    "message": "'i' is already defined."
+  },
+  {
+    "file": "desktop/js/interact.js",
+    "ruleId": "no-redeclare",
+    "message": "'sc' is already defined."
+  },
+  {
+    "file": "desktop/js/interact.js",
+    "ruleId": "no-redeclare",
+    "message": "'type' is already defined."
+  },
+  {
+    "file": "desktop/js/interact.js",
+    "ruleId": "no-redeclare",
+    "message": "'type' is already defined."
+  },
+  {
+    "file": "desktop/js/massedit.js",
+    "ruleId": "no-redeclare",
+    "message": "'filters' is already defined."
+  },
+  {
+    "file": "desktop/js/massedit.js",
+    "ruleId": "no-redeclare",
+    "message": "'idx' is already defined."
+  },
+  {
+    "file": "desktop/js/massedit.js",
+    "ruleId": "no-redeclare",
+    "message": "'inputJValue' is already defined."
+  },
+  {
+    "file": "desktop/js/massedit.js",
+    "ruleId": "no-redeclare",
+    "message": "'jValue' is already defined."
+  },
+  {
+    "file": "desktop/js/massedit.js",
+    "ruleId": "no-redeclare",
+    "message": "'jValue' is already defined."
+  },
+  {
+    "file": "desktop/js/massedit.js",
+    "ruleId": "no-redeclare",
+    "message": "'jValues' is already defined."
+  },
+  {
+    "file": "desktop/js/massedit.js",
+    "ruleId": "no-redeclare",
+    "message": "'key' is already defined."
+  },
+  {
+    "file": "desktop/js/massedit.js",
+    "ruleId": "no-redeclare",
+    "message": "'key' is already defined."
+  },
+  {
+    "file": "desktop/js/massedit.js",
+    "ruleId": "no-redeclare",
+    "message": "'key' is already defined."
+  },
+  {
+    "file": "desktop/js/massedit.js",
+    "ruleId": "no-redeclare",
+    "message": "'newOption' is already defined."
+  },
+  {
+    "file": "desktop/js/massedit.js",
+    "ruleId": "no-redeclare",
+    "message": "'newOption' is already defined."
+  },
+  {
+    "file": "desktop/js/massedit.js",
+    "ruleId": "no-redeclare",
+    "message": "'newOption' is already defined."
+  },
+  {
+    "file": "desktop/js/massedit.js",
+    "ruleId": "no-redeclare",
+    "message": "'selectJValues' is already defined."
+  },
+  {
+    "file": "desktop/js/massedit.js",
+    "ruleId": "no-redeclare",
+    "message": "'url' is already defined."
+  },
+  {
+    "file": "desktop/js/massedit.js",
+    "ruleId": "no-redeclare",
+    "message": "'url' is already defined."
+  },
+  {
+    "file": "desktop/js/massedit.js",
+    "ruleId": "no-redeclare",
+    "message": "'value' is already defined."
+  },
+  {
+    "file": "desktop/js/massedit.js",
+    "ruleId": "no-redeclare",
+    "message": "'value' is already defined."
+  },
+  {
+    "file": "desktop/js/massedit.js",
+    "ruleId": "no-redeclare",
+    "message": "'values' is already defined."
+  },
+  {
+    "file": "desktop/js/object.js",
+    "ruleId": "no-redeclare",
+    "message": "'i' is already defined."
+  },
+  {
+    "file": "desktop/js/object.js",
+    "ruleId": "no-redeclare",
+    "message": "'j' is already defined."
+  },
+  {
+    "file": "desktop/js/object.js",
+    "ruleId": "no-redeclare",
+    "message": "'object' is already defined."
+  },
+  {
+    "file": "desktop/js/object.js",
+    "ruleId": "no-redeclare",
+    "message": "'object' is already defined."
+  },
+  {
+    "file": "desktop/js/object.js",
+    "ruleId": "no-redeclare",
+    "message": "'object' is already defined."
+  },
+  {
+    "file": "desktop/js/object.js",
+    "ruleId": "no-redeclare",
+    "message": "'object' is already defined."
+  },
+  {
+    "file": "desktop/js/object.js",
+    "ruleId": "no-redeclare",
+    "message": "'object' is already defined."
+  },
+  {
+    "file": "desktop/js/object.js",
+    "ruleId": "no-redeclare",
+    "message": "'object' is already defined."
+  },
+  {
+    "file": "desktop/js/object.js",
+    "ruleId": "no-redeclare",
+    "message": "'object' is already defined."
+  },
+  {
+    "file": "desktop/js/object.js",
+    "ruleId": "no-redeclare",
+    "message": "'objectId' is already defined."
+  },
+  {
+    "file": "desktop/js/object.js",
+    "ruleId": "no-redeclare",
+    "message": "'summary' is already defined."
+  },
+  {
+    "file": "desktop/js/object.js",
+    "ruleId": "no-redeclare",
+    "message": "'type' is already defined."
+  },
+  {
+    "file": "desktop/js/object.js",
+    "ruleId": "no-redeclare",
+    "message": "'type' is already defined."
+  },
+  {
+    "file": "desktop/js/overview.js",
+    "ruleId": "no-redeclare",
+    "message": "'cmdIds' is already defined."
+  },
+  {
+    "file": "desktop/js/overview.js",
+    "ruleId": "no-redeclare",
+    "message": "'id' is already defined."
+  },
+  {
+    "file": "desktop/js/overview.js",
+    "ruleId": "no-redeclare",
+    "message": "'id' is already defined."
+  },
+  {
+    "file": "desktop/js/overview.js",
+    "ruleId": "no-redeclare",
+    "message": "'objectId' is already defined."
+  },
+  {
+    "file": "desktop/js/overview.js",
+    "ruleId": "no-redeclare",
+    "message": "'title' is already defined."
+  },
+  {
+    "file": "desktop/js/overview.js",
+    "ruleId": "no-redeclare",
+    "message": "'url' is already defined."
+  },
+  {
+    "file": "desktop/js/overview.js",
+    "ruleId": "no-redeclare",
+    "message": "'url' is already defined."
+  },
+  {
+    "file": "desktop/js/plan.js",
+    "ruleId": "no-redeclare",
+    "message": "'i' is already defined."
+  },
+  {
+    "file": "desktop/js/plan.js",
+    "ruleId": "no-redeclare",
+    "message": "'i' is already defined."
+  },
+  {
+    "file": "desktop/js/plan.js",
+    "ruleId": "no-redeclare",
+    "message": "'i' is already defined."
+  },
+  {
+    "file": "desktop/js/plan.js",
+    "ruleId": "no-redeclare",
+    "message": "'i' is already defined."
+  },
+  {
+    "file": "desktop/js/plan.js",
+    "ruleId": "no-redeclare",
+    "message": "'i' is already defined."
+  },
+  {
+    "file": "desktop/js/plan.js",
+    "ruleId": "no-redeclare",
+    "message": "'img' is already defined."
+  },
+  {
+    "file": "desktop/js/plan.js",
+    "ruleId": "no-redeclare",
+    "message": "'style' is already defined."
+  },
+  {
+    "file": "desktop/js/plan3d.js",
+    "ruleId": "no-redeclare",
+    "message": "'hemiLight' is already defined."
+  },
+  {
+    "file": "desktop/js/plugin.js",
+    "ruleId": "no-redeclare",
+    "message": "'config_panel_html' is already defined."
+  },
+  {
+    "file": "desktop/js/plugin.js",
+    "ruleId": "no-redeclare",
+    "message": "'config_panel_html' is already defined."
+  },
+  {
+    "file": "desktop/js/plugin.js",
+    "ruleId": "no-redeclare",
+    "message": "'i' is already defined."
+  },
+  {
+    "file": "desktop/js/plugin.js",
+    "ruleId": "no-redeclare",
+    "message": "'pluginId' is already defined."
+  },
+  {
+    "file": "desktop/js/replace.js",
+    "ruleId": "no-redeclare",
+    "message": "'_cmd' is already defined."
+  },
+  {
+    "file": "desktop/js/replace.js",
+    "ruleId": "no-redeclare",
+    "message": "'optionsCmds' is already defined."
+  },
+  {
+    "file": "desktop/js/scenario.js",
+    "ruleId": "no-redeclare",
+    "message": "'clickedBloc' is already defined."
+  },
+  {
+    "file": "desktop/js/scenario.js",
+    "ruleId": "no-redeclare",
+    "message": "'element' is already defined."
+  },
+  {
+    "file": "desktop/js/scenario.js",
+    "ruleId": "no-redeclare",
+    "message": "'expression' is already defined."
+  },
+  {
+    "file": "desktop/js/scenario.js",
+    "ruleId": "no-redeclare",
+    "message": "'expression' is already defined."
+  },
+  {
+    "file": "desktop/js/scenario.js",
+    "ruleId": "no-redeclare",
+    "message": "'expression' is already defined."
+  },
+  {
+    "file": "desktop/js/scenario.js",
+    "ruleId": "no-redeclare",
+    "message": "'expression' is already defined."
+  },
+  {
+    "file": "desktop/js/scenario.js",
+    "ruleId": "no-redeclare",
+    "message": "'expression' is already defined."
+  },
+  {
+    "file": "desktop/js/scenario.js",
+    "ruleId": "no-redeclare",
+    "message": "'expression' is already defined."
+  },
+  {
+    "file": "desktop/js/scenario.js",
+    "ruleId": "no-redeclare",
+    "message": "'expression' is already defined."
+  },
+  {
+    "file": "desktop/js/scenario.js",
+    "ruleId": "no-redeclare",
+    "message": "'expression' is already defined."
+  },
+  {
+    "file": "desktop/js/scenario.js",
+    "ruleId": "no-redeclare",
+    "message": "'expression' is already defined."
+  },
+  {
+    "file": "desktop/js/scenario.js",
+    "ruleId": "no-redeclare",
+    "message": "'expression' is already defined."
+  },
+  {
+    "file": "desktop/js/scenario.js",
+    "ruleId": "no-redeclare",
+    "message": "'i' is already defined."
+  },
+  {
+    "file": "desktop/js/scenario.js",
+    "ruleId": "no-redeclare",
+    "message": "'i' is already defined."
+  },
+  {
+    "file": "desktop/js/scenario.js",
+    "ruleId": "no-redeclare",
+    "message": "'i' is already defined."
+  },
+  {
+    "file": "desktop/js/scenario.js",
+    "ruleId": "no-redeclare",
+    "message": "'id' is already defined."
+  },
+  {
+    "file": "desktop/js/scenario.js",
+    "ruleId": "no-redeclare",
+    "message": "'idx' is already defined."
+  },
+  {
+    "file": "desktop/js/scenario.js",
+    "ruleId": "no-redeclare",
+    "message": "'items' is already defined."
+  },
+  {
+    "file": "desktop/js/scenario.js",
+    "ruleId": "no-redeclare",
+    "message": "'j' is already defined."
+  },
+  {
+    "file": "desktop/js/scenario.js",
+    "ruleId": "no-redeclare",
+    "message": "'j' is already defined."
+  },
+  {
+    "file": "desktop/js/scenario.js",
+    "ruleId": "no-redeclare",
+    "message": "'j' is already defined."
+  },
+  {
+    "file": "desktop/js/scenario.js",
+    "ruleId": "no-redeclare",
+    "message": "'j' is already defined."
+  },
+  {
+    "file": "desktop/js/scenario.js",
+    "ruleId": "no-redeclare",
+    "message": "'j' is already defined."
+  },
+  {
+    "file": "desktop/js/scenario.js",
+    "ruleId": "no-redeclare",
+    "message": "'j' is already defined."
+  },
+  {
+    "file": "desktop/js/scenario.js",
+    "ruleId": "no-redeclare",
+    "message": "'k' is already defined."
+  },
+  {
+    "file": "desktop/js/scenario.js",
+    "ruleId": "no-redeclare",
+    "message": "'k' is already defined."
+  },
+  {
+    "file": "desktop/js/scenario.js",
+    "ruleId": "no-redeclare",
+    "message": "'k' is already defined."
+  },
+  {
+    "file": "desktop/js/scenario.js",
+    "ruleId": "no-redeclare",
+    "message": "'msg' is already defined."
+  },
+  {
+    "file": "desktop/js/scenario.js",
+    "ruleId": "no-redeclare",
+    "message": "'newEL' is already defined."
+  },
+  {
+    "file": "desktop/js/scenario.js",
+    "ruleId": "no-redeclare",
+    "message": "'newEL' is already defined."
+  },
+  {
+    "file": "desktop/js/scenario.js",
+    "ruleId": "no-redeclare",
+    "message": "'scenario' is already defined."
+  },
+  {
+    "file": "desktop/js/scenario.js",
+    "ruleId": "no-redeclare",
+    "message": "'scenario' is already defined."
+  },
+  {
+    "file": "desktop/js/scenario.js",
+    "ruleId": "no-redeclare",
+    "message": "'scenario' is already defined."
+  },
+  {
+    "file": "desktop/js/system.js",
+    "ruleId": "no-redeclare",
+    "message": "'command' is already defined."
+  },
+  {
+    "file": "desktop/js/timeline.js",
+    "ruleId": "no-redeclare",
+    "message": "'content' is already defined."
+  },
+  {
+    "file": "desktop/js/timeline.js",
+    "ruleId": "no-redeclare",
+    "message": "'isFirstOfDay' is already defined."
+  },
+  {
+    "file": "desktop/js/timeline.js",
+    "ruleId": "no-redeclare",
+    "message": "'isLastOfDay' is already defined."
+  },
+  {
+    "file": "desktop/js/timeline.js",
+    "ruleId": "no-redeclare",
+    "message": "'prevDate' is already defined."
+  },
+  {
+    "file": "desktop/js/timeline.js",
+    "ruleId": "no-redeclare",
+    "message": "'prevDateTs' is already defined."
+  },
+  {
+    "file": "desktop/js/types.js",
+    "ruleId": "no-redeclare",
+    "message": "'_cmd' is already defined."
+  },
+  {
+    "file": "desktop/js/types.js",
+    "ruleId": "no-redeclare",
+    "message": "'_id' is already defined."
+  },
+  {
+    "file": "desktop/js/types.js",
+    "ruleId": "no-redeclare",
+    "message": "'_id' is already defined."
+  },
+  {
+    "file": "desktop/js/types.js",
+    "ruleId": "no-redeclare",
+    "message": "'idx' is already defined."
+  },
+  {
+    "file": "desktop/js/types.js",
+    "ruleId": "no-redeclare",
+    "message": "'thisCmd' is already defined."
+  },
+  {
+    "file": "desktop/js/update.js",
+    "ruleId": "no-redeclare",
+    "message": "'i' is already defined."
+  },
+  {
+    "file": "desktop/js/update.js",
+    "ruleId": "no-redeclare",
+    "message": "'id' is already defined."
+  },
+  {
+    "file": "desktop/js/update.js",
+    "ruleId": "no-redeclare",
+    "message": "'id' is already defined."
+  },
+  {
+    "file": "desktop/js/update.js",
+    "ruleId": "no-redeclare",
+    "message": "'logicalId' is already defined."
+  },
+  {
+    "file": "desktop/js/update.js",
+    "ruleId": "no-redeclare",
+    "message": "'offset' is already defined."
+  },
+  {
+    "file": "desktop/js/update.js",
+    "ruleId": "no-redeclare",
+    "message": "'updClass' is already defined."
+  },
+  {
+    "file": "desktop/js/user.js",
+    "ruleId": "no-redeclare",
+    "message": "'user' is already defined."
+  },
+  {
+    "file": "desktop/js/user.js",
+    "ruleId": "no-redeclare",
+    "message": "'user' is already defined."
+  },
+  {
+    "file": "desktop/js/view_edit.js",
+    "ruleId": "no-redeclare",
+    "message": "'i' is already defined."
+  },
+  {
+    "file": "desktop/js/widgets.js",
+    "ruleId": "no-redeclare",
+    "message": "'i' is already defined."
+  },
+  {
+    "file": "desktop/js/widgets.js",
+    "ruleId": "no-redeclare",
+    "message": "'params' is already defined."
+  },
+  {
+    "file": "desktop/js/widgets.js",
+    "ruleId": "no-unreachable",
+    "message": "Unreachable code."
+  }
+]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1240 @@
+{
+  "name": "jeedom-core-eslint",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "jeedom-core-eslint",
+      "devDependencies": {
+        "eslint": "^8.57.1"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+      "deprecated": "Use @eslint/config-array instead",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^2.0.3",
+        "debug": "^4.3.1",
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+      "deprecated": "Use @eslint/object-schema instead",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.1",
+        "@humanwhocodes/config-array": "^0.13.0",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esquery": "^1.4.2",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.3",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "jeedom-core-eslint",
+  "private": true,
+  "description": "ESLint configuration for Jeedom core JS files (CI only).",
+  "scripts": {
+    "lint": "eslint core/js desktop/js",
+    "lint:check": "node .github/scripts/eslint-baseline-check.js",
+    "lint:baseline": "node .github/scripts/eslint-baseline-check.js --update"
+  },
+  "devDependencies": {
+    "eslint": "^8.57.1"
+  }
+}


### PR DESCRIPTION
## Summary

Adds a CI ESLint check for `core/js/` and `desktop/js/` with a baseline mechanism that mirrors the existing PHPStan workflow (per @kwizer15's suggestion in #3297). Catches actual bugs (`no-const-assign`, `no-redeclare`, `no-unreachable`, etc.) without enforcing style rules like `no-var` or `prefer-const` yet.

## What's added

| File | Role |
|---|---|
| `.eslintrc.json` | Bug-only ESLint rules (no-const-assign, no-redeclare, no-dupe-keys, no-unreachable, etc.) |
| `eslint-baseline.json` | Snapshot of the 175 currently-failing `{file, ruleId, message}` tuples — line numbers excluded so the baseline survives cosmetic line shifts |
| `.github/scripts/eslint-baseline-check.js` | Runs ESLint, diffs against baseline, fails only on NEW tuples |
| `.github/workflows/eslint.yml` | Runs the check on PRs and on push to `develop`. Includes an auto-update job that regenerates the baseline and opens a PR when fixes are merged (same pattern as `update-phpstan-baseline`) |
| `package.json` + `package-lock.json` | ESLint dependency only — no runtime impact |

## Why baseline-based

Upstream `core/js/` + `desktop/js/` currently emit ~175 ESLint errors (mostly `no-redeclare` from `var X` re-declarations across nested blocks, plus a few `no-unreachable`). A non-baseline approach would either:
- fail CI permanently until everything is fixed (blocks all PRs), or
- weaken rules so much that real bugs slip through.

The baseline tolerates existing issues, prevents new ones, and welcomes fixes (when a violation disappears, the auto-update job removes it from the baseline on merge).

## Suggested changelog entry
> Add ESLint CI workflow with baseline for `core/js/` and `desktop/js/` — catches new JS errors (no-const-assign, no-redeclare, no-unreachable) without blocking on existing legacy violations.

## Style rules deferred

`no-var` and `prefer-const` are intentionally **not** enabled in this PR — they would dominate the noise. They can be re-enabled in a follow-up once the migration from `var` to `const`/`let` (PRs #3300–#3303) lands.

## Known risks / side effects
- Does not touch any existing JS files — CI/config only.
- `package.json` adds ESLint as a dev dependency; no runtime impact.
- Baseline is file-stable (no line numbers), so cosmetic changes don't break it.

## Local usage

```bash
npm install
npm run lint           # raw ESLint output
npm run lint:check     # baseline-aware check (same as CI)
npm run lint:baseline  # regenerate baseline after fixes
```

## Types of changes
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Developer tooling / CI improvement

## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the contribution guidelines.
- [x] I grant the project the right to include and distribute the code under the GNU.
- [x] I have verified that the code complies with the projects coding standards.
- [x] New tool documented (local usage above).

## Test plan
- [ ] CI runs `eslint` job on this PR — expect green (current violations = baseline)
- [ ] Verify that introducing a new violation in any JS file fails CI locally with `npm run lint:check`
- [ ] After merge, verify the `update-baseline` job triggers on push to `develop`

Part of the split following #3297 discussion. Standalone — does not touch any existing JS files.