### PR TITLE
Refactor var to const/let in core JS utilities (1/4)

### DIFF
--- a/core/js/cache.class.js
+++ b/core/js/cache.class.js
@@ -17,16 +17,16 @@
 jeedom.cache = function() { }
 
 jeedom.cache.set = function(_params) {
-  var paramsRequired = ['key', 'value']
-  var paramsSpecifics = {}
+  const paramsRequired = ['key', 'value']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/cache.ajax.php'
   paramsAJAX.data = {
     action: 'set',
@@ -39,16 +39,16 @@ jeedom.cache.set = function(_params) {
 }
 
 jeedom.cache.byKey = function(_params) {
-  var paramsRequired = ['key']
-  var paramsSpecifics = {}
+  const paramsRequired = ['key']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/cache.ajax.php'
   paramsAJAX.data = {
     action: 'byKey',
@@ -58,16 +58,16 @@ jeedom.cache.byKey = function(_params) {
 }
 
 jeedom.cache.remove = function(_params) {
-  var paramsRequired = ['key']
-  var paramsSpecifics = {}
+  const paramsRequired = ['key']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/cache.ajax.php'
   paramsAJAX.data = {
     action: 'remove',
@@ -77,16 +77,16 @@ jeedom.cache.remove = function(_params) {
 }
 
 jeedom.cache.clean = function(_params) {
-  var paramsRequired = []
-  var paramsSpecifics = {}
+  const paramsRequired = []
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/cache.ajax.php'
   paramsAJAX.data = {
     action: 'clean'
@@ -95,16 +95,16 @@ jeedom.cache.clean = function(_params) {
 }
 
 jeedom.cache.flush = function(_params) {
-  var paramsRequired = []
-  var paramsSpecifics = {}
+  const paramsRequired = []
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/cache.ajax.php'
   paramsAJAX.data = {
     action: 'flush'

--- a/core/js/core.js
+++ b/core/js/core.js
@@ -15,12 +15,13 @@
  */
 
 function getTemplate(_folder, _version, _filename, _replace) {
+  let path;
   if (_folder == 'core') {
-    var path = _folder + '/template/' + _version + '/' + _filename;
+    path = _folder + '/template/' + _version + '/' + _filename;
   } else {
-    var path = 'plugins/' + _folder + '/desktop/template/' + _version + '/' + _filename;
+    path = 'plugins/' + _folder + '/desktop/template/' + _version + '/' + _filename;
   }
-  var template = '';
+  let template = '';
   domUtils.ajax({
     type: "POST",
     url: path,
@@ -30,8 +31,8 @@ function getTemplate(_folder, _version, _filename, _replace) {
     },
     success: function(data) {
       if (isset(_replace) && _replace != null) {
-        var reg = null;
-        for (i in _replace) {
+        let reg = null;
+        for (const i in _replace) {
           reg = new RegExp(i, "g");
           data = data.replace(reg, _replace[i]);
         }
@@ -74,13 +75,15 @@ function init(_value, _default) {
 }
 
 function getUrlVars(_key,_url) {
-  var vars = [], hash, nbVars = 0;
+  const vars = [];
+  let hash, nbVars = 0;
+  let hashes;
   if(_url){
-    var hashes = _url.split('?')[1].split('&');
+    hashes = _url.split('?')[1].split('&');
   }else{
-    var hashes = window.location.search.replace('?', '').split('&');
+    hashes = window.location.search.replace('?', '').split('&');
   }
-  for (var i = 0; i < hashes.length; i++) {
+  for (let i = 0; i < hashes.length; i++) {
     if (hashes[i] !== "" && hashes[i] !== "?") {
       hash = hashes[i].split('=');
       nbVars++;
@@ -98,17 +101,17 @@ function getUrlVars(_key,_url) {
 }
 
 function setCookie(cname, cvalue, exdays) {
-  var d = new Date();
+  const d = new Date();
   if (!isset(exdays)) exdays = 1;
   d.setTime(d.getTime() + (exdays * 24 * 60 * 60 * 1000));
-  var expires = "expires=" + d.toUTCString();
+  const expires = "expires=" + d.toUTCString();
   document.cookie = cname + "=" + cvalue + ";" + expires + ";path=/;samesite=Strict";
 }
 
 function getCookie(name) {
-  var cookies = document.cookie.split(';');
-  var csplit = null;
-  for (var i in cookies) {
+  const cookies = document.cookie.split(';');
+  let csplit = null;
+  for (const i in cookies) {
     csplit = cookies[i].split('=');
     if (name.trim() == csplit[0].trim()) {
       return csplit[1];
@@ -118,8 +121,8 @@ function getCookie(name) {
 }
 
 function getDeviceType() {
-  var ua = navigator.userAgent
-  var result = {}
+  const ua = navigator.userAgent
+  const result = {}
   result.width = window.innerWidth
   result.type = 'desktop'
   result.subType = ''
@@ -147,8 +150,8 @@ function getDeviceType() {
   }
 
   if (result.type == 'phone') {
-    var margin = (result.subType == 'ios' ? 6 : 7)
-    var ori = window.orientation
+    const margin = (result.subType == 'ios' ? 6 : 7)
+    const ori = window.orientation
     if (ori == 90 || ori == -90) { //landscape
       result.bSize = (result.width / 4) - margin
     } else { //portrait

--- a/core/js/dataStore.class.js
+++ b/core/js/dataStore.class.js
@@ -17,16 +17,16 @@
 jeedom.dataStore = function() {};
 
 jeedom.dataStore.save = function(_params) {
-    var paramsRequired = ['id', 'value', 'type', 'key', 'link_id'];
-    var paramsSpecifics = {};
+    const paramsRequired = ['id', 'value', 'type', 'key', 'link_id'];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.async = _params.async || true;
 
     paramsAJAX.url = 'core/ajax/dataStore.ajax.php';
@@ -42,16 +42,16 @@ jeedom.dataStore.save = function(_params) {
 }
 
 jeedom.dataStore.byTypeLinkIdKey = function(_params) {
-    var paramsRequired = ['type', 'linkId', 'key', 'usedBy'];
-    var paramsSpecifics = {};
+    const paramsRequired = ['type', 'linkId', 'key', 'usedBy'];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/dataStore.ajax.php';
     paramsAJAX.data = {
         action: 'byTypeLinkIdKey',
@@ -64,16 +64,16 @@ jeedom.dataStore.byTypeLinkIdKey = function(_params) {
 }
 
 jeedom.dataStore.all = function(_params) {
-    var paramsRequired = ['type', 'usedBy'];
-    var paramsSpecifics = {};
+    const paramsRequired = ['type', 'usedBy'];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/dataStore.ajax.php';
     paramsAJAX.data = {
         action: 'all',
@@ -103,7 +103,7 @@ jeedom.dataStore.getSelectModal = function(_options, callback) {
             className: 'success',
             callback: {
               click: function(event) {
-                var args = {}
+                const args = {}
                 args.human = mod_insertDataStore.getValue()
                 args.id = mod_insertDataStore.getId()
                 if (args.human.trim() != '') {
@@ -127,16 +127,16 @@ jeedom.dataStore.getSelectModal = function(_options, callback) {
 }
 
 jeedom.dataStore.remove = function(_params) {
-    var paramsRequired = ['id'];
-    var paramsSpecifics = {};
+    const paramsRequired = ['id'];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/dataStore.ajax.php';
     paramsAJAX.data = {
         action: 'remove',

--- a/core/js/jeedom.class.js
+++ b/core/js/jeedom.class.js
@@ -55,8 +55,8 @@ if (!isset(jeedom.cache.getConfiguration)) {
 }
 
 jeedom.changes = function() {
-  const paramsRequired =[]
-  const paramsSpecifics ={
+  const paramsRequired = []
+  const paramsSpecifics = {
     global: false,
     noDisplayError: true,
     success: function(data) {
@@ -377,8 +377,8 @@ jeedom.notify = function(_title, _text, _class_name) {
 }
 
 jeedom.getStringUsedBy = function(_params) {
-  const paramsRequired =['search']
-  const paramsSpecifics ={}
+  const paramsRequired = ['search']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
@@ -396,8 +396,8 @@ jeedom.getStringUsedBy = function(_params) {
 }
 
 jeedom.getIdUsedBy = function(_params) {
-  const paramsRequired =['search']
-  const paramsSpecifics ={}
+  const paramsRequired = ['search']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
@@ -415,8 +415,8 @@ jeedom.getIdUsedBy = function(_params) {
 }
 
 jeedom.getConfiguration = function(_params) {
-  const paramsRequired =['key']
-  const paramsSpecifics ={
+  const paramsRequired = ['key']
+  const paramsSpecifics = {
     pre_success: function(data) {
       jeedom.cache.getConfiguration = data.result
       const keys = _params.key.split(':')
@@ -457,8 +457,8 @@ jeedom.getConfiguration = function(_params) {
 }
 
 jeedom.getInfoApplication = function(_params) {
-  const paramsRequired =[]
-  const paramsSpecifics ={}
+  const paramsRequired = []
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
@@ -475,8 +475,8 @@ jeedom.getInfoApplication = function(_params) {
 }
 
 jeedom.haltSystem = function(_params) {
-  const paramsRequired =[]
-  const paramsSpecifics ={}
+  const paramsRequired = []
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
@@ -499,8 +499,8 @@ jeedom.ssh = function(_params) {
     command = _params
     _params = {}
   }
-  const paramsRequired =[]
-  const paramsSpecifics ={}
+  const paramsRequired = []
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
@@ -525,8 +525,8 @@ jeedom.db = function(_params) {
     command = _params
     _params = {}
   }
-  const paramsRequired =[]
-  const paramsSpecifics ={}
+  const paramsRequired = []
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
@@ -545,8 +545,8 @@ jeedom.db = function(_params) {
 }
 
 jeedom.dbcorrectTable = function(_params) {
-  const paramsRequired =['table']
-  const paramsSpecifics ={}
+  const paramsRequired = ['table']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
@@ -564,8 +564,8 @@ jeedom.dbcorrectTable = function(_params) {
 }
 
 jeedom.rebootSystem = function(_params) {
-  const paramsRequired =[]
-  const paramsSpecifics ={}
+  const paramsRequired = []
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
@@ -582,8 +582,8 @@ jeedom.rebootSystem = function(_params) {
 }
 
 jeedom.systemCorrectPackage = function(_params) {
-  const paramsRequired =['package']
-  const paramsSpecifics ={}
+  const paramsRequired = ['package']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
@@ -601,8 +601,8 @@ jeedom.systemCorrectPackage = function(_params) {
 }
 
 jeedom.health = function(_params) {
-  const paramsRequired =[]
-  const paramsSpecifics ={}
+  const paramsRequired = []
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
@@ -619,8 +619,8 @@ jeedom.health = function(_params) {
 }
 
 jeedom.forceSyncHour = function(_params) {
-  const paramsRequired =[]
-  const paramsSpecifics ={}
+  const paramsRequired = []
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
@@ -719,8 +719,8 @@ jeedom.getSelectActionModal = function(_options, _callback) {
 }
 
 jeedom.getGraphData = function(_params) {
-  const paramsRequired =[]
-  const paramsSpecifics ={}
+  const paramsRequired = []
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
@@ -739,8 +739,8 @@ jeedom.getGraphData = function(_params) {
 }
 
 jeedom.getDocumentationUrl = function(_params) {
-  const paramsRequired =[]
-  const paramsSpecifics ={}
+  const paramsRequired = []
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
@@ -760,8 +760,8 @@ jeedom.getDocumentationUrl = function(_params) {
 }
 
 jeedom.addWarnme = function(_params) {
-  const paramsRequired =[]
-  const paramsSpecifics ={}
+  const paramsRequired = []
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
@@ -780,8 +780,8 @@ jeedom.addWarnme = function(_params) {
 }
 
 jeedom.getFileFolder = function(_params) {
-  const paramsRequired =['type', 'path']
-  const paramsSpecifics ={}
+  const paramsRequired = ['type', 'path']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
@@ -800,8 +800,8 @@ jeedom.getFileFolder = function(_params) {
 }
 
 jeedom.getFileContent = function(_params) {
-  const paramsRequired =['path']
-  const paramsSpecifics ={}
+  const paramsRequired = ['path']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
@@ -819,8 +819,8 @@ jeedom.getFileContent = function(_params) {
 }
 
 jeedom.setFileContent = function(_params) {
-  const paramsRequired =['path', 'content']
-  const paramsSpecifics ={}
+  const paramsRequired = ['path', 'content']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
@@ -839,8 +839,8 @@ jeedom.setFileContent = function(_params) {
 }
 
 jeedom.deleteFile = function(_params) {
-  const paramsRequired =['path']
-  const paramsSpecifics ={}
+  const paramsRequired = ['path']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
@@ -858,8 +858,8 @@ jeedom.deleteFile = function(_params) {
 }
 
 jeedom.createFolder = function(_params) {
-  const paramsRequired =['path', 'name']
-  const paramsSpecifics ={}
+  const paramsRequired = ['path', 'name']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
@@ -878,8 +878,8 @@ jeedom.createFolder = function(_params) {
 }
 
 jeedom.renameFolder = function(_params) {
-  const paramsRequired =['src', 'dst']
-  const paramsSpecifics ={}
+  const paramsRequired = ['src', 'dst']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
@@ -898,8 +898,8 @@ jeedom.renameFolder = function(_params) {
 }
 
 jeedom.deleteFolder = function(_params) {
-  const paramsRequired =['path']
-  const paramsSpecifics ={}
+  const paramsRequired = ['path']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
@@ -917,8 +917,8 @@ jeedom.deleteFolder = function(_params) {
 }
 
 jeedom.createFile = function(_params) {
-  const paramsRequired =['path', 'name']
-  const paramsSpecifics ={}
+  const paramsRequired = ['path', 'name']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
@@ -937,8 +937,8 @@ jeedom.createFile = function(_params) {
 }
 
 jeedom.emptyRemoveHistory = function(_params) {
-  const paramsRequired =[]
-  const paramsSpecifics ={}
+  const paramsRequired = []
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
@@ -955,8 +955,8 @@ jeedom.emptyRemoveHistory = function(_params) {
 }
 
 jeedom.version = function(_params) {
-  const paramsRequired =[]
-  const paramsSpecifics ={}
+  const paramsRequired = []
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
@@ -973,8 +973,8 @@ jeedom.version = function(_params) {
 }
 
 jeedom.removeImageIcon = function(_params) {
-  const paramsRequired =['filepath']
-  const paramsSpecifics ={}
+  const paramsRequired = ['filepath']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
@@ -992,8 +992,8 @@ jeedom.removeImageIcon = function(_params) {
 }
 
 jeedom.cleanFileSystemRight = function(_params) {
-  const paramsRequired =[]
-  const paramsSpecifics ={}
+  const paramsRequired = []
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
@@ -1010,8 +1010,8 @@ jeedom.cleanFileSystemRight = function(_params) {
 }
 
 jeedom.consistency = function(_params) {
-  const paramsRequired =[]
-  const paramsSpecifics ={}
+  const paramsRequired = []
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
@@ -1028,8 +1028,8 @@ jeedom.consistency = function(_params) {
 }
 
 jeedom.cleanDatabase = function(_params) {
-  const paramsRequired =[]
-  const paramsSpecifics ={}
+  const paramsRequired = []
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
@@ -1046,8 +1046,8 @@ jeedom.cleanDatabase = function(_params) {
 }
 
 jeedom.massEditSave = function(_params) {
-  const paramsRequired =['type', 'objects']
-  const paramsSpecifics ={}
+  const paramsRequired = ['type', 'objects']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
@@ -1066,8 +1066,8 @@ jeedom.massEditSave = function(_params) {
 }
 
 jeedom.massReplace = function(_params) {
-  const paramsRequired =['options', 'eqlogics', 'cmds']
-  const paramsSpecifics ={}
+  const paramsRequired = ['options', 'eqlogics', 'cmds']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
@@ -1087,8 +1087,8 @@ jeedom.massReplace = function(_params) {
 }
 
 jeedom.systemGetUpgradablePackage = function(_params) {
-  const paramsRequired =['type']
-  const paramsSpecifics ={}
+  const paramsRequired = ['type']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
@@ -1107,8 +1107,8 @@ jeedom.systemGetUpgradablePackage = function(_params) {
 }
 
 jeedom.systemUpgradablePackage = function(_params) {
-  const paramsRequired =['type']
-  const paramsSpecifics ={}
+  const paramsRequired = ['type']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {

--- a/core/js/jeedom.class.js
+++ b/core/js/jeedom.class.js
@@ -49,15 +49,14 @@ sendVarToJS([
 */
 jeephp2js = {}
 
-var Highcharts
 
 if (!isset(jeedom.cache.getConfiguration)) {
   jeedom.cache.getConfiguration = null
 }
 
 jeedom.changes = function() {
-  var paramsRequired = []
-  var paramsSpecifics = {
+  const paramsRequired =[]
+  const paramsSpecifics ={
     global: false,
     noDisplayError: true,
     success: function(data) {
@@ -65,10 +64,10 @@ jeedom.changes = function() {
         jeedom.connect = 0
       }
       jeedom.datetime = data.datetime
-      var cmd_update = []
-      var eqLogic_update = []
-      var object_summary_update = []
-      for (var i in data.result) {
+      const cmd_update = []
+      const eqLogic_update = []
+      const object_summary_update = []
+      for (const i in data.result) {
         if (data.result[i].name == 'cmd::update') {
           cmd_update.push(data.result[i].option)
           continue
@@ -122,8 +121,8 @@ jeedom.changes = function() {
     (paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics)
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics)
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/event.ajax.php'
   paramsAJAX.data = {
     action: 'changes',
@@ -136,7 +135,7 @@ jeedom.init = function() {
   jeedom.datetime = jeeFrontEnd.serverDatetime
   jeedom.display.version = document.body.dataset.uimode
 
-  var cssComputedStyle = getComputedStyle(document.documentElement)
+  const cssComputedStyle = getComputedStyle(document.documentElement)
   Highcharts.setOptions({
     accessibility: {
       enabled: false
@@ -229,7 +228,7 @@ jeedom.init = function() {
       }
     } else {
       if (isset(_event.detail.page) && _event.detail.page != '') {
-        let options = {
+        const options = {
           message: _event.detail.message,
           level: _event.detail.level
         }
@@ -291,7 +290,7 @@ jeedom.init = function() {
 jeedom.getPageType = function(_modal) {
   if (isset(_modal) && _modal == true) {
     let modalType = undefined
-    let modals = Array.prototype.slice.call(document.querySelectorAll('.jeeDialogMain')).filter(item => item.isVisible())
+    const modals = Array.prototype.slice.call(document.querySelectorAll('.jeeDialogMain')).filter(item => item.isVisible())
     if (modals.length == 1) {
       modalType = modals[0].querySelector('div[data-modalType]')?.getAttribute('data-modalType')
     } else if (modals.length > 1) {
@@ -355,7 +354,7 @@ jeedom.notify = function(_title, _text, _class_name) {
     return true
   }
   if (typeof jeeDialog !== 'undefined' && typeof jeeDialog.toast !== 'undefined') {
-    let options = {
+    const options = {
       title: _title,
       message: _text,
       onclick: function() {
@@ -378,16 +377,16 @@ jeedom.notify = function(_title, _text, _class_name) {
 }
 
 jeedom.getStringUsedBy = function(_params) {
-  var paramsRequired = ['search']
-  var paramsSpecifics = {}
+  const paramsRequired =['search']
+  const paramsSpecifics ={}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/jeedom.ajax.php'
   paramsAJAX.data = {
     action: 'getStringUsedBy',
@@ -397,16 +396,16 @@ jeedom.getStringUsedBy = function(_params) {
 }
 
 jeedom.getIdUsedBy = function(_params) {
-  var paramsRequired = ['search']
-  var paramsSpecifics = {}
+  const paramsRequired =['search']
+  const paramsSpecifics ={}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/jeedom.ajax.php'
   paramsAJAX.data = {
     action: 'getIdUsedBy',
@@ -416,13 +415,13 @@ jeedom.getIdUsedBy = function(_params) {
 }
 
 jeedom.getConfiguration = function(_params) {
-  var paramsRequired = ['key']
-  var paramsSpecifics = {
+  const paramsRequired =['key']
+  const paramsSpecifics ={
     pre_success: function(data) {
       jeedom.cache.getConfiguration = data.result
-      var keys = _params.key.split(':')
+      const keys = _params.key.split(':')
       data.result = jeedom.cache.getConfiguration
-      for (var i in keys) {
+      for (const i in keys) {
         if (data.result[keys[i]]) {
           data.result = data.result[keys[i]]
         }
@@ -436,11 +435,11 @@ jeedom.getConfiguration = function(_params) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
   if (jeedom.cache.getConfiguration != null) {
-    var keys = _params.key.split(':')
-    var result = jeedom.cache.getConfiguration
-    for (var i in keys) {
+    const keys = _params.key.split(':')
+    let result = jeedom.cache.getConfiguration
+    for (const i in keys) {
       if (result[keys[i]]) {
         result = result[keys[i]]
       }
@@ -448,7 +447,7 @@ jeedom.getConfiguration = function(_params) {
     _params.success(result)
     return
   }
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/jeedom.ajax.php'
   paramsAJAX.data = {
     action: 'getConfiguration',
@@ -458,16 +457,16 @@ jeedom.getConfiguration = function(_params) {
 }
 
 jeedom.getInfoApplication = function(_params) {
-  var paramsRequired = []
-  var paramsSpecifics = {}
+  const paramsRequired =[]
+  const paramsSpecifics ={}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/jeedom.ajax.php'
   paramsAJAX.data = {
     action: 'getInfoApplication',
@@ -476,16 +475,16 @@ jeedom.getInfoApplication = function(_params) {
 }
 
 jeedom.haltSystem = function(_params) {
-  var paramsRequired = []
-  var paramsSpecifics = {}
+  const paramsRequired =[]
+  const paramsSpecifics ={}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/jeedom.ajax.php'
   paramsAJAX.data = {
     action: 'haltSystem',
@@ -500,16 +499,16 @@ jeedom.ssh = function(_params) {
     command = _params
     _params = {}
   }
-  var paramsRequired = []
-  var paramsSpecifics = {}
+  const paramsRequired =[]
+  const paramsSpecifics ={}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/jeedom.ajax.php'
   paramsAJAX.data = {
     action: 'ssh',
@@ -526,16 +525,16 @@ jeedom.db = function(_params) {
     command = _params
     _params = {}
   }
-  var paramsRequired = []
-  var paramsSpecifics = {}
+  const paramsRequired =[]
+  const paramsSpecifics ={}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/jeedom.ajax.php'
   paramsAJAX.data = {
     action: 'db',
@@ -546,16 +545,16 @@ jeedom.db = function(_params) {
 }
 
 jeedom.dbcorrectTable = function(_params) {
-  var paramsRequired = ['table']
-  var paramsSpecifics = {}
+  const paramsRequired =['table']
+  const paramsSpecifics ={}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/jeedom.ajax.php'
   paramsAJAX.data = {
     action: 'dbcorrectTable',
@@ -565,16 +564,16 @@ jeedom.dbcorrectTable = function(_params) {
 }
 
 jeedom.rebootSystem = function(_params) {
-  var paramsRequired = []
-  var paramsSpecifics = {}
+  const paramsRequired =[]
+  const paramsSpecifics ={}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/jeedom.ajax.php'
   paramsAJAX.data = {
     action: 'rebootSystem',
@@ -583,16 +582,16 @@ jeedom.rebootSystem = function(_params) {
 }
 
 jeedom.systemCorrectPackage = function(_params) {
-  var paramsRequired = ['package']
-  var paramsSpecifics = {}
+  const paramsRequired =['package']
+  const paramsSpecifics ={}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/jeedom.ajax.php'
   paramsAJAX.data = {
     action: 'systemCorrectPackage',
@@ -602,16 +601,16 @@ jeedom.systemCorrectPackage = function(_params) {
 }
 
 jeedom.health = function(_params) {
-  var paramsRequired = []
-  var paramsSpecifics = {}
+  const paramsRequired =[]
+  const paramsSpecifics ={}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/jeedom.ajax.php'
   paramsAJAX.data = {
     action: 'health',
@@ -620,16 +619,16 @@ jeedom.health = function(_params) {
 }
 
 jeedom.forceSyncHour = function(_params) {
-  var paramsRequired = []
-  var paramsSpecifics = {}
+  const paramsRequired =[]
+  const paramsSpecifics ={}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/jeedom.ajax.php'
   paramsAJAX.data = {
     action: 'forceSyncHour',
@@ -653,7 +652,7 @@ jeedom.getCronSelectModal = function(_options, _callback) {
         className: 'success',
         callback: {
           click: function(event) {
-            var args = {}
+            const args = {}
             args.cron = {}
             args.value = mod_insertCron.getValue()
             if (args.value != undefined && args.value.trim() != '' && 'function' === typeof (_callback)) {
@@ -697,7 +696,7 @@ jeedom.getSelectActionModal = function(_options, _callback) {
         className: 'success',
         callback: {
           click: function(event) {
-            var args = {}
+            const args = {}
             args.human = mod_insertAction.getValue()
             if (args.human.trim() != '' && 'function' === typeof (_callback)) {
               _callback(args)
@@ -720,16 +719,16 @@ jeedom.getSelectActionModal = function(_options, _callback) {
 }
 
 jeedom.getGraphData = function(_params) {
-  var paramsRequired = []
-  var paramsSpecifics = {}
+  const paramsRequired =[]
+  const paramsSpecifics ={}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/jeedom.ajax.php'
   paramsAJAX.data = {
     action: 'getGraphData',
@@ -740,16 +739,16 @@ jeedom.getGraphData = function(_params) {
 }
 
 jeedom.getDocumentationUrl = function(_params) {
-  var paramsRequired = []
-  var paramsSpecifics = {}
+  const paramsRequired =[]
+  const paramsSpecifics ={}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/jeedom.ajax.php'
   paramsAJAX.data = {
     action: 'getDocumentationUrl',
@@ -761,16 +760,16 @@ jeedom.getDocumentationUrl = function(_params) {
 }
 
 jeedom.addWarnme = function(_params) {
-  var paramsRequired = []
-  var paramsSpecifics = {}
+  const paramsRequired =[]
+  const paramsSpecifics ={}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/jeedom.ajax.php'
   paramsAJAX.data = {
     action: 'addWarnme',
@@ -781,16 +780,16 @@ jeedom.addWarnme = function(_params) {
 }
 
 jeedom.getFileFolder = function(_params) {
-  var paramsRequired = ['type', 'path']
-  var paramsSpecifics = {}
+  const paramsRequired =['type', 'path']
+  const paramsSpecifics ={}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/jeedom.ajax.php'
   paramsAJAX.data = {
     action: 'getFileFolder',
@@ -801,16 +800,16 @@ jeedom.getFileFolder = function(_params) {
 }
 
 jeedom.getFileContent = function(_params) {
-  var paramsRequired = ['path']
-  var paramsSpecifics = {}
+  const paramsRequired =['path']
+  const paramsSpecifics ={}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/jeedom.ajax.php'
   paramsAJAX.data = {
     action: 'getFileContent',
@@ -820,16 +819,16 @@ jeedom.getFileContent = function(_params) {
 }
 
 jeedom.setFileContent = function(_params) {
-  var paramsRequired = ['path', 'content']
-  var paramsSpecifics = {}
+  const paramsRequired =['path', 'content']
+  const paramsSpecifics ={}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/jeedom.ajax.php'
   paramsAJAX.data = {
     action: 'setFileContent',
@@ -840,16 +839,16 @@ jeedom.setFileContent = function(_params) {
 }
 
 jeedom.deleteFile = function(_params) {
-  var paramsRequired = ['path']
-  var paramsSpecifics = {}
+  const paramsRequired =['path']
+  const paramsSpecifics ={}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/jeedom.ajax.php'
   paramsAJAX.data = {
     action: 'deleteFile',
@@ -859,16 +858,16 @@ jeedom.deleteFile = function(_params) {
 }
 
 jeedom.createFolder = function(_params) {
-  var paramsRequired = ['path', 'name']
-  var paramsSpecifics = {}
+  const paramsRequired =['path', 'name']
+  const paramsSpecifics ={}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/jeedom.ajax.php'
   paramsAJAX.data = {
     action: 'createFolder',
@@ -879,16 +878,16 @@ jeedom.createFolder = function(_params) {
 }
 
 jeedom.renameFolder = function(_params) {
-  var paramsRequired = ['src', 'dst']
-  var paramsSpecifics = {}
+  const paramsRequired =['src', 'dst']
+  const paramsSpecifics ={}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/jeedom.ajax.php'
   paramsAJAX.data = {
     action: 'renameFolder',
@@ -899,16 +898,16 @@ jeedom.renameFolder = function(_params) {
 }
 
 jeedom.deleteFolder = function(_params) {
-  var paramsRequired = ['path']
-  var paramsSpecifics = {}
+  const paramsRequired =['path']
+  const paramsSpecifics ={}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/jeedom.ajax.php'
   paramsAJAX.data = {
     action: 'deleteFolder',
@@ -918,16 +917,16 @@ jeedom.deleteFolder = function(_params) {
 }
 
 jeedom.createFile = function(_params) {
-  var paramsRequired = ['path', 'name']
-  var paramsSpecifics = {}
+  const paramsRequired =['path', 'name']
+  const paramsSpecifics ={}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/jeedom.ajax.php'
   paramsAJAX.data = {
     action: 'createFile',
@@ -938,16 +937,16 @@ jeedom.createFile = function(_params) {
 }
 
 jeedom.emptyRemoveHistory = function(_params) {
-  var paramsRequired = []
-  var paramsSpecifics = {}
+  const paramsRequired =[]
+  const paramsSpecifics ={}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/jeedom.ajax.php'
   paramsAJAX.data = {
     action: 'emptyRemoveHistory',
@@ -956,16 +955,16 @@ jeedom.emptyRemoveHistory = function(_params) {
 }
 
 jeedom.version = function(_params) {
-  var paramsRequired = []
-  var paramsSpecifics = {}
+  const paramsRequired =[]
+  const paramsSpecifics ={}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/jeedom.ajax.php'
   paramsAJAX.data = {
     action: 'version'
@@ -974,16 +973,16 @@ jeedom.version = function(_params) {
 }
 
 jeedom.removeImageIcon = function(_params) {
-  var paramsRequired = ['filepath']
-  var paramsSpecifics = {}
+  const paramsRequired =['filepath']
+  const paramsSpecifics ={}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/jeedom.ajax.php'
   paramsAJAX.data = {
     action: 'removeImageIcon',
@@ -993,16 +992,16 @@ jeedom.removeImageIcon = function(_params) {
 }
 
 jeedom.cleanFileSystemRight = function(_params) {
-  var paramsRequired = []
-  var paramsSpecifics = {}
+  const paramsRequired =[]
+  const paramsSpecifics ={}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/jeedom.ajax.php'
   paramsAJAX.data = {
     action: 'cleanFileSystemRight'
@@ -1011,16 +1010,16 @@ jeedom.cleanFileSystemRight = function(_params) {
 }
 
 jeedom.consistency = function(_params) {
-  var paramsRequired = []
-  var paramsSpecifics = {}
+  const paramsRequired =[]
+  const paramsSpecifics ={}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/jeedom.ajax.php'
   paramsAJAX.data = {
     action: 'consistency'
@@ -1029,16 +1028,16 @@ jeedom.consistency = function(_params) {
 }
 
 jeedom.cleanDatabase = function(_params) {
-  var paramsRequired = []
-  var paramsSpecifics = {}
+  const paramsRequired =[]
+  const paramsSpecifics ={}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/jeedom.ajax.php'
   paramsAJAX.data = {
     action: 'cleanDatabase'
@@ -1047,16 +1046,16 @@ jeedom.cleanDatabase = function(_params) {
 }
 
 jeedom.massEditSave = function(_params) {
-  var paramsRequired = ['type', 'objects']
-  var paramsSpecifics = {}
+  const paramsRequired =['type', 'objects']
+  const paramsSpecifics ={}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/jeedom.ajax.php'
   paramsAJAX.data = {
     action: 'massEditSave',
@@ -1067,16 +1066,16 @@ jeedom.massEditSave = function(_params) {
 }
 
 jeedom.massReplace = function(_params) {
-  var paramsRequired = ['options', 'eqlogics', 'cmds']
-  var paramsSpecifics = {}
+  const paramsRequired =['options', 'eqlogics', 'cmds']
+  const paramsSpecifics ={}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/jeedom.ajax.php'
   paramsAJAX.data = {
     action: 'massReplace',
@@ -1088,16 +1087,16 @@ jeedom.massReplace = function(_params) {
 }
 
 jeedom.systemGetUpgradablePackage = function(_params) {
-  var paramsRequired = ['type']
-  var paramsSpecifics = {}
+  const paramsRequired =['type']
+  const paramsSpecifics ={}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/jeedom.ajax.php'
   paramsAJAX.data = {
     action: 'systemGetUpgradablePackage',
@@ -1108,16 +1107,16 @@ jeedom.systemGetUpgradablePackage = function(_params) {
 }
 
 jeedom.systemUpgradablePackage = function(_params) {
-  var paramsRequired = ['type']
-  var paramsSpecifics = {}
+  const paramsRequired =['type']
+  const paramsSpecifics ={}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/jeedom.ajax.php'
   paramsAJAX.data = {
     action: 'systemUpgradablePackage',

--- a/core/js/listener.class.js
+++ b/core/js/listener.class.js
@@ -17,16 +17,16 @@
 jeedom.listener = function() {};
 
 jeedom.listener.all = function(_params) {
-  var paramsRequired = [];
-  var paramsSpecifics = {};
+  const paramsRequired = [];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/listener.ajax.php';
   paramsAJAX.data = {
     action: 'all'
@@ -35,16 +35,16 @@ jeedom.listener.all = function(_params) {
 }
 
 jeedom.listener.save = function(_params) {
-  var paramsRequired = ['listeners'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['listeners'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/listener.ajax.php';
   paramsAJAX.data = {
     action: 'save',
@@ -54,16 +54,16 @@ jeedom.listener.save = function(_params) {
 }
 
 jeedom.listener.remove = function(_params) {
-  var paramsRequired = ['id'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['id'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/listener.ajax.php';
   paramsAJAX.data = {
     action: 'remove',

--- a/core/js/message.class.js
+++ b/core/js/message.class.js
@@ -19,16 +19,16 @@ jeedom.message = function() {};
 jeedom.message.cache = Array();
 
 jeedom.message.all = function(_params) {
-    var paramsRequired = [];
-    var paramsSpecifics = {};
+    const paramsRequired = [];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/message.ajax.php';
     paramsAJAX.data = {
         action: "all",
@@ -38,16 +38,16 @@ jeedom.message.all = function(_params) {
 }
 
 jeedom.message.remove = function(_params) {
-    var paramsRequired = ['id'];
-    var paramsSpecifics = {};
+    const paramsRequired = ['id'];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/message.ajax.php';
     paramsAJAX.data = {
         action: 'removeMessage',
@@ -57,16 +57,16 @@ jeedom.message.remove = function(_params) {
 }
 
 jeedom.message.clear = function(_params) {
-    var paramsRequired = [];
-    var paramsSpecifics = {};
+    const paramsRequired = [];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/message.ajax.php';
     paramsAJAX.data = {
         action: 'clearMessage',
@@ -76,8 +76,8 @@ jeedom.message.clear = function(_params) {
 }
 
 jeedom.message.number = function(_params) {
-    var paramsRequired = [];
-    var paramsSpecifics = {
+    const paramsRequired = [];
+    const paramsSpecifics = {
         global: false,
         noDisplayError: true,
     };
@@ -87,8 +87,8 @@ jeedom.message.number = function(_params) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/message.ajax.php';
     paramsAJAX.data = {
         action: 'nbMessage',

--- a/core/js/network.class.js
+++ b/core/js/network.class.js
@@ -17,16 +17,16 @@
 jeedom.network = function() {};
 
 jeedom.network.restartDns = function(_params) {
-    var paramsRequired = [];
-    var paramsSpecifics = {};
+    const paramsRequired = [];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/network.ajax.php';
     paramsAJAX.data = {
         action: 'restartDns',
@@ -35,16 +35,16 @@ jeedom.network.restartDns = function(_params) {
 }
 
 jeedom.network.stopDns = function(_params) {
-    var paramsRequired = [];
-    var paramsSpecifics = {};
+    const paramsRequired = [];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/network.ajax.php';
     paramsAJAX.data = {
         action: 'stopDns',
@@ -53,16 +53,16 @@ jeedom.network.stopDns = function(_params) {
 }
 
 jeedom.network.getInterfacesInfo = function(_params) {
-    var paramsRequired = [];
-    var paramsSpecifics = {};
+    const paramsRequired = [];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/network.ajax.php';
     paramsAJAX.data = {
         action: 'getInterfacesInfo'

--- a/core/js/private.class.js
+++ b/core/js/private.class.js
@@ -2,7 +2,7 @@
  * Set of configuration default, variables and functions
  * @namespace jeedom.private
  */
-var init = function(_param, _default) {
+const _init = function(_param, _default) {
   return (typeof _param == 'number') ? _param : (typeof _param != 'boolean' || _param) && (_param !== false && _param || _default || '');
 }
 
@@ -79,7 +79,7 @@ jeedom.private.handleAjaxErrorAPI = function(_request, _status, _error) {
  */
 jeedom.private.getParamsAJAX = function(_params) {
   // Special case parameter type
-  var typeInData = false;
+  let typeInData = false;
   if (!['POST', 'GET'].includes(_params.type)) {
     typeInData = true;
     _params.data = _params.data || {};
@@ -87,7 +87,7 @@ jeedom.private.getParamsAJAX = function(_params) {
     _params.type = 'POST'; //Use POST
   }
 
-  var paramsAJAX = {
+  const paramsAJAX = {
     type: _params.type,
     dataType: _params.dataType,
     async: _params.async,
@@ -106,7 +106,7 @@ jeedom.private.getParamsAJAX = function(_params) {
         });
       } else {
         //Directly send data object to caller
-        var result = init(data.result, jeedom.private.no_result);
+        let result = _init(data.result, jeedom.private.no_result);
 
         if (data.result === false) {
           result = false;
@@ -151,13 +151,13 @@ jeedom.private.checkParamValue = function(_params) {
     };
   }
 
-  var value = _params.value;
-  var regexp = _params.regexp;
-  var name = _params.name || 'One parameter';
+  let value = _params.value;
+  const regexp = _params.regexp;
+  const name = _params.name || 'One parameter';
 
   if (typeof value == 'object') {
     //Recursivity for array or object
-    for (var i in value) {
+    for (const i in value) {
       checkParamValue({
         name: name,
         value: value[i],
@@ -194,17 +194,17 @@ jeedom.private.checkParamValue = function(_params) {
  * @return {string} ret.missing.toString : return missing parameter as string (used for display)
  */
 jeedom.private.checkParamsRequired = function(_params, _paramsRequired) {
-  var missings = Array();
-  var group = Array();
-  var missingAtLeastOneParam = false;
-  var optionalGroupNumber = 0;
-  var ok = null;
-  for (var key in _paramsRequired) {
+  const missings = Array();
+  const group = Array();
+  let missingAtLeastOneParam = false;
+  let optionalGroupNumber = 0;
+  let ok = null;
+  for (const key in _paramsRequired) {
     if (typeof _paramsRequired[key] === 'object') {
       optionalGroupNumber++;
       ok = false;
       //One is enough, but need all present / missing parameters:
-      for (var key2 in _paramsRequired[key]) {
+      for (const key2 in _paramsRequired[key]) {
         if (_params.hasOwnProperty(_paramsRequired[key][key2])) {
           ok = true;
         } else {
@@ -241,14 +241,14 @@ jeedom.private.checkParamsRequired = function(_params, _paramsRequired) {
   }
 
   if (missingAtLeastOneParam) {
-    var tostring = 'Parameters missing : ';
-    var miss = null;
-    for (var i in missings) {
+    let tostring = 'Parameters missing : ';
+    let miss = null;
+    for (const i in missings) {
       miss = missings[i];
       tostring += miss.name + ' ';
 
       //If optionnal parameter, define if optionnal group is set
-      var checkedstring = miss.optional && (group[miss.group.id].checked) ? 'yes' : 'no' || '';
+      const checkedstring = miss.optional && (group[miss.group.id].checked) ? 'yes' : 'no' || '';
       tostring += (miss.optional) ? '[optional, group=' + miss.group.id + ' checked=' + checkedstring + ']' : '[needed]';
       tostring += ', ';
     }
@@ -271,15 +271,13 @@ jeedom.private.checkAndGetParams = function(_params, _paramsSpecifics, _paramsRe
   //Throw execption if error
   jeedom.private.checkParamsRequired(_params, _paramsRequired || []);
   //Merge default and function specific parameters
-  var params = domUtils.extend({}, jeedom.private.default_params, _paramsSpecifics, _params || {});
+  const params = domUtils.extend({}, jeedom.private.default_params, _paramsSpecifics, _params || {});
 
-  //Convert all objects in params to json
-  var param = null;
-  for (var attr in params) {
+  for (const attr in params) {
     params[attr] = (typeof params[attr] == 'object') ? JSON.stringify(params[attr]) : params[attr];
   }
 
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
 
   return {
     params: params,
@@ -294,7 +292,7 @@ jeedom.private.checkParamsValue = function(_params) {
   if (Object.prototype.toString.call(_params) == '[object Object]') {
     jeedom.private.checkParamValue(_params);
   } else {
-    for (var i in _params) {
+    for (const i in _params) {
       jeedom.private.checkParamValue(_params[i]);
     }
   }

--- a/core/js/queue.class.js
+++ b/core/js/queue.class.js
@@ -18,16 +18,16 @@ jeedom.queue = function() {};
 
 
 jeedom.queue.all = function(_params) {
-    var paramsRequired = [];
-    var paramsSpecifics = {};
+    const paramsRequired = [];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/queue.ajax.php';
     paramsAJAX.data = {
         action: 'all'
@@ -36,16 +36,16 @@ jeedom.queue.all = function(_params) {
 }
 
 jeedom.queue.save = function(_params) {
-    var paramsRequired = ['queues'];
-    var paramsSpecifics = {};
+    const paramsRequired = ['queues'];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/queue.ajax.php';
     paramsAJAX.data = {
         action: 'save',

--- a/core/js/repo.class.js
+++ b/core/js/repo.class.js
@@ -17,8 +17,8 @@
 jeedom.repo = function() {};
 
 jeedom.repo.install = function(_params) {
-  var paramsRequired = ['id', 'repo'];
-  var paramsSpecifics = {
+  const paramsRequired = ['id', 'repo'];
+  const paramsSpecifics = {
     global: _params.global || true,
   };
   try {
@@ -27,8 +27,8 @@ jeedom.repo.install = function(_params) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/repo.ajax.php';
   paramsAJAX.data = {
     action: 'install',
@@ -40,8 +40,8 @@ jeedom.repo.install = function(_params) {
 }
 
 jeedom.repo.remove = function(_params) {
-  var paramsRequired = ['id', 'repo'];
-  var paramsSpecifics = {
+  const paramsRequired = ['id', 'repo'];
+  const paramsSpecifics = {
     global: _params.global || true,
   };
   try {
@@ -50,8 +50,8 @@ jeedom.repo.remove = function(_params) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/repo.ajax.php';
   paramsAJAX.data = {
     action: 'remove',
@@ -62,8 +62,8 @@ jeedom.repo.remove = function(_params) {
 }
 
 jeedom.repo.test = function(_params) {
-  var paramsRequired = ['repo'];
-  var paramsSpecifics = {
+  const paramsRequired = ['repo'];
+  const paramsSpecifics = {
     global: _params.global || true,
   };
   try {
@@ -72,8 +72,8 @@ jeedom.repo.test = function(_params) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/repo.ajax.php';
   paramsAJAX.data = {
     action: 'test',
@@ -83,8 +83,8 @@ jeedom.repo.test = function(_params) {
 }
 
 jeedom.repo.backupList = function(_params) {
-  var paramsRequired = ['repo'];
-  var paramsSpecifics = {
+  const paramsRequired = ['repo'];
+  const paramsSpecifics = {
     global: _params.global || true,
   };
   try {
@@ -93,8 +93,8 @@ jeedom.repo.backupList = function(_params) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/repo.ajax.php';
   paramsAJAX.data = {
     action: 'backupList',
@@ -104,8 +104,8 @@ jeedom.repo.backupList = function(_params) {
 }
 
 jeedom.repo.pullInstall = function(_params) {
-  var paramsRequired = ['repo'];
-  var paramsSpecifics = {
+  const paramsRequired = ['repo'];
+  const paramsSpecifics = {
     global: _params.global || true,
   };
   try {
@@ -114,8 +114,8 @@ jeedom.repo.pullInstall = function(_params) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/repo.ajax.php';
   paramsAJAX.data = {
     repo: _params.repo,

--- a/core/js/security.class.js
+++ b/core/js/security.class.js
@@ -17,16 +17,16 @@
 jeedom.security = function() {};
 
 jeedom.security.remove = function(_params) {
-    var paramsRequired = ['id'];
-    var paramsSpecifics = {};
+    const paramsRequired = ['id'];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/connection.ajax.php';
     paramsAJAX.data = {
         action: 'remove',
@@ -36,16 +36,16 @@ jeedom.security.remove = function(_params) {
 }
 
 jeedom.security.ban = function(_params) {
-    var paramsRequired = ['id'];
-    var paramsSpecifics = {};
+    const paramsRequired = ['id'];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/connection.ajax.php';
     paramsAJAX.data = {
         action: 'ban',


### PR DESCRIPTION
## Summary

First of four migration PRs splitting the `var` → `const`/`let` work from #3297 by functional domain. This batch covers **11 utility/AJAX-boilerplate files**:

```
jeedom.class.js   private.class.js   core.js
cache.class.js    queue.class.js     listener.class.js
network.class.js  security.class.js  message.class.js
dataStore.class.js  repo.class.js
```

Most of these files follow the same uniform AJAX boilerplate pattern (`paramsRequired`, `paramsSpecifics`, try/catch, `domUtils.ajax(paramsAJAX)`), so the migration is largely mechanical: `var X = ...` → `const X = ...` for declarations that are never reassigned, `let` for the rest.

## Incidental fixes (caught during migration)

- **`jeedom.class.js`** — removed the top-level `var Highcharts` declaration. With `var` at top-level it became `window.Highcharts` and was overwritten by `highstock.js` loaded later. With `const`/`let` it would shadow `window.Highcharts`, leaving the local binding `undefined` and crashing `jeedom.init()` with `TypeError: Highcharts.setOptions is undefined`. Fix: rely on `window.Highcharts` directly.
- **`private.class.js`** — renamed top-level `var init` to `_init`. With `const init` it collided with the global `function init()` declared in `core.js` (`SyntaxError: redeclaration of non-configurable global property init`).
- **`private.class.js`** — `const value` → `let value` (was reassigned by `value += ''`, would have thrown `TypeError: Assignment to constant variable`).
- **`private.class.js`** — removed unused `var param = null` (dead code).

## Test plan

- [ ] Reload any Jeedom page — verify `jeedom.init()` runs without console errors
- [ ] Open a chart that uses Highcharts (history, dashboard widget) — verify it renders
- [ ] Trigger any API call going through `jeedom.private.getParamsAJAX` — verify the result handler still works
- [ ] Verify `init()` and `_init()` both work where used

Part of the split following #3297 discussion. Stacks logically with #3299 (ESLint baseline) but does not depend on it.