### PR TITLE
Refactor var to const/let in equipment and commands (2/4)

### DIFF
--- a/core/js/cmd.class.js
+++ b/core/js/cmd.class.js
@@ -62,8 +62,8 @@ jeedom.cmd.execute = function(_params) {
   if (_params.value != 'undefined' && (is_array(_params.value) || is_object(_params.value))) {
     _params.value = JSON.stringify(_params.value)
   }
-  const paramsRequired =['id']
-  const paramsSpecifics ={
+  const paramsRequired = ['id']
+  const paramsSpecifics = {
     global: false,
     pre_success: function(data) {
       if (data.state != 'ok') {
@@ -205,8 +205,8 @@ jeedom.cmd.execute = function(_params) {
 }
 
 jeedom.cmd.test = function(_params) {
-  const paramsRequired =['id']
-  const paramsSpecifics ={
+  const paramsRequired = ['id']
+  const paramsSpecifics = {
     global: false,
     success: function(result) {
       switch (result.type) {
@@ -482,8 +482,8 @@ jeedom.cmd.resetUpdateFunction = function() {
 }
 
 jeedom.cmd.getWidgetHelp = function(_params) {
-  const paramsRequired =['id', 'version']
-  const paramsSpecifics ={}
+  const paramsRequired = ['id', 'version']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
@@ -503,8 +503,8 @@ jeedom.cmd.getWidgetHelp = function(_params) {
 }
 
 jeedom.cmd.toHtml = function(_params) {
-  const paramsRequired =['id', 'version']
-  const paramsSpecifics ={}
+  const paramsRequired = ['id', 'version']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
@@ -523,8 +523,8 @@ jeedom.cmd.toHtml = function(_params) {
 }
 
 jeedom.cmd.replaceCmd = function(_params) {
-  const paramsRequired =['source_id', 'target_id']
-  const paramsSpecifics ={}
+  const paramsRequired = ['source_id', 'target_id']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
@@ -543,8 +543,8 @@ jeedom.cmd.replaceCmd = function(_params) {
 }
 
 jeedom.cmd.save = function(_params) {
-  const paramsRequired =['cmd']
-  const paramsSpecifics ={
+  const paramsRequired = ['cmd']
+  const paramsSpecifics = {
     pre_success: function(data) {
       if (isset(jeedom.cmd.cache.byId[data.result.id])) {
         delete jeedom.cmd.cache.byId[data.result.id]
@@ -572,8 +572,8 @@ jeedom.cmd.save = function(_params) {
 }
 
 jeedom.cmd.setIsVisibles = function(_params) {
-  const paramsRequired =['cmds', 'isVisible']
-  const paramsSpecifics ={}
+  const paramsRequired = ['cmds', 'isVisible']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
@@ -592,8 +592,8 @@ jeedom.cmd.setIsVisibles = function(_params) {
 }
 
 jeedom.cmd.multiSave = function(_params) {
-  const paramsRequired =['cmds']
-  const paramsSpecifics ={
+  const paramsRequired = ['cmds']
+  const paramsSpecifics = {
     pre_success: function(data) {
       jeedom.cmd.cache.byId = []
       return data
@@ -616,8 +616,8 @@ jeedom.cmd.multiSave = function(_params) {
 }
 
 jeedom.cmd.byId = function(_params) {
-  const paramsRequired =['id']
-  const paramsSpecifics ={
+  const paramsRequired = ['id']
+  const paramsSpecifics = {
     pre_success: function(data) {
       jeedom.cmd.cache.byId[data.result.id] = data.result
       return data
@@ -644,8 +644,8 @@ jeedom.cmd.byId = function(_params) {
 }
 
 jeedom.cmd.getHumanCmdName = function(_params) {
-  const paramsRequired =['id']
-  const paramsSpecifics ={
+  const paramsRequired = ['id']
+  const paramsSpecifics = {
     pre_success: function(data) {
       jeedom.cmd.cache.byId[data.result.id] = data.result
       return data
@@ -672,8 +672,8 @@ jeedom.cmd.getHumanCmdName = function(_params) {
 }
 
 jeedom.cmd.byHumanName = function(_params) {
-  const paramsRequired =['humanName']
-  const paramsSpecifics ={
+  const paramsRequired = ['humanName']
+  const paramsSpecifics = {
     pre_success: function(data) {
       jeedom.cmd.cache.byHumanName[data.result.humanName] = data.result
       return data
@@ -700,8 +700,8 @@ jeedom.cmd.byHumanName = function(_params) {
 }
 
 jeedom.cmd.usedBy = function(_params) {
-  const paramsRequired =['id']
-  const paramsSpecifics ={}
+  const paramsRequired = ['id']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
@@ -719,8 +719,8 @@ jeedom.cmd.usedBy = function(_params) {
 }
 
 jeedom.cmd.dropInflux = function(_params) {
-  const paramsRequired =['cmd_id']
-  const paramsSpecifics ={}
+  const paramsRequired = ['cmd_id']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
@@ -738,8 +738,8 @@ jeedom.cmd.dropInflux = function(_params) {
 }
 
 jeedom.cmd.historyInflux = function(_params) {
-  const paramsRequired =['cmd_id']
-  const paramsSpecifics ={}
+  const paramsRequired = ['cmd_id']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
@@ -757,8 +757,8 @@ jeedom.cmd.historyInflux = function(_params) {
 }
 
 jeedom.cmd.dropDatabaseInflux = function(_params) {
-  const paramsRequired =[]
-  const paramsSpecifics ={}
+  const paramsRequired = []
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
@@ -775,8 +775,8 @@ jeedom.cmd.dropDatabaseInflux = function(_params) {
 }
 
 jeedom.cmd.historyInfluxAll = function(_params) {
-  const paramsRequired =[]
-  const paramsSpecifics ={}
+  const paramsRequired = []
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
@@ -1080,8 +1080,8 @@ jeedom.cmd.displayActionOption = function(_expression, _options, _callback) {
 }
 
 jeedom.cmd.displayActionsOption = function(_params) {
-  const paramsRequired =['params']
-  const paramsSpecifics ={}
+  const paramsRequired = ['params']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
@@ -1141,8 +1141,8 @@ jeedom.cmd.normalizeName = function(_tagname) {
 }
 
 jeedom.cmd.setOrder = function(_params) {
-  const paramsRequired =['cmds']
-  const paramsSpecifics ={}
+  const paramsRequired = ['cmds']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
@@ -1160,8 +1160,8 @@ jeedom.cmd.setOrder = function(_params) {
 }
 
 jeedom.cmd.getDeadCmd = function(_params) {
-  const paramsRequired =[]
-  const paramsSpecifics ={}
+  const paramsRequired = []
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {

--- a/core/js/cmd.class.js
+++ b/core/js/cmd.class.js
@@ -32,13 +32,13 @@ jeedom.cmd.notifyEq = function(_eqlogic, _hide) {
     return
   }
   if (isElement_jQuery(_eqlogic)) _eqlogic = _eqlogic[0]
-  var refresh = _eqlogic.querySelector('.cmd.refresh')
+  let refresh = _eqlogic.querySelector('.cmd.refresh')
   if (refresh != null) {
     refresh.addClass('spinning')
   } else {
     _eqlogic.querySelector('.widget-name')?.insertAdjacentHTML('afterbegin', '<span class="cmd refresh pull-right remove"><i class="fas fa-sync"></i></span>')
   }
-  var refresh = _eqlogic.querySelector('.cmd.refresh')
+  refresh = _eqlogic.querySelector('.cmd.refresh')
   if (_hide && refresh != null) {
     setTimeout(function() {
       if (refresh.hasClass('remove')) {
@@ -54,22 +54,22 @@ jeedom.cmd.execute = function(_params) {
   if (jeedom.cmd.disableExecute) {
     return
   }
-  var notify = _params.notify ?? true
-  if (notify) {
-    var eqLogic = document.querySelector('.cmd[data-cmd_id="' + _params.id + '"]')?.closest('div.eqLogic-widget')
-    if (eqLogic) jeedom.cmd.notifyEq(eqLogic, false)
-  }
+  const notify = _params.notify ?? true
+  const eqLogic = notify
+    ? document.querySelector('.cmd[data-cmd_id="' + _params.id + '"]')?.closest('div.eqLogic-widget')
+    : null
+  if (eqLogic) jeedom.cmd.notifyEq(eqLogic, false)
   if (_params.value != 'undefined' && (is_array(_params.value) || is_object(_params.value))) {
     _params.value = JSON.stringify(_params.value)
   }
-  var paramsRequired = ['id']
-  var paramsSpecifics = {
+  const paramsRequired =['id']
+  const paramsSpecifics ={
     global: false,
     pre_success: function(data) {
       if (data.state != 'ok') {
         if (data.code == -32005) {
           if (jeedom.display.version == 'mobile') {
-            var result = prompt("{{Veuillez indiquer le code ?}}", "")
+            const result = prompt("{{Veuillez indiquer le code ?}}", "")
             if (result != null) {
               _params.codeAccess = result
               jeedom.cmd.execute(_params)
@@ -113,7 +113,7 @@ jeedom.cmd.execute = function(_params) {
           }
         } else if (data.code == -32006) {
           if (jeedom.display.version == 'mobile') {
-            var result = confirm("{{Êtes-vous sûr de vouloir faire cette action ?}}")
+            const result = confirm("{{Êtes-vous sûr de vouloir faire cette action ?}}")
             if (result) {
               _params.confirmAction = 1
               jeedom.cmd.execute(_params)
@@ -180,10 +180,10 @@ jeedom.cmd.execute = function(_params) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/cmd.ajax.php'
-  var cache = 1
+  let cache = 1
   if (_params.cache !== undefined) {
     cache = _params.cache
   }
@@ -205,8 +205,8 @@ jeedom.cmd.execute = function(_params) {
 }
 
 jeedom.cmd.test = function(_params) {
-  var paramsRequired = ['id']
-  var paramsSpecifics = {
+  const paramsRequired =['id']
+  const paramsSpecifics ={
     global: false,
     success: function(result) {
       switch (result.type) {
@@ -244,8 +244,8 @@ jeedom.cmd.test = function(_params) {
               })
               break
             case 'slider':
-              let min = result.configuration.minValue || 0
-              let max = result.configuration.maxValue || 100
+              const min = result.configuration.minValue || 0
+              const max = result.configuration.maxValue || 100
               jeeDialog.prompt({
                 title: '{{Entrer une valeur entre}}' + ' ' + min + ' ' + '{{et}}' + ' ' + max ,
                 value: parseInt(min) + (parseInt(max) / 2),
@@ -307,9 +307,9 @@ jeedom.cmd.test = function(_params) {
               })
               break
             case 'select':
-              let values = result.configuration.listValue.split(';')
-              let inputOptions = []
-              for (let i in values) {
+              const values = result.configuration.listValue.split(';')
+              const inputOptions = []
+              for (const i in values) {
                 inputOptions.push({ text: values[i].split('|')[1], value: values[i].split('|')[0] })
               }
               jeeDialog.prompt({
@@ -343,7 +343,7 @@ jeedom.cmd.test = function(_params) {
               })
               break
             case 'message':
-              let productName = JEEDOM_PRODUCT_NAME
+              const productName = JEEDOM_PRODUCT_NAME
               let content = `<input class="promptAttr" data-l1key="title" autocomplete="off" type="text" placeholder="${result.display.title_placeholder || `{{Titre pour la commande}} ${result.name}`}">`
               content += `<textarea class="promptAttr" data-l1key="message" placeholder="${result.display.message_placeholder || `{{Message pour la commande}} ${result.name}`}"></textarea>`
 
@@ -388,8 +388,8 @@ jeedom.cmd.test = function(_params) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/cmd.ajax.php'
   paramsAJAX.data = {
     action: 'getCmd',
@@ -400,7 +400,7 @@ jeedom.cmd.test = function(_params) {
 
 //deprecated
 jeedom.cmd.refreshByEqLogic = function(_params) {
-  var cmds = document.querySelectorAll('.cmd[data-eqLogic_id="' + _params.eqLogic_id + '"]')
+  const cmds = document.querySelectorAll('.cmd[data-eqLogic_id="' + _params.eqLogic_id + '"]')
   if (cmds.length == 0) {
     return
   }
@@ -414,8 +414,8 @@ jeedom.cmd.refreshByEqLogic = function(_params) {
       id: _cmd.getAttribute('data-cmd_id'),
       version: _cmd.getAttribute('data-version'),
       success: function(data) {
-        var html = domUtils.parseHTML(data.html).childNodes[0]
-        var uid = html.getAttribute('data-cmd_uid')
+        const html = domUtils.parseHTML(data.html).childNodes[0]
+        const uid = html.getAttribute('data-cmd_uid')
         if (uid != 'undefined') {
           cmd.setAttribute('data-cmd_uid', uid)
         }
@@ -427,8 +427,8 @@ jeedom.cmd.refreshByEqLogic = function(_params) {
 }
 
 jeedom.cmd.refreshValue = function(_params) {
-  var cmd = null
-  for (var i in _params) {
+  const cmd = null
+  for (const i in _params) {
     if(_params[i].cmd_id == ''){
       continue;
     }
@@ -445,7 +445,7 @@ jeedom.cmd.refreshValue = function(_params) {
     if (typeof jeedom.cmd.update[_params[i].cmd_id] == 'function') {
       jeedom.cmd.update[_params[i].cmd_id](_params[i])
     }
-    for (var j in jeedom.cmd.update[_params[i].cmd_id]) {
+    for (const j in jeedom.cmd.update[_params[i].cmd_id]) {
       jeedom.cmd.update[_params[i].cmd_id][j](_params[i])
     }
   }
@@ -463,13 +463,13 @@ jeedom.cmd.addUpdateFunction = function(_cmd_id, _function) {
     return
   }
   if (typeof jeedom.cmd.update[_cmd_id] == 'function') {
-    let prevFunction = jeedom.cmd.update[_cmd_id]
+    const prevFunction = jeedom.cmd.update[_cmd_id]
     if (prevFunction.toString() == _function.toString()) {
       return
     }
     jeedom.cmd.update[_cmd_id] = [prevFunction, _function]
   }
-  for (var i in jeedom.cmd.update[_cmd_id]) {
+  for (const i in jeedom.cmd.update[_cmd_id]) {
     if (jeedom.cmd.update[_cmd_id][i].toString() == _function.toString()) {
       return
     }
@@ -482,16 +482,16 @@ jeedom.cmd.resetUpdateFunction = function() {
 }
 
 jeedom.cmd.getWidgetHelp = function(_params) {
-  var paramsRequired = ['id', 'version']
-  var paramsSpecifics = {}
+  const paramsRequired =['id', 'version']
+  const paramsSpecifics ={}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/cmd.ajax.php'
   paramsAJAX.data = {
     action: 'getWidgetHelp',
@@ -503,16 +503,16 @@ jeedom.cmd.getWidgetHelp = function(_params) {
 }
 
 jeedom.cmd.toHtml = function(_params) {
-  var paramsRequired = ['id', 'version']
-  var paramsSpecifics = {}
+  const paramsRequired =['id', 'version']
+  const paramsSpecifics ={}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/cmd.ajax.php'
   paramsAJAX.data = {
     action: 'toHtml',
@@ -523,16 +523,16 @@ jeedom.cmd.toHtml = function(_params) {
 }
 
 jeedom.cmd.replaceCmd = function(_params) {
-  var paramsRequired = ['source_id', 'target_id']
-  var paramsSpecifics = {}
+  const paramsRequired =['source_id', 'target_id']
+  const paramsSpecifics ={}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/cmd.ajax.php'
   paramsAJAX.data = {
     action: 'replaceCmd',
@@ -543,8 +543,8 @@ jeedom.cmd.replaceCmd = function(_params) {
 }
 
 jeedom.cmd.save = function(_params) {
-  var paramsRequired = ['cmd']
-  var paramsSpecifics = {
+  const paramsRequired =['cmd']
+  const paramsSpecifics ={
     pre_success: function(data) {
       if (isset(jeedom.cmd.cache.byId[data.result.id])) {
         delete jeedom.cmd.cache.byId[data.result.id]
@@ -561,8 +561,8 @@ jeedom.cmd.save = function(_params) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/cmd.ajax.php'
   paramsAJAX.data = {
     action: 'save',
@@ -572,16 +572,16 @@ jeedom.cmd.save = function(_params) {
 }
 
 jeedom.cmd.setIsVisibles = function(_params) {
-  var paramsRequired = ['cmds', 'isVisible']
-  var paramsSpecifics = {}
+  const paramsRequired =['cmds', 'isVisible']
+  const paramsSpecifics ={}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/cmd.ajax.php'
   paramsAJAX.data = {
     action: 'setIsVisibles',
@@ -592,8 +592,8 @@ jeedom.cmd.setIsVisibles = function(_params) {
 }
 
 jeedom.cmd.multiSave = function(_params) {
-  var paramsRequired = ['cmds']
-  var paramsSpecifics = {
+  const paramsRequired =['cmds']
+  const paramsSpecifics ={
     pre_success: function(data) {
       jeedom.cmd.cache.byId = []
       return data
@@ -605,8 +605,8 @@ jeedom.cmd.multiSave = function(_params) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/cmd.ajax.php'
   paramsAJAX.data = {
     action: 'multiSave',
@@ -616,8 +616,8 @@ jeedom.cmd.multiSave = function(_params) {
 }
 
 jeedom.cmd.byId = function(_params) {
-  var paramsRequired = ['id']
-  var paramsSpecifics = {
+  const paramsRequired =['id']
+  const paramsSpecifics ={
     pre_success: function(data) {
       jeedom.cmd.cache.byId[data.result.id] = data.result
       return data
@@ -629,12 +629,12 @@ jeedom.cmd.byId = function(_params) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
   if (isset(jeedom.cmd.cache.byId[params.id]) && init(params.noCache, false) == false) {
     params.success(jeedom.cmd.cache.byId[params.id])
     return
   }
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/cmd.ajax.php'
   paramsAJAX.data = {
     action: 'byId',
@@ -644,8 +644,8 @@ jeedom.cmd.byId = function(_params) {
 }
 
 jeedom.cmd.getHumanCmdName = function(_params) {
-  var paramsRequired = ['id']
-  var paramsSpecifics = {
+  const paramsRequired =['id']
+  const paramsSpecifics ={
     pre_success: function(data) {
       jeedom.cmd.cache.byId[data.result.id] = data.result
       return data
@@ -657,12 +657,12 @@ jeedom.cmd.getHumanCmdName = function(_params) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
   if (isset(jeedom.cmd.cache.byId[params.id]) && init(params.noCache, false) == false) {
     params.success(jeedom.cmd.cache.byId[params.id])
     return
   }
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/cmd.ajax.php'
   paramsAJAX.data = {
     action: 'getHumanCmdName',
@@ -672,8 +672,8 @@ jeedom.cmd.getHumanCmdName = function(_params) {
 }
 
 jeedom.cmd.byHumanName = function(_params) {
-  var paramsRequired = ['humanName']
-  var paramsSpecifics = {
+  const paramsRequired =['humanName']
+  const paramsSpecifics ={
     pre_success: function(data) {
       jeedom.cmd.cache.byHumanName[data.result.humanName] = data.result
       return data
@@ -685,12 +685,12 @@ jeedom.cmd.byHumanName = function(_params) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
   if (isset(jeedom.cmd.cache.byHumanName[params.humanName]) && init(params.noCache, false) == false) {
     params.success(jeedom.cmd.cache.byHumanName[params.humanName])
     return
   }
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/cmd.ajax.php'
   paramsAJAX.data = {
     action: 'byHumanName',
@@ -700,16 +700,16 @@ jeedom.cmd.byHumanName = function(_params) {
 }
 
 jeedom.cmd.usedBy = function(_params) {
-  var paramsRequired = ['id']
-  var paramsSpecifics = {}
+  const paramsRequired =['id']
+  const paramsSpecifics ={}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/cmd.ajax.php'
   paramsAJAX.data = {
     action: 'usedBy',
@@ -719,16 +719,16 @@ jeedom.cmd.usedBy = function(_params) {
 }
 
 jeedom.cmd.dropInflux = function(_params) {
-  var paramsRequired = ['cmd_id']
-  var paramsSpecifics = {}
+  const paramsRequired =['cmd_id']
+  const paramsSpecifics ={}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/cmd.ajax.php'
   paramsAJAX.data = {
     action: 'dropInflux',
@@ -738,16 +738,16 @@ jeedom.cmd.dropInflux = function(_params) {
 }
 
 jeedom.cmd.historyInflux = function(_params) {
-  var paramsRequired = ['cmd_id']
-  var paramsSpecifics = {}
+  const paramsRequired =['cmd_id']
+  const paramsSpecifics ={}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/cmd.ajax.php'
   paramsAJAX.data = {
     action: 'historyInflux',
@@ -757,16 +757,16 @@ jeedom.cmd.historyInflux = function(_params) {
 }
 
 jeedom.cmd.dropDatabaseInflux = function(_params) {
-  var paramsRequired = []
-  var paramsSpecifics = {}
+  const paramsRequired =[]
+  const paramsSpecifics ={}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/cmd.ajax.php'
   paramsAJAX.data = {
     action: 'dropDatabaseInflux'
@@ -775,16 +775,16 @@ jeedom.cmd.dropDatabaseInflux = function(_params) {
 }
 
 jeedom.cmd.historyInfluxAll = function(_params) {
-  var paramsRequired = []
-  var paramsSpecifics = {}
+  const paramsRequired =[]
+  const paramsSpecifics ={}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/cmd.ajax.php'
   paramsAJAX.data = {
     action: 'historyInfluxAll'
@@ -810,7 +810,7 @@ jeedom.cmd.changeType = function(_cmd, _subType) {
     _cmd.querySelector('.cmdAttr[data-l1key="htmlstate"]')?.seen()
   }
 
-  var selSubType = document.createElement('select')
+  const selSubType = document.createElement('select')
   selSubType.style.width = '120px'
   selSubType.style.marginTop = '5px'
   selSubType.addClass('cmdAttr', 'form-control', 'input-sm')
@@ -824,7 +824,7 @@ jeedom.cmd.changeType = function(_cmd, _subType) {
       _params.error(error)
     },
     success: function(subType) {
-      for (var i in subType) {
+      for (const i in subType) {
         newOption = document.createElement('option')
         newOption.text = subType[i].name
         newOption.value = i
@@ -863,9 +863,9 @@ jeedom.cmd.changeSubType = function(_cmd) {
       _params.error(error)
     },
     success: function(subtype) {
-      for (var i in subtype) {
+      for (const i in subtype) {
         if (isset(subtype[i].visible)) {
-          var el = _cmd.querySelector('.cmdAttr[data-l1key="' + i + '"]')
+          let el = _cmd.querySelector('.cmdAttr[data-l1key="' + i + '"]')
           if (!el) continue
           if (el.getAttribute('type') == 'checkbox' && el.parentNode.tagName.toLowerCase() == 'span') {
             el = el.parentNode
@@ -903,8 +903,8 @@ jeedom.cmd.changeSubType = function(_cmd) {
             }
           }
         } else {
-          for (var j in subtype[i]) {
-            var el = _cmd.querySelector('.cmdAttr[data-l1key="' + i + '"][data-l2key="' + j + '"]')
+          for (const j in subtype[i]) {
+            let el = _cmd.querySelector('.cmdAttr[data-l1key="' + i + '"][data-l2key="' + j + '"]')
             if (!el) continue
             if (el.getAttribute('type') == 'checkbox' && el.parentNode.tagName.toLowerCase() == 'span') {
               el = el.parentNode
@@ -967,7 +967,7 @@ jeedom.cmd.changeSubType = function(_cmd) {
 }
 
 jeedom.cmd.availableType = function() {
-  var selType = '<select style="width : 120px; margin-bottom : 3px;" class="cmdAttr form-control input-sm" data-l1key="type">'
+  let selType = '<select style="width : 120px; margin-bottom : 3px;" class="cmdAttr form-control input-sm" data-l1key="type">'
   selType += '<option value="info">{{Info}}</option>'
   selType += '<option value="action">{{Action}}</option>'
   selType += '</select>'
@@ -1007,7 +1007,7 @@ jeedom.cmd.getSelectModal = function(_options, _callback) {
         className: 'success',
         callback: {
           click: function(event) {
-            var args = {}
+            const args = {}
             args.cmd = {}
             args.human = mod_insertCmd.getValue()
             args.cmd.id = mod_insertCmd.getCmdId()
@@ -1043,7 +1043,7 @@ jeedom.cmd.displayActionOption = function(_expression, _options, _callback) {
     }
   }
 
-  var html = ''
+  let html = ''
   domUtils.ajax({
     type: "POST",
     url: "core/ajax/scenario.ajax.php",
@@ -1080,16 +1080,16 @@ jeedom.cmd.displayActionOption = function(_expression, _options, _callback) {
 }
 
 jeedom.cmd.displayActionsOption = function(_params) {
-  var paramsRequired = ['params']
-  var paramsSpecifics = {}
+  const paramsRequired =['params']
+  const paramsSpecifics ={}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.async = _params.async || true
   paramsAJAX.url = 'core/ajax/scenario.ajax.php'
   paramsAJAX.data = {
@@ -1100,10 +1100,10 @@ jeedom.cmd.displayActionsOption = function(_params) {
 }
 
 jeedom.cmd.normalizeName = function(_tagname) {
-  var cmdName = _tagname.toLowerCase().trim()
-  var cmdTests = []
-  var cmdType = null
-  var cmdList = {
+  const cmdName = _tagname.toLowerCase().trim()
+  let cmdTests = []
+  const cmdType = null
+  const cmdList = {
     'on': 'on',
     'off': 'off',
     'monter': 'on',
@@ -1128,11 +1128,11 @@ jeedom.cmd.normalizeName = function(_tagname) {
     'stop': 'off',
     'go': 'on'
   }
-  var cmdTestsList = [' ', '-', '_']
-  for (var i in cmdTestsList) {
+  const cmdTestsList = [' ', '-', '_']
+  for (const i in cmdTestsList) {
     cmdTests = cmdTests.concat(cmdName.split(cmdTestsList[i]))
   }
-  for (var j in cmdTests) {
+  for (const j in cmdTests) {
     if (cmdList[cmdTests[j]]) {
       return cmdList[cmdTests[j]]
     }
@@ -1141,16 +1141,16 @@ jeedom.cmd.normalizeName = function(_tagname) {
 }
 
 jeedom.cmd.setOrder = function(_params) {
-  var paramsRequired = ['cmds']
-  var paramsSpecifics = {}
+  const paramsRequired =['cmds']
+  const paramsSpecifics ={}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/cmd.ajax.php'
   paramsAJAX.data = {
     action: 'setOrder',
@@ -1160,16 +1160,16 @@ jeedom.cmd.setOrder = function(_params) {
 }
 
 jeedom.cmd.getDeadCmd = function(_params) {
-  var paramsRequired = []
-  var paramsSpecifics = {}
+  const paramsRequired =[]
+  const paramsSpecifics ={}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/cmd.ajax.php'
   paramsAJAX.data = {
     action: 'getDeadCmd'
@@ -1179,9 +1179,9 @@ jeedom.cmd.getDeadCmd = function(_params) {
 
 /* time widgets */
 jeedom.cmd.formatMomentDuration = function(_duration) {
-  var durationString = ''
-  var used = 0
-  var lang = jeeFrontEnd.language
+  let durationString = ''
+  let used = 0
+  const lang = jeeFrontEnd.language
 
   if (_duration._data.years > 0) {
     durationString += _duration._data.years + jeedom.config.locales[lang].duration.year
@@ -1221,10 +1221,11 @@ jeedom.cmd.displayDuration = function(_date, _el, _type = 'duration') {
   if (isElement_jQuery(_el)) _el = _el[0] //Deprecated, keep for mobile during transition
   if (_type == 'date') {
     moment.locale(jeeFrontEnd.language.substring(0, 2))
+    let dateString
     if (isset(jeedom.config.locales[jeeFrontEnd.language].calendar)) {
-      var dateString = moment(_date, 'YYYY-MM-DD HH:mm:ss').calendar(jeedom.config.locales[jeeFrontEnd.language].calendar)
+      dateString = moment(_date, 'YYYY-MM-DD HH:mm:ss').calendar(jeedom.config.locales[jeeFrontEnd.language].calendar)
     } else {
-      var dateString = moment(_date, 'YYYY-MM-DD HH:mm:ss').calendar(jeedom.config.locales['en_US'].calendar)
+      dateString = moment(_date, 'YYYY-MM-DD HH:mm:ss').calendar(jeedom.config.locales['en_US'].calendar)
     }
     _el.innerHTML = dateString
     return true
@@ -1234,29 +1235,30 @@ jeedom.cmd.displayDuration = function(_date, _el, _type = 'duration') {
     clearInterval(_el.getAttribute('data-interval'))
   }
 
-  var tsDate = moment(_date).unix() * 1000
-  var now = Date.now() + ((new Date).getTimezoneOffset() + jeeFrontEnd.serverTZoffsetMin) * 60000 + jeeFrontEnd.clientServerDiffDatetime
+  const tsDate = moment(_date).unix() * 1000
+  const now = Date.now() + ((new Date).getTimezoneOffset() + jeeFrontEnd.serverTZoffsetMin) * 60000 + jeeFrontEnd.clientServerDiffDatetime
 
-  var interval = 10000
+  let interval = 10000
+  let durationString
   //_past more than one second ?
   if (now - tsDate > 1000) {
-    var duration = moment.duration(moment() - moment(_date))
-    var durationSec = duration._milliseconds / 1000
+    const duration = moment.duration(moment() - moment(_date))
+    const durationSec = duration._milliseconds / 1000
     if (durationSec > 86399) {
       interval = 3600000
     } else if (durationSec > 3599) {
       interval = 60000
     }
-    var durationString = jeedom.cmd.formatMomentDuration(duration)
+    durationString = jeedom.cmd.formatMomentDuration(duration)
   } else {
-    var durationString = "0" + jeedom.config.locales[jeeFrontEnd.language].duration.second
+    durationString = "0" + jeedom.config.locales[jeeFrontEnd.language].duration.second
   }
   _el.innerHTML = durationString
 
   //set refresh interval:
-  var myinterval = setInterval(function() {
-    var duration = moment.duration(moment() - moment(_date))
-    var durationString = jeedom.cmd.formatMomentDuration(duration)
+  const myinterval = setInterval(function() {
+    const duration = moment.duration(moment() - moment(_date))
+    const durationString = jeedom.cmd.formatMomentDuration(duration)
     _el.innerHTML = durationString
   }, interval)
 

--- a/core/js/cmd.class.js
+++ b/core/js/cmd.class.js
@@ -58,8 +58,8 @@ jeedom.cmd.execute = function(_params) {
   let eqLogic = null
   if (notify) {
     eqLogic = document.querySelector('.cmd[data-cmd_id="' + _params.id + '"]')?.closest('div.eqLogic-widget') ?? null
-  }
   if (eqLogic) jeedom.cmd.notifyEq(eqLogic, false)
+}
   if (_params.value != 'undefined' && (is_array(_params.value) || is_object(_params.value))) {
     _params.value = JSON.stringify(_params.value)
   }

--- a/core/js/cmd.class.js
+++ b/core/js/cmd.class.js
@@ -55,9 +55,10 @@ jeedom.cmd.execute = function(_params) {
     return
   }
   const notify = _params.notify ?? true
-  const eqLogic = notify
-    ? document.querySelector('.cmd[data-cmd_id="' + _params.id + '"]')?.closest('div.eqLogic-widget')
-    : null
+  let eqLogic = null
+  if (notify) {
+    eqLogic = document.querySelector('.cmd[data-cmd_id="' + _params.id + '"]')?.closest('div.eqLogic-widget') ?? null
+  }
   if (eqLogic) jeedom.cmd.notifyEq(eqLogic, false)
   if (_params.value != 'undefined' && (is_array(_params.value) || is_object(_params.value))) {
     _params.value = JSON.stringify(_params.value)

--- a/core/js/eqLogic.class.js
+++ b/core/js/eqLogic.class.js
@@ -40,8 +40,8 @@ if(!isset(jeedom.eqLogic.cache.byLogical)){
 }
 
 jeedom.eqLogic.save = function(_params) {
-  var paramsRequired = ['type', 'eqLogics']
-  var paramsSpecifics = {
+  const paramsRequired = ['type', 'eqLogics']
+  const paramsSpecifics = {
     pre_success: function(data) {
       if (isset(jeedom.eqLogic.cache.byId[data.result.id])) {
         delete jeedom.eqLogic.cache.byId[data.result.id]
@@ -61,8 +61,8 @@ jeedom.eqLogic.save = function(_params) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.async = _params.async || true
   paramsAJAX.url = 'core/ajax/eqLogic.ajax.php'
   paramsAJAX.data = {
@@ -74,16 +74,16 @@ jeedom.eqLogic.save = function(_params) {
 }
 
 jeedom.eqLogic.byType = function(_params) {
-  var paramsRequired = ['type']
-  var paramsSpecifics = {}
+  const paramsRequired = ['type']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/eqLogic.ajax.php'
   paramsAJAX.data = {
     action: 'listByType',
@@ -93,16 +93,16 @@ jeedom.eqLogic.byType = function(_params) {
 }
 
 jeedom.eqLogic.byObjectId = function(_params) {
-  var paramsRequired = ['object_id']
-  var paramsSpecifics = {}
+  const paramsRequired = ['object_id']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/eqLogic.ajax.php'
   paramsAJAX.data = {
     action: 'listByObject',
@@ -115,16 +115,16 @@ jeedom.eqLogic.byObjectId = function(_params) {
 }
 
 jeedom.eqLogic.simpleSave = function(_params) {
-  var paramsRequired = ['eqLogic']
-  var paramsSpecifics = {}
+  const paramsRequired = ['eqLogic']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/eqLogic.ajax.php'
   paramsAJAX.data = {
     action: 'simpleSave',
@@ -134,16 +134,16 @@ jeedom.eqLogic.simpleSave = function(_params) {
 }
 
 jeedom.eqLogic.getUseBeforeRemove = function(_params) {
-  var paramsRequired = ['id']
-  var paramsSpecifics = {}
+  const paramsRequired = ['id']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/eqLogic.ajax.php'
   paramsAJAX.data = {
     action: 'getUseBeforeRemove',
@@ -153,16 +153,16 @@ jeedom.eqLogic.getUseBeforeRemove = function(_params) {
 }
 
 jeedom.eqLogic.usedBy = function(_params) {
-  var paramsRequired = ['id']
-  var paramsSpecifics = {}
+  const paramsRequired = ['id']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/eqLogic.ajax.php'
   paramsAJAX.data = {
     action: 'usedBy',
@@ -172,8 +172,8 @@ jeedom.eqLogic.usedBy = function(_params) {
 }
 
 jeedom.eqLogic.remove = function(_params) {
-  var paramsRequired = ['id', 'type']
-  var paramsSpecifics = {
+  const paramsRequired = ['id', 'type']
+  const paramsSpecifics = {
     pre_success: function(data) {
       if (isset(jeedom.eqLogic.cache.byId[_params.id])) {
         delete jeedom.eqLogic.cache.byId[_params.id]
@@ -187,8 +187,8 @@ jeedom.eqLogic.remove = function(_params) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/eqLogic.ajax.php'
   paramsAJAX.data = {
     action: 'remove',
@@ -199,8 +199,8 @@ jeedom.eqLogic.remove = function(_params) {
 }
 
 jeedom.eqLogic.copy = function(_params) {
-  var paramsRequired = ['id', 'name']
-  var paramsSpecifics = {
+  const paramsRequired = ['id', 'name']
+  const paramsSpecifics = {
     pre_success: function(data) {
       if (isset(jeedom.eqLogic.cache.byId[_params.id])) {
         delete jeedom.eqLogic.cache.byId[_params.id]
@@ -214,8 +214,8 @@ jeedom.eqLogic.copy = function(_params) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/eqLogic.ajax.php'
   paramsAJAX.data = {
     action: 'copy',
@@ -226,8 +226,8 @@ jeedom.eqLogic.copy = function(_params) {
 }
 
 jeedom.eqLogic.print = function(_params) {
-  var paramsRequired = ['id', 'type']
-  var paramsSpecifics = {
+  const paramsRequired = ['id', 'type']
+  const paramsSpecifics = {
     pre_success: function(data) {
       if (data.result && data.result.cmd) {
         jeedom.eqLogic.cache.getCmd[_params.id] = data.result.cmd
@@ -241,8 +241,8 @@ jeedom.eqLogic.print = function(_params) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/eqLogic.ajax.php'
   paramsAJAX.data = {
     action: 'get',
@@ -255,16 +255,16 @@ jeedom.eqLogic.print = function(_params) {
 }
 
 jeedom.eqLogic.toHtml = function(_params) {
-  var paramsRequired = ['id', 'version']
-  var paramsSpecifics = {}
+  const paramsRequired = ['id', 'version']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/eqLogic.ajax.php'
   paramsAJAX.data = {
     action: 'toHtml',
@@ -276,8 +276,8 @@ jeedom.eqLogic.toHtml = function(_params) {
 }
 
 jeedom.eqLogic.getCmd = function(_params) {
-  var paramsRequired = ['id']
-  var paramsSpecifics = {
+  const paramsRequired = ['id']
+  const paramsSpecifics = {
     pre_success: function(data) {
       jeedom.eqLogic.cache.getCmd[_params.id] = data.result
       return data
@@ -293,8 +293,8 @@ jeedom.eqLogic.getCmd = function(_params) {
     _params.success(jeedom.eqLogic.cache.getCmd[_params.id])
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/cmd.ajax.php'
   paramsAJAX.data = {
     action: 'byEqLogic',
@@ -305,8 +305,8 @@ jeedom.eqLogic.getCmd = function(_params) {
 }
 
 jeedom.eqLogic.byId = function(_params) {
-  var paramsRequired = ['id']
-  var paramsSpecifics = {
+  const paramsRequired = ['id']
+  const paramsSpecifics = {
     pre_success: function(data) {
       jeedom.eqLogic.cache.byId[data.result.id] = data.result
       return data
@@ -322,8 +322,8 @@ jeedom.eqLogic.byId = function(_params) {
     _params.success(jeedom.eqLogic.cache.byId[_params.id])
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/eqLogic.ajax.php'
   paramsAJAX.data = {
     action: 'byId',
@@ -333,16 +333,16 @@ jeedom.eqLogic.byId = function(_params) {
 }
 
 jeedom.eqLogic.removeImage = function(_params) {
-  var paramsRequired = ['id'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['id'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/eqLogic.ajax.php';
   paramsAJAX.data = {
     action: 'removeImage',
@@ -352,8 +352,8 @@ jeedom.eqLogic.removeImage = function(_params) {
 }
 
 jeedom.eqLogic.byLogical = function(_params) {
-  var paramsRequired = ['logical', 'type']
-  var paramsSpecifics = {
+  const paramsRequired = ['logical', 'type']
+  const paramsSpecifics = {
     pre_success: function(data) {
       jeedom.eqLogic.cache.byLogical[data.result.logical, data.result.type] = data.result
       return data
@@ -369,8 +369,8 @@ jeedom.eqLogic.byLogical = function(_params) {
     _params.success(jeedom.eqLogic.cache.byLogical[_params.logical, _params.type])
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/eqLogic.ajax.php'
   paramsAJAX.data = {
     action: 'byLogical',
@@ -388,8 +388,8 @@ jeedom.eqLogic.buildSelectCmd = function(_params) {
     id: _params.id,
     async: false,
     success: function(cmds) {
-      var result = ''
-      for (var i in cmds) {
+      let result = ''
+      for (const i in cmds) {
         if ((init(_params.filter.type, 'all') == 'all' || cmds[i].type == _params.filter.type) &&
           (init(_params.filter.subType, 'all') == 'all' || cmds[i].subType == _params.filter.subType) &&
           (init(_params.filter.isHistorized, 'all') == 'all' || cmds[i].isHistorized == _params.filter.isHistorized)
@@ -421,7 +421,7 @@ jeedom.eqLogic.getSelectModal = function(_options, callback) {
         className: 'success',
         callback: {
           click: function(event) {
-            var args = {}
+            const args = {}
             args.human = mod_insertEqLogic.getValue()
             args.id = mod_insertEqLogic.getId()
             if (args.human.trim() != '') {
@@ -445,17 +445,17 @@ jeedom.eqLogic.getSelectModal = function(_options, callback) {
 }
 
 jeedom.eqLogic.refreshValue = function(_params) {
-  var paramsRequired = []
-  var eqLogics = {}
-  var sends = {}
-  var eqLogic = null
-  var page = document.body.getAttribute('data-page')
+  const paramsRequired = []
+  const eqLogics = {}
+  const sends = {}
+  let eqLogic = null
+  const page = document.body.getAttribute('data-page')
 
-  for (var i in _params) {
+  for (const i in _params) {
     eqLogic = document.querySelector('.eqLogic[data-eqLogic_id="' + _params[i].eqLogic_id + '"]')
     if (eqLogic != null) {
       if ((page == 'dashboard' && _params[i].visible == '0') || _params[i].enable == '0') { //Remove it
-        let parent = eqLogic.parentNode
+        const parent = eqLogic.parentNode
         eqLogic.remove()
         if (parent.querySelectorAll('.eqLogic').length == 0) {
           if (page == 'dashboard') {
@@ -482,13 +482,13 @@ jeedom.eqLogic.refreshValue = function(_params) {
   if (Object.keys(eqLogics).length == 0) {
     return
   }
-  var paramsSpecifics = {
+  const paramsSpecifics = {
     global: false,
     noDisplayError: true,
     success: function(result) {
-      var eqLogic = null
-      var uid = null
-      for (var i in result) {
+      let eqLogic = null
+      let uid = null
+      for (const i in result) {
         tile = domUtils.parseHTML(result[i].html)
         if (tile.childNodes.length == 0) {
           continue
@@ -500,6 +500,7 @@ jeedom.eqLogic.refreshValue = function(_params) {
         if (isElement_jQuery(eqLogic)) eqLogic = eqLogic[0]
         if (eqLogic == null) {
           if (page == 'dashboard') {
+            let object_div, previousEqLogic
             if ((object_div = document.getElementById('div_ob' + result[i].object_id)) != null) {
               if (object_div.querySelector('.eqLogic')?.getAttribute('data-order') >= result[i].order) {
                 object_div.querySelector('.eqLogic').before(tile)
@@ -509,7 +510,7 @@ jeedom.eqLogic.refreshValue = function(_params) {
                 object_div.html(result[i].html, true)
               }
               jeedomUtils.positionEqLogic(result[i].id)
-              var packer = Packery.data(object_div)
+              const packer = Packery.data(object_div)
               if (packer != undefined) packer.destroy()
               new Packery(object_div, {isLayoutInstant: true, transitionDuration: 0})
 
@@ -521,7 +522,7 @@ jeedom.eqLogic.refreshValue = function(_params) {
             document.querySelector('.alertListContainer').html(result[i].html, true)
             jeedomUtils.positionEqLogic(result[i].id, false)
             jeedomUtils.initTooltips()
-            let container = document.querySelector('.alertListContainer')
+            const container = document.querySelector('.alertListContainer')
             Packery.data(container).destroy()
             new Packery(container, { itemSelector: "#alertEqlogic .eqLogic-widget", isLayoutInstant: true, transitionDuration: 0 })
           } else if (page == 'plan' && !jeeFrontEnd.planEditOption.state) { //no create if plan is in edition
@@ -536,8 +537,8 @@ jeedom.eqLogic.refreshValue = function(_params) {
               },
               success: function(plans) {
                 try {
-                  var object
-                  for (var ii in plans) {
+                  let object
+                  for (const ii in plans) {
                     if (plans[ii].plan.link_id == result[i].id) {
                       object = jeeP.displayObject(plans[ii].plan, plans[ii].html, true)
                       if (object != undefined) {
@@ -558,8 +559,8 @@ jeedom.eqLogic.refreshValue = function(_params) {
           if (page == 'eqAnalyse' && result[i].alert == '') {
             eqLogic.remove()
             if (document.querySelector('.alertListContainer')?.querySelectorAll('.eqLogic').length > 0) {
-              let container = document.querySelector('.alertListContainer')
-              var packer = Packery.data(container)
+              const container = document.querySelector('.alertListContainer')
+              const packer = Packery.data(container)
               if (packer != undefined) packer.destroy()
             }
             continue
@@ -602,8 +603,8 @@ jeedom.eqLogic.refreshValue = function(_params) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/eqLogic.ajax.php'
   paramsAJAX.data = {
     action: 'toHtml',
@@ -613,9 +614,9 @@ jeedom.eqLogic.refreshValue = function(_params) {
 }
 
 jeedom.eqLogic.initGraphInfo = function(_eqLogicUid, _doNotHighlightGraphCmd) {
-  var divGraph = document.querySelector('div.eqLogic[data-eqlogic_uid="' + _eqLogicUid + '"]:not(.zone-widget) div.eqlogicbackgraph')
+  const divGraph = document.querySelector('div.eqLogic[data-eqlogic_uid="' + _eqLogicUid + '"]:not(.zone-widget) div.eqlogicbackgraph')
   if (divGraph != null) {
-    var cmdId = divGraph.dataset.cmdid
+    const cmdId = divGraph.dataset.cmdid
     if (!_doNotHighlightGraphCmd || _doNotHighlightGraphCmd === false) {
       document.querySelector('div.eqLogic[data-eqlogic_uid="' + _eqLogicUid + '"] div.cmd-widget[data-cmd_id="' + cmdId + '"] .cmdName')?.insertAdjacentHTML('afterbegin', '<span class="graphInfoCmd">• </span>')
     }
@@ -624,18 +625,19 @@ jeedom.eqLogic.initGraphInfo = function(_eqLogicUid, _doNotHighlightGraphCmd) {
 }
 
 jeedom.eqLogic.drawGraphInfo = function(_eqLogicUid, _cmdId) {
-  var drawEqEl = document.querySelector('div.eqLogic[data-eqlogic_uid="' + _eqLogicUid + '"] .eqlogicbackgraph[data-cmdid="' + _cmdId + '"]')
+  const drawEqEl = document.querySelector('div.eqLogic[data-eqlogic_uid="' + _eqLogicUid + '"] .eqlogicbackgraph[data-cmdid="' + _cmdId + '"]')
   if (drawEqEl == null) return
   drawEqEl.empty()
   if (drawEqEl.length == 0) return false
+  let topMargin
   if (drawEqEl.hasClass('fixedbackgraph')) {
-    var topMargin = 0
+    topMargin = 0
   } else {
-    var topMargin = 35
+    topMargin = 35
   }
-  var dateEnd = moment().format('YYYY-MM-DD HH:mm:ss')
-  var dateStart
-  var decay = drawEqEl.dataset.format
+  const dateEnd = moment().format('YYYY-MM-DD HH:mm:ss')
+  let dateStart
+  const decay = drawEqEl.dataset.format
   switch (decay) {
     case 'hour':
       jeedom.eqLogic.backGraphIntervals[_cmdId] = 2 * 60 * 1000
@@ -670,12 +672,12 @@ jeedom.eqLogic.drawGraphInfo = function(_eqLogicUid, _cmdId) {
     success: function(result) {
       if (result.data.length == 0) return false
       if (result.timelineOnly) return false
-      var now = (moment().unix() + (jeeFrontEnd.serverTZoffsetMin * 60)) * 1000
-      var values = result.data.map(function(elt) {
+      const now = (moment().unix() + (jeeFrontEnd.serverTZoffsetMin * 60)) * 1000
+      const values = result.data.map(function(elt) {
         return elt[1]
       })
-      var minValue = result.cmd.subType == 'binary' ? 0 : Math.min.apply(null, values)
-      var maxValue = result.cmd.subType == 'binary' ? 1.1 : Math.max.apply(null, values) * 1.01
+      const minValue = result.cmd.subType == 'binary' ? 0 : Math.min.apply(null, values)
+      const maxValue = result.cmd.subType == 'binary' ? 1.1 : Math.max.apply(null, values) * 1.01
       result.data.push([now, result.data.slice(-1)[0][1]])
       new Highcharts.StockChart({
         chart: {
@@ -754,16 +756,16 @@ jeedom.eqLogic.drawGraphInfo = function(_eqLogicUid, _cmdId) {
 }
 
 jeedom.eqLogic.setOrder = function(_params) {
-  var paramsRequired = ['eqLogics']
-  var paramsSpecifics = {}
+  const paramsRequired = ['eqLogics']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/eqLogic.ajax.php'
   paramsAJAX.data = {
     action: 'setOrder',
@@ -773,16 +775,16 @@ jeedom.eqLogic.setOrder = function(_params) {
 }
 
 jeedom.eqLogic.setGenericType = function(_params) {
-  var paramsRequired = ['eqLogics']
-  var paramsSpecifics = {}
+  const paramsRequired = ['eqLogics']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/eqLogic.ajax.php'
   paramsAJAX.data = {
     action: 'setGenericType',
@@ -792,16 +794,16 @@ jeedom.eqLogic.setGenericType = function(_params) {
 }
 
 jeedom.eqLogic.removes = function(_params) {
-  var paramsRequired = ['eqLogics']
-  var paramsSpecifics = {}
+  const paramsRequired = ['eqLogics']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/eqLogic.ajax.php'
   paramsAJAX.data = {
     action: 'removes',
@@ -811,16 +813,16 @@ jeedom.eqLogic.removes = function(_params) {
 }
 
 jeedom.eqLogic.setIsVisibles = function(_params) {
-  var paramsRequired = ['eqLogics', 'isVisible']
-  var paramsSpecifics = {}
+  const paramsRequired = ['eqLogics', 'isVisible']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/eqLogic.ajax.php'
   paramsAJAX.data = {
     action: 'setIsVisibles',
@@ -831,16 +833,16 @@ jeedom.eqLogic.setIsVisibles = function(_params) {
 }
 
 jeedom.eqLogic.setIsEnables = function(_params) {
-  var paramsRequired = ['eqLogics', 'isEnable']
-  var paramsSpecifics = {}
+  const paramsRequired = ['eqLogics', 'isEnable']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/eqLogic.ajax.php'
   paramsAJAX.data = {
     action: 'setIsEnables',
@@ -851,16 +853,16 @@ jeedom.eqLogic.setIsEnables = function(_params) {
 }
 
 jeedom.eqLogic.htmlAlert = function(_params) {
-  var paramsRequired = ['version']
-  var paramsSpecifics = {}
+  const paramsRequired = ['version']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/eqLogic.ajax.php'
   paramsAJAX.data = {
     action: 'htmlAlert',
@@ -870,16 +872,16 @@ jeedom.eqLogic.htmlAlert = function(_params) {
 }
 
 jeedom.eqLogic.htmlBattery = function(_params) {
-  var paramsRequired = ['version']
-  var paramsSpecifics = {}
+  const paramsRequired = ['version']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/eqLogic.ajax.php'
   paramsAJAX.data = {
     action: 'htmlBattery',

--- a/core/js/object.class.js
+++ b/core/js/object.class.js
@@ -26,16 +26,16 @@ if (!isset(jeedom.object.cache.byId)) {
 }
 
 jeedom.object.getEqLogic = function(_params) {
-  var paramsRequired = ['id'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['id'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/eqLogic.ajax.php';
   paramsAJAX.data = {
     action: "listByObject",
@@ -48,16 +48,16 @@ jeedom.object.getEqLogic = function(_params) {
 }
 
 jeedom.object.getEqLogicsFromSummary = function(_params) {
-  var paramsRequired = ['id', 'summary'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['id', 'summary'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
 
   paramsAJAX.url = 'core/ajax/object.ajax.php';
   paramsAJAX.data = {
@@ -71,8 +71,8 @@ jeedom.object.getEqLogicsFromSummary = function(_params) {
 }
 
 jeedom.object.all = function(_params) {
-  var paramsRequired = [];
-  var paramsSpecifics = {
+  const paramsRequired = [];
+  const paramsSpecifics = {
     pre_success: function(data) {
       if (!isset(_params.onlyHasEqLogic)) {
         jeedom.object.cache.all = data.result;
@@ -86,7 +86,7 @@ jeedom.object.all = function(_params) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
   if (isset(jeedom.object.cache.all) && !isset(_params.onlyHasEqLogic) && init(params.noCache, false) == false) {
     params.success(jeedom.object.cache.all);
     return;
@@ -94,7 +94,7 @@ jeedom.object.all = function(_params) {
   if (_params.onlyVisible == undefined) {
     _params.onlyVisible = true
   }
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/object.ajax.php';
   paramsAJAX.data = {
     action: 'all',
@@ -106,16 +106,16 @@ jeedom.object.all = function(_params) {
 }
 
 jeedom.object.toHtml = function(_params) {
-  var paramsRequired = ['id'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['id'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/object.ajax.php';
   paramsAJAX.data = {
     action: 'toHtml',
@@ -130,8 +130,8 @@ jeedom.object.toHtml = function(_params) {
 }
 
 jeedom.object.remove = function(_params) {
-  var paramsRequired = ['id'];
-  var paramsSpecifics = {
+  const paramsRequired = ['id'];
+  const paramsSpecifics = {
     pre_success: function(data) {
       if (isset(jeedom.object.cache.all)) {
         delete jeedom.object.cache.all;
@@ -151,8 +151,8 @@ jeedom.object.remove = function(_params) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/object.ajax.php';
   paramsAJAX.data = {
     action: 'remove',
@@ -162,8 +162,8 @@ jeedom.object.remove = function(_params) {
 }
 
 jeedom.object.save = function(_params) {
-  var paramsRequired = ['object'];
-  var paramsSpecifics = {
+  const paramsRequired = ['object'];
+  const paramsSpecifics = {
     pre_success: function(data) {
       if (isset(jeedom.object.cache.all)) {
         delete jeedom.object.cache.all;
@@ -183,8 +183,8 @@ jeedom.object.save = function(_params) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/object.ajax.php';
   paramsAJAX.data = {
     action: 'save',
@@ -194,8 +194,8 @@ jeedom.object.save = function(_params) {
 }
 
 jeedom.object.byId = function(_params) {
-  var paramsRequired = ['id'];
-  var paramsSpecifics = {
+  const paramsRequired = ['id'];
+  const paramsSpecifics = {
     pre_success: function(data) {
       jeedom.object.cache.byId[data.result.id] = data.result;
       return data;
@@ -207,12 +207,12 @@ jeedom.object.byId = function(_params) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
   if (isset(jeedom.object.cache.byId[params.id]) && init(_params.cache, true) == true) {
     params.success(jeedom.object.cache.byId[params.id]);
     return;
   }
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/object.ajax.php';
   paramsAJAX.data = {
     action: 'byId',
@@ -222,16 +222,16 @@ jeedom.object.byId = function(_params) {
 }
 
 jeedom.object.orderEqLogicByUsage = function(_params) {
-  var paramsRequired = ['id'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['id'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/object.ajax.php';
   paramsAJAX.data = {
     action: 'orderEqLogicByUsage',
@@ -241,16 +241,16 @@ jeedom.object.orderEqLogicByUsage = function(_params) {
 }
 
 jeedom.object.getActionSummary = function(_params) {
-  var paramsRequired = ['object_id', 'summary'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['object_id', 'summary'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/object.ajax.php';
   paramsAJAX.data = {
     action: 'getActionSummary',
@@ -262,16 +262,16 @@ jeedom.object.getActionSummary = function(_params) {
 }
 
 jeedom.object.setOrder = function(_params) {
-  var paramsRequired = ['objects'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['objects'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/object.ajax.php';
   paramsAJAX.data = {
     action: 'setOrder',
@@ -281,16 +281,16 @@ jeedom.object.setOrder = function(_params) {
 }
 
 jeedom.object.getUISelectList = function(_params) {
-  var paramsRequired = [];
-  var paramsSpecifics = {};
+  const paramsRequired = [];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/object.ajax.php';
   paramsAJAX.data = {
     action: 'getUISelectList',
@@ -302,27 +302,25 @@ jeedom.object.getUISelectList = function(_params) {
 
 
 jeedom.object.summaryUpdate = function(_params) {
-  var summaryUpdate = {};
-  var sends = {};
-  var object = null;
-  var summarySpan = null;
-  var keySpan = null;
-  var updated = null;
-  var icon = null;
+  const summaryUpdate = {};
+  const sends = {};
+  let summarySpan = null;
+  let keySpan = null;
+  let updated = null;
+  let icon = null;
 
   //modifiy html summaries icons / numbers both desktop/mobile.
-  for (var i in _params) {
+  for (const i in _params) {
     //object can be global summary element, or nodelist of object summary and dashOverviewPrev summary
     objectSummaryList = Array.from(document.querySelectorAll('.objectSummary' + _params[i].object_id))
     if (objectSummaryList.length == 0) continue
     version = objectSummaryList[0].getAttribute('data-version')
     if (version == undefined) continue
 
-    var updated
     if (isset(_params[i]['keys'])) {
       objectSummaryList.forEach(function(objectSummary) {
         updated = false
-        for (var key in _params[i]['keys']) {
+        for (const key in _params[i]['keys']) {
           summarySpan = objectSummary.querySelector('.objectSummaryParent[data-summary="' + key + '"]')
           if (summarySpan == null) {
             summarySpan = document.querySelector('div.objectPreview[data-object_id="' + _params[i].object_id + '"]')?.querySelector('.objectSummaryParent[data-summary="' + key + '"]')
@@ -374,11 +372,11 @@ jeedom.object.summaryUpdate = function(_params) {
     return
   }
 
-  var paramsRequired = [];
-  var paramsSpecifics = {
+  const paramsRequired = [];
+  const paramsSpecifics = {
     global: false,
     success: function(result) {
-      for (var id in result) {
+      for (const id in result) {
         try {
           summaryUpdate[id].objectSummaryList.forEach(function(objectSummary) {
             summary = domUtils.parseHTML(result[id].html)
@@ -398,8 +396,8 @@ jeedom.object.summaryUpdate = function(_params) {
     return;
   }
 
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/object.ajax.php';
   paramsAJAX.data = {
     action: 'getSummaryHtml',
@@ -435,16 +433,16 @@ jeedom.object.getImgPath = function(_params) {
 }
 
 jeedom.object.removeImage = function(_params) {
-  var paramsRequired = ['id'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['id'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/object.ajax.php';
   paramsAJAX.data = {
     action: 'removeImage',
@@ -454,16 +452,16 @@ jeedom.object.removeImage = function(_params) {
 }
 
 jeedom.object.uploadImage = function(_params) {
-  var paramsRequired = ['id', 'file'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['id', 'file'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/object.ajax.php';
   paramsAJAX.data = {
     action: 'uploadImage',

--- a/core/js/scenario.class.js
+++ b/core/js/scenario.class.js
@@ -25,8 +25,8 @@ if (!isset(jeedom.scenario.cache.byGroupObjectName)) {
 }
 
 jeedom.scenario.all = function(_params) {
-  var paramsRequired = []
-  var paramsSpecifics = {
+  const paramsRequired = []
+  const paramsSpecifics = {
     pre_success: function(data) {
       jeedom.scenario.cache.all = data.result
       return data
@@ -38,12 +38,12 @@ jeedom.scenario.all = function(_params) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
   if (isset(jeedom.scenario.cache.all) && jeedom.scenario.cache.all != null && init(_params.nocache, false) == false) {
     params.success(jeedom.scenario.cache.all)
     return
   }
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/scenario.ajax.php'
   paramsAJAX.data = {
     action: 'all',
@@ -52,10 +52,10 @@ jeedom.scenario.all = function(_params) {
 }
 
 jeedom.scenario.allOrderedByGroupObjectName = function(_params) {
-  var asGroup = _params.asGroup ? _params.asGroup : 0
-  var asTag = _params.asTag ? _params.asTag : 0
-  var paramsRequired = []
-  var paramsSpecifics = {
+  const asGroup = _params.asGroup ? _params.asGroup : 0
+  const asTag = _params.asTag ? _params.asTag : 0
+  const paramsRequired = []
+  const paramsSpecifics = {
     pre_success: function(data) {
       if (!isset(jeedom.scenario.cache.byGroupObjectName)) jeedom.scenario.cache.byGroupObjectName = Array()
       if (asTag) return data
@@ -69,14 +69,14 @@ jeedom.scenario.allOrderedByGroupObjectName = function(_params) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
   /*
   if (!asTag && isset(jeedom.scenario.cache.byGroupObjectName) && isset(jeedom.scenario.cache.byGroupObjectName[asGroup]) && jeedom.scenario.cache.byGroupObjectName[asGroup] != null  && init(_params.nocache, false) == false) {
     params.success(jeedom.scenario.cache.byGroupObjectName[asGroup])
     return
   }
   */
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/scenario.ajax.php'
   paramsAJAX.data = {
     action: 'allOrderedByGroupObjectName',
@@ -87,8 +87,8 @@ jeedom.scenario.allOrderedByGroupObjectName = function(_params) {
 }
 
 jeedom.scenario.saveAll = function(_params) {
-  var paramsRequired = ['scenarios']
-  var paramsSpecifics = {}
+  const paramsRequired = ['scenarios']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
@@ -97,8 +97,8 @@ jeedom.scenario.saveAll = function(_params) {
   }
   delete jeedom.scenario.cache.all
   delete jeedom.scenario.cache.byGroupObjectName
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/scenario.ajax.php'
   paramsAJAX.data = {
     action: 'saveAll',
@@ -108,16 +108,16 @@ jeedom.scenario.saveAll = function(_params) {
 }
 
 jeedom.scenario.toHtml = function(_params) {
-  var paramsRequired = ['id', 'version']
-  var paramsSpecifics = {}
+  const paramsRequired = ['id', 'version']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/scenario.ajax.php'
   paramsAJAX.data = {
     action: 'toHtml',
@@ -128,8 +128,8 @@ jeedom.scenario.toHtml = function(_params) {
 }
 
 jeedom.scenario.changeState = function(_params) {
-  var paramsRequired = ['id', 'state']
-  var paramsSpecifics = {
+  const paramsRequired = ['id', 'state']
+  const paramsSpecifics = {
     global: false
   }
   try {
@@ -138,8 +138,8 @@ jeedom.scenario.changeState = function(_params) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/scenario.ajax.php'
   paramsAJAX.data = {
     action: 'changeState',
@@ -150,8 +150,8 @@ jeedom.scenario.changeState = function(_params) {
 }
 
 jeedom.scenario.getTemplate = function(_params) {
-  var paramsRequired = []
-  var paramsSpecifics = {
+  const paramsRequired = []
+  const paramsSpecifics = {
     global: false
   }
   try {
@@ -160,8 +160,8 @@ jeedom.scenario.getTemplate = function(_params) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/scenario.ajax.php'
   paramsAJAX.data = {
     action: 'getTemplate',
@@ -170,16 +170,16 @@ jeedom.scenario.getTemplate = function(_params) {
 }
 
 jeedom.scenario.convertToTemplate = function(_params) {
-  var paramsRequired = ['id']
-  var paramsSpecifics = {}
+  const paramsRequired = ['id']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/scenario.ajax.php'
   paramsAJAX.data = {
     action: 'convertToTemplate',
@@ -190,16 +190,16 @@ jeedom.scenario.convertToTemplate = function(_params) {
 }
 
 jeedom.scenario.removeTemplate = function(_params) {
-  var paramsRequired = ['template']
-  var paramsSpecifics = {}
+  const paramsRequired = ['template']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/scenario.ajax.php'
   paramsAJAX.data = {
     action: 'removeTemplate',
@@ -209,16 +209,16 @@ jeedom.scenario.removeTemplate = function(_params) {
 }
 
 jeedom.scenario.loadTemplateDiff = function(_params) {
-  var paramsRequired = ['template', 'id']
-  var paramsSpecifics = {}
+  const paramsRequired = ['template', 'id']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/scenario.ajax.php'
   paramsAJAX.data = {
     action: 'loadTemplateDiff',
@@ -229,16 +229,16 @@ jeedom.scenario.loadTemplateDiff = function(_params) {
 }
 
 jeedom.scenario.applyTemplate = function(_params) {
-  var paramsRequired = ['template', 'id', 'convert']
-  var paramsSpecifics = {}
+  const paramsRequired = ['template', 'id', 'convert']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/scenario.ajax.php'
   paramsAJAX.data = {
     action: 'applyTemplate',
@@ -256,23 +256,24 @@ jeedom.scenario.refreshValue = function(_params) {
       return
     }
   }
-  var sc = document.querySelector('.scenario-widget[data-scenario_id="' + _params.scenario_id + '"]')
+  const sc = document.querySelector('.scenario-widget[data-scenario_id="' + _params.scenario_id + '"]')
   if (sc == null) {
     return
   }
-  var version = sc.getAttribute('data-version')
-  var paramsRequired = ['id']
-  var paramsSpecifics = {
+  const version = sc.getAttribute('data-version')
+  const paramsRequired = ['id']
+  const paramsSpecifics = {
     global: false,
     success: function(result) {
+      let tile
       try {
-        var tile = domUtils.parseHTML(result)
+        tile = domUtils.parseHTML(result)
         sc.empty().appendChild(tile)
         sc.querySelector('.scenario-widget').replaceWith(...sc.querySelector('scenario-widget').childNodes)
       } catch (error) {
         console.error(error)
       }
-      var tile = domUtils.parseHTML(result)
+      tile = domUtils.parseHTML(result)
       sc.empty().appendChild(result.childNodes)
       if (jeedomUtils.userDevice.type == undefined) {
         sc.triggerEvent('create')
@@ -286,8 +287,8 @@ jeedom.scenario.refreshValue = function(_params) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/scenario.ajax.php'
   paramsAJAX.data = {
     action: 'toHtml',
@@ -298,8 +299,8 @@ jeedom.scenario.refreshValue = function(_params) {
 }
 
 jeedom.scenario.copy = function(_params) {
-  var paramsRequired = ['id', 'name']
-  var paramsSpecifics = {}
+  const paramsRequired = ['id', 'name']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
@@ -308,8 +309,8 @@ jeedom.scenario.copy = function(_params) {
   }
   delete jeedom.scenario.cache.all
   delete jeedom.scenario.cache.byGroupObjectName
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/scenario.ajax.php'
   paramsAJAX.data = {
     action: 'copy',
@@ -320,16 +321,16 @@ jeedom.scenario.copy = function(_params) {
 }
 
 jeedom.scenario.byId = function(_params) {
-  var paramsRequired = ['id']
-  var paramsSpecifics = {}
+  const paramsRequired = ['id']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/scenario.ajax.php'
   paramsAJAX.data = {
     action: 'byId',
@@ -339,16 +340,16 @@ jeedom.scenario.byId = function(_params) {
 }
 
 jeedom.scenario.get = function(_params) {
-  var paramsRequired = ['id']
-  var paramsSpecifics = {}
+  const paramsRequired = ['id']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/scenario.ajax.php'
   paramsAJAX.data = {
     action: 'get',
@@ -358,8 +359,8 @@ jeedom.scenario.get = function(_params) {
 }
 
 jeedom.scenario.save = function(_params) {
-  var paramsRequired = ['scenario']
-  var paramsSpecifics = {}
+  const paramsRequired = ['scenario']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
@@ -368,8 +369,8 @@ jeedom.scenario.save = function(_params) {
   }
   delete jeedom.scenario.cache.all
   delete jeedom.scenario.cache.byGroupObjectName
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/scenario.ajax.php'
   paramsAJAX.data = {
     action: 'save',
@@ -379,8 +380,8 @@ jeedom.scenario.save = function(_params) {
 }
 
 jeedom.scenario.remove = function(_params) {
-  var paramsRequired = ['id']
-  var paramsSpecifics = {}
+  const paramsRequired = ['id']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
@@ -389,8 +390,8 @@ jeedom.scenario.remove = function(_params) {
   }
   delete jeedom.scenario.cache.all
   delete jeedom.scenario.cache.byGroupObjectName
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/scenario.ajax.php'
   paramsAJAX.data = {
     action: 'remove',
@@ -400,16 +401,16 @@ jeedom.scenario.remove = function(_params) {
 }
 
 jeedom.scenario.clearAllLogs = function(_params) {
-  var paramsRequired = []
-  var paramsSpecifics = {}
+  const paramsRequired = []
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/scenario.ajax.php'
   paramsAJAX.data = {
     action: 'clearAllLogs'
@@ -418,16 +419,16 @@ jeedom.scenario.clearAllLogs = function(_params) {
 }
 
 jeedom.scenario.emptyLog = function(_params) {
-  var paramsRequired = ['id']
-  var paramsSpecifics = {}
+  const paramsRequired = ['id']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/scenario.ajax.php'
   paramsAJAX.data = {
     action: 'emptyLog',
@@ -456,7 +457,7 @@ jeedom.scenario.getSelectModal = function(_options, callback) {
         className: 'success',
         callback: {
           click: function(event) {
-            var args = {}
+            const args = {}
             args.human = mod_insertScenario.getValue()
             args.id = mod_insertScenario.getId()
             if (args.human.trim() != '') {
@@ -480,16 +481,16 @@ jeedom.scenario.getSelectModal = function(_options, callback) {
 }
 
 jeedom.scenario.testExpression = function(_params) {
-  var paramsRequired = ['expression']
-  var paramsSpecifics = {}
+  const paramsRequired = ['expression']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/scenario.ajax.php'
   paramsAJAX.data = {
     action: 'testExpression',
@@ -499,16 +500,16 @@ jeedom.scenario.testExpression = function(_params) {
 }
 
 jeedom.scenario.setOrder = function(_params) {
-  var paramsRequired = ['scenarios']
-  var paramsSpecifics = {}
+  const paramsRequired = ['scenarios']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/scenario.ajax.php'
   paramsAJAX.data = {
     action: 'setOrder',
@@ -606,7 +607,7 @@ jeedom.scenario.setAutoComplete = function(_params) {
 
   _params.parent.querySelectorAll('.expression').forEach(_expr => {
     //Empty Action block ?
-    var attrType = _expr.querySelector('.expressionAttr[data-l1key="type"]')
+    const attrType = _expr.querySelector('.expressionAttr[data-l1key="type"]')
     if (attrType) {
       if (attrType.value == 'condition') {
         _expr.querySelector('.expressionAttr[data-l1key="' + _params.type + '"]').jeeComplete({
@@ -614,8 +615,8 @@ jeedom.scenario.setAutoComplete = function(_params) {
           minLength: 1,
           source: function(request, response) {
             //return last term after last space:
-            var values = request.term.split(' ')
-            var term = values[values.length - 1]
+            const values = request.term.split(' ')
+            const term = values[values.length - 1]
             if (term == '') return false //only space entered
             response(
               jeedom.scenario.autoCompleteCondition.filter(item => item.includes(term))
@@ -636,8 +637,8 @@ jeedom.scenario.setAutoComplete = function(_params) {
             if (data.value.substr(-1) == '#') {
               data.value = data.value.slice(0, -1) + data.value
             } else {
-              var values = data.value.split(' ')
-              var term = values[values.length - 1]
+              const values = data.value.split(' ')
+              const term = values[values.length - 1]
               data.value = data.value.slice(0, -term.length) + data.value
             }
           }


### PR DESCRIPTION
## Summary

Second of four migration PRs splitting #3297 by functional domain. This batch covers **4 files handling core domain logic** (equipment, commands, objects, scenarios):

```
eqLogic.class.js   cmd.class.js
object.class.js    scenario.class.js
```

These are the most complex files in `core/js/`, with deeply nested callbacks (success/error/pre_success/forEach), so this batch warrants more careful review than the utility batch.

## Incidental fix (caught during migration)

- **`cmd.class.js` (`jeedom.cmd.execute`)** — `var eqLogic` was declared inside an `if (notify) { ... }` block but referenced from callbacks at lines 87, 107, 131, 151, 166, 172 (the `jeedom.cmd.notifyEq(eqLogic, true)` calls in `pre_success`). With `var`, function-scoped hoisting made it visible. Migrated to `const`/`let` it became block-scoped and threw `ReferenceError: eqLogic is not defined` on every dashboard command execution. Fix: hoisted the declaration out of the `if` block using a ternary so `const eqLogic = ... : null`.

## Test plan

- [ ] Execute a command from the dashboard (action button or info refresh) — verify no `ReferenceError` and the eqLogic notification (the brief icon flash) still triggers
- [ ] Open the configuration modal of any equipment — verify `eqLogic.print` and `eqLogic.save` work
- [ ] Open a scenario and run it manually — verify scenario execution
- [ ] Open an object summary on the dashboard — verify summary updates

Part of the split following #3297 discussion.