### PR TITLE
Refactor var to const/let in UI rendering files (3/4)

### DIFF
--- a/core/js/history.class.js
+++ b/core/js/history.class.js
@@ -19,8 +19,8 @@ jeedom.history.chart = []
 jeedom.history.chartDrawTime = 150
 
 jeedom.history.get = function(_params) {
-  var paramsRequired = ['cmd_id', 'dateStart', 'dateEnd']
-  var paramsSpecifics = {
+  const paramsRequired = ['cmd_id', 'dateStart', 'dateEnd']
+  const paramsSpecifics = {
     global: _params.global || true,
     pre_success: function(data) {
       if (data.result == undefined) return data
@@ -36,8 +36,8 @@ jeedom.history.get = function(_params) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/cmd.ajax.php'
   paramsAJAX.data = {
     action: 'getHistory',
@@ -50,8 +50,8 @@ jeedom.history.get = function(_params) {
 }
 
 jeedom.history.getLast = function(_params) {
-  var paramsRequired = ['cmd_id', 'time']
-  var paramsSpecifics = {
+  const paramsRequired = ['cmd_id', 'time']
+  const paramsSpecifics = {
     global: _params.global || true,
     pre_success: function(data) {
       if (isset(jeedom.cmd.cache.byId[data.result.id])) {
@@ -66,8 +66,8 @@ jeedom.history.getLast = function(_params) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = $.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = $.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/cmd.ajax.php'
   paramsAJAX.data = {
     action: 'getLastHistory',
@@ -78,16 +78,16 @@ jeedom.history.getLast = function(_params) {
 }
 
 jeedom.history.getInitDates = function(_params) {
-  var paramsRequired = []
-  var paramsSpecifics = {}
+  const paramsRequired = []
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/cmd.ajax.php'
   paramsAJAX.data = {
     action: 'getInitDates'
@@ -96,16 +96,16 @@ jeedom.history.getInitDates = function(_params) {
 }
 
 jeedom.history.removeHistoryInFutur = function(_params) {
-  var paramsRequired = []
-  var paramsSpecifics = {}
+  const paramsRequired = []
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/history.ajax.php'
   paramsAJAX.data = {
     action: 'removeHistoryInFutur'
@@ -114,16 +114,16 @@ jeedom.history.removeHistoryInFutur = function(_params) {
 }
 
 jeedom.history.copyHistoryToCmd = function(_params) {
-  var paramsRequired = ['source_id', 'target_id']
-  var paramsSpecifics = {}
+  const paramsRequired = ['source_id', 'target_id']
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/cmd.ajax.php'
   paramsAJAX.data = {
     action: 'copyHistoryToCmd',
@@ -134,13 +134,13 @@ jeedom.history.copyHistoryToCmd = function(_params) {
 }
 
 jeedom.history.generatePlotBand = function(_startTime, _endTime) {
-  var plotBands = []
-  var day = 86400000
+  const plotBands = []
+  const day = 86400000
   if ((_endTime - _startTime) > (9 * day)) {
     return plotBands
   }
   _startTime = Math.floor(_startTime / day) * day
-  var plotBand
+  let plotBand
   while (_startTime < _endTime) {
     plotBand = {}
     plotBand.from = _startTime
@@ -155,12 +155,12 @@ jeedom.history.generatePlotBand = function(_startTime, _endTime) {
 }
 
 jeedom.history.graphUpdate = function(_params) {
-  for (var i in _params) {
+  for (const i in _params) {
     if(_params[i].cmd_id == ''){
       continue;
     }
-    for(var chart in jeedom.history.chart){
-      for(var serie in jeedom.history.chart[chart].chart.series){
+    for(const chart in jeedom.history.chart){
+      for(const serie in jeedom.history.chart[chart].chart.series){
         if(jeedom.history.chart[chart].chart.series[serie] && jeedom.history.chart[chart].chart.series[serie].options.id == _params[i].cmd_id){
           jeedom.history.chart[chart].chart.series[serie].addPoint([Date.now()+(-1*(new Date()).getTimezoneOffset()*60*1000),_params[i].value])
         }
@@ -171,8 +171,8 @@ jeedom.history.graphUpdate = function(_params) {
 
 jeedom.history.changePoint = function(_params) {
   // console.log('changePoint:', _params)
-  var paramsRequired = ['cmd_id', 'datetime', 'value', 'oldValue']
-  var paramsSpecifics = {
+  const paramsRequired = ['cmd_id', 'datetime', 'value', 'oldValue']
+  const paramsSpecifics = {
     error: function(error) {
       jeedomUtils.showAlert({
         message: error.message,
@@ -189,7 +189,7 @@ jeedom.history.changePoint = function(_params) {
         message: '{{La valeur a été éditée avec succès}}',
         level: 'success'
       })
-      var shown = document.getElementById('ul_history').querySelectorAll('li.li_history.active[data-cmd_id="' + _params.cmd_id + '"]')
+      const shown = document.getElementById('ul_history').querySelectorAll('li.li_history.active[data-cmd_id="' + _params.cmd_id + '"]')
       if (shown) {
         jeeFrontEnd.history.addChart(_params.cmd_id, 0)
         jeeFrontEnd.history.addChart(_params.cmd_id, 1)
@@ -202,8 +202,8 @@ jeedom.history.changePoint = function(_params) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/cmd.ajax.php'
   paramsAJAX.data = {
     action: 'changeHistoryPoint',
@@ -228,9 +228,9 @@ jeedom.history.modalchangePoint = function(event, _this, _params) {
     return
   }
 
-  var id = _this.series.userOptions.id
-  var datetime = Highcharts.dateFormat('%Y-%m-%d %H:%M:%S', _this.x)
-  var value = _this.y
+  const id = _this.series.userOptions.id
+  const datetime = Highcharts.dateFormat('%Y-%m-%d %H:%M:%S', _this.x)
+  const value = _this.y
   jeeDialog.prompt({
     title: "{{Edition d'historique}}",
     message: "<b>" + _this.series.name + "</b><br> {{date :}} <b>" + datetime + "</b><br>{{valeur :}} <b>" + value + "</b><br><i>{{Ne rien mettre pour supprimer la valeur}}</i>"
@@ -257,7 +257,7 @@ jeedom.history.drawChart = function(_params) {
   _params.option = init(_params.option, {
     derive: ''
   })
-  var _visible = (isset(_params.visible)) ? _params.visible : true
+  const _visible = (isset(_params.visible)) ? _params.visible : true
 
   //get command history
   domUtils.ajax({
@@ -297,7 +297,7 @@ jeedom.history.drawChart = function(_params) {
           return
         }
         if (!_params.noError) {
-          var message = '{{Il n\'existe encore aucun historique pour cette commande :}} ' + data.result.history_name
+          let message = '{{Il n\'existe encore aucun historique pour cette commande :}} ' + data.result.history_name
           if (init(data.result.dateStart) != '') {
             message += (init(data.result.dateEnd) != '') ? ' {{du}} ' + data.result.dateStart + ' {{au}} ' + data.result.dateEnd : ' {{à partir de}} ' + data.result.dateStart
           } else {
@@ -333,27 +333,26 @@ jeedom.history.drawChart = function(_params) {
       @tsLast: last timestamp existing in data
       @tsEnd: dateEnd timestamp, data must end there and difference between end and start must be the same on both series
       */
-      var comparisonSerie = false
+      let comparisonSerie = false
       if (isset(_params.compare) && _params.compare == 1) comparisonSerie = true
 
       if (isset(jeedom.history.chart[_params.el]) && (jeedom.history.chart[_params.el].comparing)) {
-        var tsFirst, tsStart, tsLast, tsEnd
-        tsFirst = data.result.data[0][0]
-        tsStart = Date.parse(data.result.dateStart.replace(/-/g, '/') + ' GMT')
+        const tsFirst = data.result.data[0][0]
+        const tsStart = Date.parse(data.result.dateStart.replace(/-/g, '/') + ' GMT')
         if (tsStart < tsFirst) {
           data.result.data.unshift([tsStart, data.result.data[0][1]])
         }
 
-        if (!comparisonSerie) { //reference series, may ends at current time:
+        let tsEnd
+        if (!comparisonSerie) {
           tsEnd = Date.parse(data.result.dateEnd.replace(/-/g, '/') + ' GMT')
           jeedom.history.chart[_params.el].comparingToEnd = data.result.dateEnd
           jeedom.history.chart[_params.el].comparingTsDiff = tsEnd - tsStart
-        } else { //comparison series, must ends at same timestamp diff than reference one:
+        } else {
           tsEnd = tsStart + jeedom.history.chart[_params.el].comparingTsDiff
-          //remove leading and trailing over data:
           data.result.data = data.result.data.filter(v => v[0] <= tsEnd)
         }
-        tsLast = data.result.data.slice(-1)[0][0]
+        const tsLast = data.result.data.slice(-1)[0][0]
         if (tsEnd > tsLast) {
           data.result.data.push([tsEnd, data.result.data.slice(-1)[0][1]])
         }
@@ -366,21 +365,21 @@ jeedom.history.drawChart = function(_params) {
       _params.option.graphDerive = (data.result.derive == "1") ? true : false
 
       //series colors, options defined in core/js/jeedom.class.js jeedom.init():
-      var colors = Highcharts.getOptions().colors
-      var colorsNbr = colors.length
-      var colorUsed = []
-      var numSeries = 0
+      const colors = Highcharts.getOptions().colors
+      const colorsNbr = colors.length
+      const colorUsed = []
+      let numSeries = 0
       if (isset(jeedom.history.chart[_params.el]) && isset(jeedom.history.chart[_params.el].chart) && isset(jeedom.history.chart[_params.el].chart.series)) {
         if (jeedom.history.chart[_params.el].chart.series.length > colorsNbr) { //More series than colors, rotate colors:
           numSeries = Math.abs(jeedom.history.chart[_params.el].chart.series.length % colorsNbr) - 1
         } else { //Ensure no two series with same color:
           jeedom.history.chart[_params.el].chart.series.forEach((serie, index) => {
             if (!serie.userOptions.group) {
-              var sColorHindex = Highcharts.getOptions().colors.indexOf(serie.color)
+              const sColorHindex = Highcharts.getOptions().colors.indexOf(serie.color)
               if (!colorUsed.includes(sColorHindex)) colorUsed.push(sColorHindex)
             }
 
-            for (var i = 0; i < colorsNbr; i++) {
+            for (let i = 0; i < colorsNbr; i++) {
               if (!colorUsed.includes(i)) {
                 numSeries = i
                 break
@@ -389,7 +388,7 @@ jeedom.history.drawChart = function(_params) {
           })
         }
       }
-      var seriesNumber = numSeries + 1
+      let seriesNumber = numSeries + 1
       if (seriesNumber <= 0 || seriesNumber > colorsNbr) seriesNumber = 1
       if (!isset(_params.option.graphColor) || _params.option.graphColor === undefined) {
         _params.option.graphColor = colors[seriesNumber - 1]
@@ -408,7 +407,7 @@ jeedom.history.drawChart = function(_params) {
           _params.option.graphType = (isset(data.result.cmd.display) && init(data.result.cmd.display.graphType) != '') ? data.result.cmd.display.graphType : 'area'
         }
         if (init(_params.option.groupingType) == '' && isset(data.result.cmd.display) && init(data.result.cmd.display.groupingType) != '') {
-          var split = data.result.cmd.display.groupingType.split('||')[0]
+          let split = data.result.cmd.display.groupingType.split('||')[0]
 		  split = split.split('::')
           _params.option.groupingType = {
             function: split[0],
@@ -417,7 +416,7 @@ jeedom.history.drawChart = function(_params) {
         }
       }
 
-      var stacking = (_params.option.graphStack == undefined || _params.option.graphStack == null || _params.option.graphStack == 0) ? null : 'value'
+      const stacking = (_params.option.graphStack == undefined || _params.option.graphStack == null || _params.option.graphStack == 0) ? null : 'value'
       _params.option.graphStack = (_params.option.graphStack == undefined || _params.option.graphStack == null || _params.option.graphStack == 0) ? Math.floor(Math.random() * 10000 + 2) : 1
       _params.showLegend = (init(_params.showLegend, true) && init(_params.showLegend, true) != "0") ? true : false
       _params.showTimeSelector = (init(_params.showTimeSelector, true) && init(_params.showTimeSelector, true) != "0") ? true : false
@@ -426,7 +425,7 @@ jeedom.history.drawChart = function(_params) {
       _params.showAxis = (init(_params.option.graphScaleVisible, true) && init(_params.option.graphScaleVisible, true) != "0") ? true : false
 
       //define legend and reset graph:
-      var legend = {
+      const legend = {
         borderColor: 'transparent',
         borderWidth: 0,
         symbolHeight: 8,
@@ -441,7 +440,7 @@ jeedom.history.drawChart = function(_params) {
       }
 
       //___________________________jeedom default chart params:
-      var charts = {
+      const charts = {
         zoomType: 'xy',
         marginTop: 40, //ensure same top space for buttons with or without rangeSelector
         resetZoomButton: {
@@ -467,7 +466,7 @@ jeedom.history.drawChart = function(_params) {
 
             //default min/max set earlier in series
             //.doing initialized at 1 when chart created with first curve
-            var thisId = event.target.userOptions._jeeId
+            const thisId = event.target.userOptions._jeeId
             setTimeout(function() {
               try {
                 jeedom.history.setRangeSelectorButtons(event.target.userOptions._jeeId)
@@ -495,7 +494,7 @@ jeedom.history.drawChart = function(_params) {
           },
           render: function(event) {
             //shift dotted zones clipPaths to ensure no overlapping step mode:
-            var solidClip = null
+            let solidClip = null
             document.querySelectorAll('.highcharts-zone-graph-0.customSolidZone').forEach(function(element) {
               solidClip = element.getAttribute('clip-path').replace('url(#', '#').replace(')', '')
               document.querySelector(solidClip).style.transform = 'translate(5px)'
@@ -506,7 +505,7 @@ jeedom.history.drawChart = function(_params) {
             })
           },
           addSeries: function(event) {
-            var thisId = this._jeeId
+            const thisId = this._jeeId
             if (jeedom.history.chart[thisId].doing > 0) { //chart not done, loading several series at once:
               jeedom.history.chart[thisId].doing += 1
             } else {                                      //chart done (-1), loading another series later:
@@ -528,7 +527,7 @@ jeedom.history.drawChart = function(_params) {
             }
           },
           selection: function(event) {
-            var chartId = event.target._jeeId
+            const chartId = event.target._jeeId
 
             if (event.resetSelection) { //Zoom back after reset zoom button
               this.resetZoomButton.hide()
@@ -550,14 +549,14 @@ jeedom.history.drawChart = function(_params) {
               setTimeout(function() {
                 try {
                   if (jeedom.history.chart[chartId].comparing) {
-                    var options = {
+                    const options = {
                       type: 'selection',
                       redraw: true,
                       resetDateRange: true,
                     }
                     jeedom.history.chartCallback(chartId, options)
                   } else {
-                    var options = {
+                    const options = {
                       type: 'selection',
                       redraw: true,
                       extremeXmin: jeedom.history.chart[chartId].zoomPrevXmin,
@@ -599,7 +598,7 @@ jeedom.history.drawChart = function(_params) {
 
       //pie chart option from views:
       if (_params.option.graphType == 'pie') {
-        var series = {
+        const series = {
           type: _params.option.graphType,
           id: _params.cmd_id,
           cursor: 'pointer',
@@ -673,11 +672,11 @@ jeedom.history.drawChart = function(_params) {
 
       //not pie, standard curve history:
       if (_params.option.graphType != 'pie') {
-        var dataGrouping = {
+        let dataGrouping = {
           enabled: false
         }
         if (isset(_params.option.groupingType) && typeof _params.option.groupingType === 'string' && _params.option.groupingType != '') {
-          var split = _params.option.groupingType.split('||')[0]
+          let split = _params.option.groupingType.split('||')[0]
 		  split=split.split('::')
           _params.option.groupingType = {
             function: split[0],
@@ -696,6 +695,7 @@ jeedom.history.drawChart = function(_params) {
         }
 
         //cmd info string has no value:
+        let series
         if (data.result.timelineOnly) {
           if (!isset(jeedom.history.chart[_params.el]) || !isset(jeedom.history.chart[_params.el].nbTimeline)) {
             nbTimeline = 1
@@ -704,7 +704,7 @@ jeedom.history.drawChart = function(_params) {
             nbTimeline = jeedom.history.chart[_params.el].nbTimeline
           }
 
-          var series = {
+          series = {
             type: 'flags',
             visible: _visible,
             name: (isset(_params.option.name)) ? _params.option.name + ' ' + data.result.unite : data.result.history_name + ' ' + data.result.unite,
@@ -723,7 +723,7 @@ jeedom.history.drawChart = function(_params) {
             }
           }
 
-          for (var i in data.result.data) {
+          for (const i in data.result.data) {
             series.data.push({
               x: data.result.data[i][0],
               title: data.result.data[i][1]
@@ -734,16 +734,16 @@ jeedom.history.drawChart = function(_params) {
             _params.option.graphType = 'area'
           }
           if (_params.calcul) {
-            for (var i in data.result.data) {
+            for (const i in data.result.data) {
               data.result.data[i][1] = _params.calcul(data.result.data[i][1])
             }
           }
           if (_params.option.invertData) {
-            for (var i in data.result.data) {
+            for (const i in data.result.data) {
               data.result.data[i][1] = -data.result.data[i][1]
             }
           }
-          var series = {
+          series = {
             dataGrouping: dataGrouping,
             type: _params.option.graphType,
             visible: _visible,
@@ -787,10 +787,10 @@ jeedom.history.drawChart = function(_params) {
 
           if (init(_params.option.groupingType) == '' && !comparisonSerie && _params.option.graphType != 'column') {
             //continue value to now, dotted if last value older than one minute (ts in millisecond):
-            var dateEnd = new Date(data.result.dateEnd)
+            const dateEnd = new Date(data.result.dateEnd)
             dateEnd.setTime(dateEnd.getTime() - dateEnd.getTimezoneOffset() * 60 * 1000)
-            var dateEndTs = dateEnd.getTime()
-            var diffms = dateEndTs - data.result.data[data.result.data.length - 1][0]
+            const dateEndTs = dateEnd.getTime()
+            const diffms = dateEndTs - data.result.data[data.result.data.length - 1][0]
             if (diffms > 60000) {
               series.zoneAxis = 'x'
               data.result.data.push([dateEndTs, data.result.data[data.result.data.length - 1][1]])
@@ -814,7 +814,7 @@ jeedom.history.drawChart = function(_params) {
         }
 
         //set axis position. View allow to set left/right on graph axis, or odd/even:
-        var axisOpposite
+        let axisOpposite
         if (_params.option.graphScale == undefined) {
           if (!isset(jeedom.history.chart[_params.el])) {
             axisOpposite = true
@@ -836,7 +836,7 @@ jeedom.history.drawChart = function(_params) {
           jeedom.history.chart[_params.el].yAxisScaling = true
 
           //dateRange buttons config:
-          var dateRange = ['all', '30 min', '1 hour', '1 day', '7 days', '1 month', '1 year'].indexOf(_params.dateRange)
+          let dateRange = ['all', '30 min', '1 hour', '1 day', '7 days', '1 month', '1 year'].indexOf(_params.dateRange)
           if (dateRange == -1) dateRange = 4
 
           jeedom.history.chart[_params.el].type = _params.option.graphType
@@ -1017,7 +1017,7 @@ jeedom.history.drawChart = function(_params) {
           jeedom.history.chart[_params.el].chart._jeeId = _params.el //else only in useroptions
           jeedom.history.chart[_params.el].doing = 1
 
-          var options = { default: {} }
+          const options = { default: {} }
           if (isset(_params.yAxisScaling) && _params.yAxisScaling !== '') options.default.yAxisScaling = _params.yAxisScaling
           if (isset(_params.yAxisByUnit) && _params.yAxisByUnit !== '') options.default.yAxisByUnit = _params.yAxisByUnit
           if (isset(_params.yAxisScalePercent) && _params.yAxisScalePercent !== '') options.default.yAxisScalePercent = _params.yAxisScalePercent
@@ -1057,7 +1057,7 @@ jeedom.history.drawChart = function(_params) {
             }, false)
           } else if (_params.option.graphStack != 1) {
             //add new yAxis:
-            var yAxis = {
+            const yAxis = {
               id: _params.cmd_id + '-yAxis',
               showEmpty: false,
               gridLineWidth: 0,
@@ -1129,7 +1129,7 @@ Hicharts events calls
 yAxis scaling
 */
 jeedom.history.initChart = function(_chartId, _options) {
-  var thisId = _chartId
+  const thisId = _chartId
   jeedom.history.chart[thisId].comparing = false
   jeedom.history.chart[thisId].zoom = false
   jeedom.history.chart[thisId].mode = jeedom.getPageType()
@@ -1158,7 +1158,7 @@ jeedom.history.initChart = function(_chartId, _options) {
     3: disabled
   */
 
-  var xStart = (jeedom.history.chart[thisId].rangeSelector === undefined ? -15 : 0)
+  const xStart = (jeedom.history.chart[thisId].rangeSelector === undefined ? -15 : 0)
 
   //Tracking button:
   jeedom.history.chart[thisId].btTracking = jeedom.history.chart[thisId].chart.renderer.button('<i class="fas fa-hand-pointer"></i>', undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, true)
@@ -1292,13 +1292,13 @@ jeedom.history.initLegendContextMenu = function(_chartId) {
     selector: "div.chartContainer .highcharts-legend-item",
     position: function(opt, x, y) {
       //legend bottom graph, open menu upside if possible:
-      var menuHeight = opt.ctxMenu.clientHeight
-      var menuWidth = opt.ctxMenu.clientWidth
-      var winHeight = window.innerHeight
-      var winWidth = window.innerWidth
+      const menuHeight = opt.ctxMenu.clientHeight
+      const menuWidth = opt.ctxMenu.clientWidth
+      const winHeight = window.innerHeight
+      const winWidth = window.innerWidth
 
-      var newTop = y - menuHeight
-      var newLeft = x
+      let newTop = y - menuHeight
+      let newLeft = x
 
       if ((y - menuHeight - 20) < 0) {
         newTop = y
@@ -1312,17 +1312,17 @@ jeedom.history.initLegendContextMenu = function(_chartId) {
       })
     },
     build: function(trigger) {
-      var __ctxel__ = trigger.parentNode.closest('div.chartContainer').getAttribute('id')
+      const __ctxel__ = trigger.parentNode.closest('div.chartContainer').getAttribute('id')
       if (isset(jeeFrontEnd.history) && isset(jeeFrontEnd.history.__ctxel__) && jeedom.history.chart[jeeFrontEnd.history.__ctxel__].comparing) return false
-      var chart = jeedom.history.chart[__ctxel__].chart
+      const chart = jeedom.history.chart[__ctxel__].chart
       if (!chart) return false
       if (jeedom.history.chart[chart._jeeId].type == 'pie') return false
       if (jeedom.history.chart[chart._jeeId].comparing) return false
 
-      var serieId = trigger.getAttribute('class').split('highcharts-series-')[1].split(' ')[0]
-      var cmdId = chart.series[serieId].userOptions.id
-      var axis = chart.get(cmdId)
-      var contextmenuitems = {}
+      const serieId = trigger.getAttribute('class').split('highcharts-series-')[1].split(' ')[0]
+      const cmdId = chart.series[serieId].userOptions.id
+      const axis = chart.get(cmdId)
+      const contextmenuitems = {}
       contextmenuitems['cmdid'] = { 'name': 'id: ' + cmdId, 'id': 'cmdid', 'disabled': true }
       contextmenuitems['isolate'] = { 'name': '{{Isoler}} (Ctrl Clic)', 'id': 'isolate', 'icon': 'fas fa-chart-line' }
       contextmenuitems['showall'] = { 'name': '{{Afficher tout}} (Alt Clic)', 'id': 'showall', 'icon': 'fas fa-poll-h' }
@@ -1332,7 +1332,7 @@ jeedom.history.initLegendContextMenu = function(_chartId) {
         contextmenuitems['showaxis'] = { 'name': '{{Afficher axe}}', 'id': 'showaxis', 'icon': 'far fa-eye' }
       }
 
-      var idx = 0
+      let idx = 0
       Highcharts.getOptions().colors.forEach(function(color) {
         contextmenuitems['color_' + idx] = {
           'name': '<i class="fas fa-square" style="color:' + Highcharts.getOptions().colors[idx] + '!important;"></i>',
@@ -1375,7 +1375,7 @@ jeedom.history.initLegendContextMenu = function(_chartId) {
             })
 
             //synch "yAxis Visible"
-            var allVisible = true
+            let allVisible = true
             chart.yAxis.filter(v => v.userOptions.id != 'navigator-y-axis').forEach(function(yAxis) {
               if (!yAxis.visible) allVisible = false
             })
@@ -1389,10 +1389,10 @@ jeedom.history.initLegendContextMenu = function(_chartId) {
             return
           }
           if (key.startsWith('color_')) {
-            var idx = key.split('_')[1]
-            var opacityHigh = 0.85
-            var opacityLow = 0.1
-            var newC = Highcharts.getOptions().colors[idx]
+            const idx = key.split('_')[1]
+            const opacityHigh = 0.85
+            const opacityLow = 0.1
+            const newC = Highcharts.getOptions().colors[idx]
             chart.series[serieId].update({
               color: newC,
               fillColor: {
@@ -1451,7 +1451,7 @@ Once chart is done
 jeedom.history.chartDone = function(_chartId) {
   if (_chartId === undefined) return false
   if (jeedom.history.chart[_chartId].doing > 0) return false
-  var chart = jeedom.history.chart[_chartId].chart
+  const chart = jeedom.history.chart[_chartId].chart
   jeedom.history.chart[_chartId].doing = -1
   try {
     setTimeout(function() {
@@ -1483,7 +1483,7 @@ Set each existing yAxis scale according to chart yAxisScaling and yAxisByUnit
 jeedom.history.setAxisScales = function(_chartId, _options) {
   if (_chartId === undefined) return false
   if (jeedom.history.chart[_chartId].type == 'pie') return false
-  var chart = jeedom.history.chart[_chartId].chart
+  const chart = jeedom.history.chart[_chartId].chart
 
   //All done with render false, redraw at end if in _options
 
@@ -1505,11 +1505,11 @@ jeedom.history.setAxisScales = function(_chartId, _options) {
     }
   }
 
-  var units = {}
+  const units = {}
 
   //No scale | unit : All axis with same unit will get same min/max
   if (!jeedom.history.chart[_chartId].yAxisScaling && jeedom.history.chart[_chartId].yAxisByUnit) {
-    var unit, mathMin, mathMax
+    let unit, mathMin, mathMax
     chart.yAxis.filter(v => v.userOptions.id != 'navigator-y-axis').forEach((axis, index) => {
       if (axis.series.length == 0) return
       unit = axis.series[0].userOptions.unite
@@ -1525,11 +1525,11 @@ jeedom.history.setAxisScales = function(_chartId, _options) {
       units[unit].axis.push(axis.userOptions.id)
 
       if (axis.series[0].data.length > 0) {
-        var mathMin = Math.min.apply(Math, axis.series[0].data.filter(x => x.y !== null).map(function(key) { return key.y }))
-        var mathMax = Math.max.apply(Math, axis.series[0].data.filter(x => x.y !== null).map(function(key) { return key.y }))
+        mathMin = Math.min.apply(Math, axis.series[0].data.filter(x => x.y !== null).map(function(key) { return key.y }))
+        mathMax = Math.max.apply(Math, axis.series[0].data.filter(x => x.y !== null).map(function(key) { return key.y }))
       } else if (axis.series[0].points) {
-        var mathMin = Math.min.apply(Math, axis.series[0].points.filter(x => x.y !== null).map(function(key) { return key.y }))
-        var mathMax = Math.max.apply(Math, axis.series[0].points.filter(x => x.y !== null).map(function(key) { return key.y }))
+        mathMin = Math.min.apply(Math, axis.series[0].points.filter(x => x.y !== null).map(function(key) { return key.y }))
+        mathMax = Math.max.apply(Math, axis.series[0].points.filter(x => x.y !== null).map(function(key) { return key.y }))
       }
       if (mathMin < units[unit].min) units[unit].min = mathMin
       if (mathMax > units[unit].max) units[unit].max = mathMax
@@ -1566,8 +1566,8 @@ jeedom.history.setAxisScales = function(_chartId, _options) {
 
   //No scale | No unit : (HighChart default) All axis will get same global min/max
   if (!jeedom.history.chart[_chartId].yAxisScaling && !jeedom.history.chart[_chartId].yAxisByUnit) {
-    var softMax = 0
-    var mathMax
+    let softMax = 0
+    let mathMax
     chart.yAxis.filter(v => v.userOptions.id != 'navigator-y-axis').forEach((axis, index) => {
       mathMax = Math.max.apply(Math, axis.series[0].data.filter(x => x !== null).map(function(key) { return key.y }))
       if (mathMax > softMax) softMax = mathMax
@@ -1590,7 +1590,7 @@ jeedom.history.setAxisScales = function(_chartId, _options) {
 
   //scale | unit : (Jeedom default)  All axis with same unit will get same min/max
   if (jeedom.history.chart[_chartId].yAxisScaling && jeedom.history.chart[_chartId].yAxisByUnit) {
-    var unit, mathMin, mathMax, cmin, cmax
+    let unit, mathMin, mathMax, cmin, cmax
     chart.yAxis.filter(v => v.userOptions.id != 'navigator-y-axis').forEach((axis, index) => {
       if (axis.series.length == 0) return
       unit = axis.series[0].userOptions.unite
@@ -1606,11 +1606,11 @@ jeedom.history.setAxisScales = function(_chartId, _options) {
       units[unit].axis.push(axis.userOptions.id)
 
       if (axis.series[0].data.length > 0) {
-        var mathMin = Math.min.apply(Math, axis.series[0].data.filter(x => x !== null).map(function(key) { return key.options.y }))
-        var mathMax = Math.max.apply(Math, axis.series[0].data.filter(x => x !== null).map(function(key) { return key.options.y }))
+        mathMin = Math.min.apply(Math, axis.series[0].data.filter(x => x !== null).map(function(key) { return key.options.y }))
+        mathMax = Math.max.apply(Math, axis.series[0].data.filter(x => x !== null).map(function(key) { return key.options.y }))
       } else if (axis.series[0].points) {
-        var mathMin = Math.min.apply(Math, axis.series[0].points.filter(x => x !== null).map(function(key) { return key.y }))
-        var mathMax = Math.max.apply(Math, axis.series[0].points.filter(x => x !== null).map(function(key) { return key.y }))
+        mathMin = Math.min.apply(Math, axis.series[0].points.filter(x => x !== null).map(function(key) { return key.y }))
+        mathMax = Math.max.apply(Math, axis.series[0].points.filter(x => x !== null).map(function(key) { return key.y }))
       }
 
       if (mathMin < units[unit].min) units[unit].min = mathMin
@@ -1649,14 +1649,14 @@ jeedom.history.setAxisScales = function(_chartId, _options) {
 
   //scale | No unit : Each axis will get its own min/max
   if (jeedom.history.chart[_chartId].yAxisScaling && !jeedom.history.chart[_chartId].yAxisByUnit) {
-    var min, max
+    let min, max
     chart.yAxis.filter(v => v.userOptions.id != 'navigator-y-axis').forEach((axis, index) => {
       if (axis.series[0].data.length > 0) {
-        var min = Math.min.apply(Math, axis.series[0].data.filter(x => x !== null).map(function(key) { return key.options.y }))
-        var max = Math.max.apply(Math, axis.series[0].data.filter(x => x !== null).map(function(key) { return key.options.y }))
+        min = Math.min.apply(Math, axis.series[0].data.filter(x => x !== null).map(function(key) { return key.options.y }))
+        max = Math.max.apply(Math, axis.series[0].data.filter(x => x !== null).map(function(key) { return key.options.y }))
       } else if (axis.series[0].points) {
-        var min = Math.min.apply(Math, axis.series[0].points.filter(x => x !== null).map(function(key) { return key.y }))
-        var max = Math.max.apply(Math, axis.series[0].points.filter(x => x !== null).map(function(key) { return key.y }))
+        min = Math.min.apply(Math, axis.series[0].points.filter(x => x !== null).map(function(key) { return key.y }))
+        max = Math.max.apply(Math, axis.series[0].points.filter(x => x !== null).map(function(key) { return key.y }))
       }
 
       if (jeedom.history.chart[_chartId].comparing && axis.series[1]) {
@@ -1696,7 +1696,7 @@ jeedom.history.setAxisScales = function(_chartId, _options) {
     if (Object.keys(units).length == 0) { //no unit
       chart.yAxis.filter(v => v.userOptions.id != 'navigator-y-axis').forEach((axis, index) => {
         if (axis.series.length == 0) return
-        var seriesColor = axis.series[0].color
+        const seriesColor = axis.series[0].color
         axis.update({
           visible: true,
           labels: {
@@ -1707,10 +1707,10 @@ jeedom.history.setAxisScales = function(_chartId, _options) {
         }, false)
       })
     } else { //unit
-      var overUnits = Object.keys(units).filter(key => units[key].axis.length > 1)
+      const overUnits = Object.keys(units).filter(key => units[key].axis.length > 1)
       overUnits.forEach((unit, index) => {
         units[unit].axis.forEach((id, idx) => {
-          var axis = chart.get(id)
+          const axis = chart.get(id)
           if (idx == 0) {
             axis.update({
               visible: true,
@@ -1737,7 +1737,7 @@ jeedom.history.setAxisScales = function(_chartId, _options) {
   if (jeedom.history.chart[_chartId].mode == 'view') {
     if (Object.keys(units).length == 0) { //no unit
       chart.yAxis.filter(v => v.userOptions.id != 'navigator-y-axis').forEach((axis, index) => {
-        var seriesColor = axis.series[0].color
+        const seriesColor = axis.series[0].color
         axis.update({
           labels: {
             style: {
@@ -1771,7 +1771,7 @@ Toggle all yAxis scaling
 */
 jeedom.history.toggleyAxisScaling = function(_chartId) {
   if (jeedom.history.chart[_chartId].zoom) return
-  var chart = jeedom.history.chart[_chartId].chart
+  const chart = jeedom.history.chart[_chartId].chart
 
   jeedom.history.chart[_chartId].yAxisScaling = !jeedom.history.chart[_chartId].yAxisScaling
   if (!jeedom.history.chart[_chartId].yAxisScaling) {
@@ -1786,12 +1786,13 @@ jeedom.history.toggleyAxisScaling = function(_chartId) {
 Set inactive opacity for tracking
 */
 jeedom.history.toggleTracking = function(_chartId) {
-  var chart = jeedom.history.chart[_chartId].chart
+  const chart = jeedom.history.chart[_chartId].chart
+  let opacity
   if (jeedom.history.chart[_chartId].tracking) {
     jeedom.history.chart[_chartId].btTracking.setState(0)
-    var opacity = 1
+    opacity = 1
   } else {
-    var opacity = Highcharts.getOptions().jeedom.opacityLow
+    opacity = Highcharts.getOptions().jeedom.opacityLow
     jeedom.history.chart[_chartId].btTracking.setState(2)
   }
   jeedom.history.chart[_chartId].tracking = !jeedom.history.chart[_chartId].tracking
@@ -1813,7 +1814,7 @@ jeedom.history.toggleTracking = function(_chartId) {
 Toggle all yAxis visibility
 */
 jeedom.history.toggleYaxisVisible = function(_chartId) {
-  var chart = jeedom.history.chart[_chartId].chart
+  const chart = jeedom.history.chart[_chartId].chart
   if (jeedom.history.chart[_chartId].yAxisVisible) {
     jeedom.history.chart[_chartId].btToggleyaxisVisible.setState(0)
   } else {
@@ -1837,7 +1838,7 @@ jeedom.history.emptyChart = function(_chartId, _yAxis) {
   jeedom.history.chart[_chartId].chart.series.forEach(function(series) {
     if (series.options && !isNaN(series.options.id)) {
       if (!series.name.includes('Navigator ')) {
-        var cmd_id = series.options.id
+        const cmd_id = series.options.id
         series.remove(false)
         if (_yAxis) {
           try {
@@ -1852,9 +1853,9 @@ jeedom.history.emptyChart = function(_chartId, _yAxis) {
 
 jeedom.history.setRangeSelectorButtons = function(_chartId) {
   if (_chartId === undefined || jeedom.history.chart[_chartId].chart === undefined || jeedom.history.chart[_chartId].chart.rangeSelector === undefined) return false
-  var chart = jeedom.history.chart[_chartId].chart
-  var min = chart.xAxis[0].dataMin
-  var max = chart.xAxis[0].dataMax
+  const chart = jeedom.history.chart[_chartId].chart
+  const min = chart.xAxis[0].dataMin
+  const max = chart.xAxis[0].dataMax
   chart.rangeSelector.buttonOptions.forEach(function(option, index) {
     if (max - (option._range + min) < 0) {
       chart.rangeSelector.buttons[index].addClass('warning')
@@ -1868,18 +1869,18 @@ jeedom.history.setRangeSelectorButtons = function(_chartId) {
 Handle rangeSelector buttons for dynamic reloading:
 */
 jeedom.history.handleRangeButton = function(_button, _chartId) {
-  var mStart = moment(jeedom.history.chart[_chartId].dateStart, 'YYYY-MM-DD')
-  var mEnd = moment(jeedom.history.chart[_chartId].dateEnd, 'YYYY-MM-DD hh:mm:ss')
-  var mRequestStart = mEnd.clone().subtract(_button.count, _button.type)
+  const mStart = moment(jeedom.history.chart[_chartId].dateStart, 'YYYY-MM-DD')
+  const mEnd = moment(jeedom.history.chart[_chartId].dateEnd, 'YYYY-MM-DD hh:mm:ss')
+  const mRequestStart = mEnd.clone().subtract(_button.count, _button.type)
 
   if (mRequestStart.isBefore(mStart)) {
-    var cmds = jeedom.history.chart[_chartId].cmd
+    const cmds = jeedom.history.chart[_chartId].cmd
 
     //delete all series and their yAxis, then reload them with larger date range and same parameters!
-    var chart = jeedom.history.chart[_chartId].chart
-    var dateEnd = jeedom.history.chart[_chartId].dateEnd
-    var done = 0
-    var cmd_id, cmd_option
+    const chart = jeedom.history.chart[_chartId].chart
+    const dateEnd = jeedom.history.chart[_chartId].dateEnd
+    let done = 0
+    let cmd_id, cmd_option
     jeedom.history.chart[_chartId].chart.series.forEach(function(series) {
       if (series.options && !isNaN(series.options.id)) {
         cmd_id = series.options.id
@@ -1911,7 +1912,7 @@ jeedom.history.handleRangeButton = function(_button, _chartId) {
       }
     })
 
-    var in_startDate = document.getElementById("in_startDate")
+    const in_startDate = document.getElementById("in_startDate")
     if (in_startDate) in_startDate.value = mRequestStart.format('YYYY-MM-DD')
 
     return true

--- a/core/js/plan.class.js
+++ b/core/js/plan.class.js
@@ -18,16 +18,16 @@ jeedom.plan = function() {};
 jeedom.plan.cache = Array();
 
 jeedom.plan.remove = function(_params) {
-  var paramsRequired = [];
-  var paramsSpecifics = {};
+  const paramsRequired = [];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/plan.ajax.php';
   paramsAJAX.data = {
     action: 'remove',
@@ -40,8 +40,8 @@ jeedom.plan.remove = function(_params) {
 }
 
 jeedom.plan.execute = function(_params) {
-  var paramsRequired = ['id'];
-  var paramsSpecifics = {
+  const paramsRequired = ['id'];
+  const paramsSpecifics = {
     global: false
   };
   try {
@@ -50,8 +50,8 @@ jeedom.plan.execute = function(_params) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/plan.ajax.php';
   paramsAJAX.data = {
     action: 'execute',
@@ -61,8 +61,8 @@ jeedom.plan.execute = function(_params) {
 }
 
 jeedom.plan.save = function(_params) {
-  var paramsRequired = ['plans'];
-  var paramsSpecifics = {
+  const paramsRequired = ['plans'];
+  const paramsSpecifics = {
     global: _params.global || true,
   };
   try {
@@ -71,9 +71,9 @@ jeedom.plan.save = function(_params) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
 
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/plan.ajax.php';
   paramsAJAX.data = {
     action: 'save',
@@ -83,16 +83,16 @@ jeedom.plan.save = function(_params) {
 }
 
 jeedom.plan.byId = function(_params) {
-  var paramsRequired = ['id'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['id'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/plan.ajax.php';
   paramsAJAX.data = {
     action: 'get',
@@ -102,16 +102,16 @@ jeedom.plan.byId = function(_params) {
 }
 
 jeedom.plan.getObjectPlan = function(_params) {
-  var paramsRequired = ['id'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['id'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/plan.ajax.php';
   paramsAJAX.data = {
     action: 'getObjectPlan',
@@ -122,16 +122,16 @@ jeedom.plan.getObjectPlan = function(_params) {
 }
 
 jeedom.plan.create = function(_params) {
-  var paramsRequired = ['plan'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['plan'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/plan.ajax.php';
   paramsAJAX.data = {
     action: 'create',
@@ -142,16 +142,16 @@ jeedom.plan.create = function(_params) {
 }
 
 jeedom.plan.copy = function(_params) {
-  var paramsRequired = [];
-  var paramsSpecifics = {};
+  const paramsRequired = [];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/plan.ajax.php';
   paramsAJAX.data = {
     action: 'copy',
@@ -164,16 +164,16 @@ jeedom.plan.copy = function(_params) {
 }
 
 jeedom.plan.byPlanHeader = function(_params) {
-  var paramsRequired = ['id'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['id'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/plan.ajax.php';
   paramsAJAX.data = {
     action: 'planHeader',
@@ -185,16 +185,16 @@ jeedom.plan.byPlanHeader = function(_params) {
 }
 
 jeedom.plan.removeImageHeader = function(_params) {
-  var paramsRequired = ['planHeader_id'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['planHeader_id'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/plan.ajax.php';
   paramsAJAX.data = {
     action: 'removeImageHeader',
@@ -204,16 +204,16 @@ jeedom.plan.removeImageHeader = function(_params) {
 }
 
 jeedom.plan.saveHeader = function(_params) {
-  var paramsRequired = ['planHeader'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['planHeader'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/plan.ajax.php';
   paramsAJAX.data = {
     action: 'savePlanHeader',
@@ -223,16 +223,16 @@ jeedom.plan.saveHeader = function(_params) {
 }
 
 jeedom.plan.copyHeader = function(_params) {
-  var paramsRequired = ['id', 'name'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['id', 'name'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/plan.ajax.php';
   paramsAJAX.data = {
     action: 'copyPlanHeader',
@@ -243,16 +243,16 @@ jeedom.plan.copyHeader = function(_params) {
 }
 
 jeedom.plan.removeHeader = function(_params) {
-  var paramsRequired = ['id'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['id'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/plan.ajax.php';
   paramsAJAX.data = {
     action: 'removePlanHeader',
@@ -262,16 +262,16 @@ jeedom.plan.removeHeader = function(_params) {
 }
 
 jeedom.plan.getHeader = function(_params) {
-  var paramsRequired = ['id'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['id'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/plan.ajax.php';
   paramsAJAX.data = {
     action: 'getPlanHeader',
@@ -282,8 +282,8 @@ jeedom.plan.getHeader = function(_params) {
 }
 
 jeedom.plan.allHeader = function(_params) {
-  var paramsRequired = [];
-  var paramsSpecifics = {
+  const paramsRequired = [];
+  const paramsSpecifics = {
     pre_success: function(data) {
       jeedom.plan.cache.all = data.result;
       return data;
@@ -295,12 +295,12 @@ jeedom.plan.allHeader = function(_params) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
   if (isset(jeedom.plan.cache.all)) {
     params.success(jeedom.plan.cache.all);
     return;
   }
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/plan.ajax.php';
   paramsAJAX.data = {
     action: 'allHeader',

--- a/core/js/plan3d.class.js
+++ b/core/js/plan3d.class.js
@@ -18,16 +18,16 @@ jeedom.plan3d = function() {};
 jeedom.plan3d.cache = Array();
 
 jeedom.plan3d.remove = function(_params) {
-    var paramsRequired = [];
-    var paramsSpecifics = {};
+    const paramsRequired = [];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/plan3d.ajax.php';
     paramsAJAX.data = {
         action: 'remove',
@@ -40,8 +40,8 @@ jeedom.plan3d.remove = function(_params) {
 }
 
 jeedom.plan3d.save = function(_params) {
-    var paramsRequired = ['plan3ds'];
-    var paramsSpecifics = {
+    const paramsRequired = ['plan3ds'];
+    const paramsSpecifics = {
         global: _params.global || true,
     };
     try {
@@ -50,9 +50,9 @@ jeedom.plan3d.save = function(_params) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
 
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/plan3d.ajax.php';
     paramsAJAX.data = {
         action: 'save',
@@ -62,16 +62,16 @@ jeedom.plan3d.save = function(_params) {
 }
 
 jeedom.plan3d.byId = function(_params) {
-    var paramsRequired = ['id'];
-    var paramsSpecifics = {};
+    const paramsRequired = ['id'];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/plan3d.ajax.php';
     paramsAJAX.data = {
         action: 'get',
@@ -81,16 +81,16 @@ jeedom.plan3d.byId = function(_params) {
 }
 
 jeedom.plan3d.byName = function(_params) {
-    var paramsRequired = ['name', 'plan3dHeader_id'];
-    var paramsSpecifics = {};
+    const paramsRequired = ['name', 'plan3dHeader_id'];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/plan3d.ajax.php';
     paramsAJAX.data = {
         action: 'byName',
@@ -101,16 +101,16 @@ jeedom.plan3d.byName = function(_params) {
 }
 
 jeedom.plan3d.byplan3dHeader = function(_params) {
-    var paramsRequired = ['plan3dHeader_id'];
-    var paramsSpecifics = {};
+    const paramsRequired = ['plan3dHeader_id'];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/plan3d.ajax.php';
     paramsAJAX.data = {
         action: 'plan3dHeader',
@@ -120,16 +120,16 @@ jeedom.plan3d.byplan3dHeader = function(_params) {
 }
 
 jeedom.plan3d.saveHeader = function(_params) {
-    var paramsRequired = ['plan3dHeader'];
-    var paramsSpecifics = {};
+    const paramsRequired = ['plan3dHeader'];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/plan3d.ajax.php';
     paramsAJAX.data = {
         action: 'saveplan3dHeader',
@@ -139,16 +139,16 @@ jeedom.plan3d.saveHeader = function(_params) {
 }
 
 jeedom.plan3d.removeHeader = function(_params) {
-    var paramsRequired = ['id'];
-    var paramsSpecifics = {};
+    const paramsRequired = ['id'];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/plan3d.ajax.php';
     paramsAJAX.data = {
         action: 'removeplan3dHeader',
@@ -158,16 +158,16 @@ jeedom.plan3d.removeHeader = function(_params) {
 }
 
 jeedom.plan3d.getHeader = function(_params) {
-    var paramsRequired = ['id'];
-    var paramsSpecifics = {};
+    const paramsRequired = ['id'];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/plan3d.ajax.php';
     paramsAJAX.data = {
         action: 'getplan3dHeader',
@@ -178,8 +178,8 @@ jeedom.plan3d.getHeader = function(_params) {
 }
 
 jeedom.plan3d.allHeader = function(_params) {
-    var paramsRequired = [];
-    var paramsSpecifics = {
+    const paramsRequired = [];
+    const paramsSpecifics = {
         pre_success: function(data) {
             jeedom.plan3d.cache.all = data.result;
             return data;
@@ -191,12 +191,12 @@ jeedom.plan3d.allHeader = function(_params) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
     if (isset(jeedom.plan3d.cache.all)) {
         params.success(jeedom.plan3d.cache.all);
         return;
     }
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/plan3d.ajax.php';
     paramsAJAX.data = {
         action: 'allHeader',

--- a/core/js/plugin.template.js
+++ b/core/js/plugin.template.js
@@ -26,16 +26,16 @@ if (!jeeFrontEnd.pluginTemplate) {
       if (is_numeric(getUrlVars('id'))) {
         jeeFrontEnd.pluginTemplate.displayEqlogic(null, getUrlVars('id'))
       }
-      let returnToThumbnailDisplay = document.querySelector('.eqLogicAction[data-action="returnToThumbnailDisplay"]')
+      const returnToThumbnailDisplay = document.querySelector('.eqLogicAction[data-action="returnToThumbnailDisplay"]')
       if (returnToThumbnailDisplay) {
         returnToThumbnailDisplay.removeAttribute('data-target')
         returnToThumbnailDisplay.removeAttribute('href')
       }
     },
     setTableDisplay: function() {
-      var butDisp = document.getElementById('bt_pluginDisplayAsTable')
+      const butDisp = document.getElementById('bt_pluginDisplayAsTable')
       if (!butDisp) return
-      var coreSupport = butDisp.dataset.coresupport == '1' ? true : false
+      const coreSupport = butDisp.dataset.coresupport == '1' ? true : false
       if (butDisp != null) {
         butDisp.removeClass('hidden') //Not shown on previous core versions
         if (getCookie('jeedom_displayAsTable') == 'true' || jeedom.theme.theme_displayAsTable == 1) {
@@ -108,7 +108,7 @@ if (!jeeFrontEnd.pluginTemplate) {
             printEqLogic(data)
           }
           document.querySelectorAll('.cmd').remove()
-          for (var i in data.cmd) {
+          for (const i in data.cmd) {
             if (data.cmd[i].type == 'info') {
               data.cmd[i].state = String(data.cmd[i].state).replace(/<[^>]*>?/gm, '')
               data.cmd[i]['htmlstate'] = '<span class="cmdTableState"'
@@ -133,7 +133,7 @@ if (!jeeFrontEnd.pluginTemplate) {
           document.querySelectorAll('.cmdTableState').forEach(_cmdState => {
             jeedom.cmd.addUpdateFunction(_cmdState.getAttribute('data-cmd_id'), function(_options) {
               _options.value = String(_options.value).replace(/<[^>]*>?/gm, '')
-              let cmd = document.querySelector('.cmdTableState[data-cmd_id="' + _options.cmd_id + '"]')
+              const cmd = document.querySelector('.cmdTableState[data-cmd_id="' + _options.cmd_id + '"]')
               if (cmd === null) {
                 return
               }
@@ -167,7 +167,7 @@ if (!jeeFrontEnd.pluginTemplate) {
     addCmdToTableDefault: function(_cmd) {
       if (document.getElementById('table_cmd') == null) return
       if (document.querySelector('#table_cmd thead') == null) {
-        table = '<thead>'
+        let table = '<thead>'
         table += '<tr>'
         table += '<th>{{Id}}</th>'
         table += '<th>{{Nom}}</th>'
@@ -184,12 +184,12 @@ if (!jeeFrontEnd.pluginTemplate) {
         document.getElementById('table_cmd').insertAdjacentHTML('beforeend', table)
       }
       if (!isset(_cmd)) {
-        var _cmd = { configuration: {} }
+        _cmd = { configuration: {} }
       }
       if (!isset(_cmd.configuration)) {
         _cmd.configuration = {}
       }
-      var tr = '<tr>'
+      let tr = '<tr>'
       tr += '<td style="min-width:50px;width:70px;">'
       tr += '<span class="cmdAttr" data-l1key="id"></span>'
       tr += '</td>'
@@ -241,7 +241,7 @@ if (!jeeFrontEnd.pluginTemplate) {
       tr += '</td>'
       tr += '</tr>'
 
-      let newRow = document.createElement('tr')
+      const newRow = document.createElement('tr')
       newRow.innerHTML = tr
       newRow.addClass('cmd')
       newRow.setAttribute('data-cmd_id', init(_cmd.id))
@@ -275,9 +275,9 @@ if (!jeeFrontEnd.pluginTemplate) {
               })
             },
             success: function(_data) {
-              var vars = getUrlVars()
-              var url = 'index.php?'
-              for (var i in vars) {
+              const vars = getUrlVars()
+              let url = 'index.php?'
+              for (const i in vars) {
                 if (i != 'id' && i != 'saveSuccessFull' && i != 'removeSuccessFull') {
                   url += i + '=' + vars[i].replace('#', '') + '&'
                 }
@@ -294,10 +294,10 @@ if (!jeeFrontEnd.pluginTemplate) {
     saveEqLogic: function() {
       jeeFrontEnd.modifyWithoutSave = false
       modifyWithoutSave = false
-      var eqLogics = []
+      const eqLogics = []
       document.querySelectorAll('.eqLogic').forEach(_eqLogic => {
         if (_eqLogic.isVisible()) {
-          var eqLogic = _eqLogic.getJeeValues('.eqLogicAttr')[0]
+          let eqLogic = _eqLogic.getJeeValues('.eqLogicAttr')[0]
 
           //No subType will break:
           _eqLogic.querySelectorAll('tr.cmd select[data-l1key="subType"]').forEach(_select => {
@@ -330,15 +330,15 @@ if (!jeeFrontEnd.pluginTemplate) {
         success: function(data) {
           jeeFrontEnd.modifyWithoutSave = false
           modifyWithoutSave = false
-          var vars = getUrlVars()
-          var url = 'index.php?'
-          for (var i in vars) {
+          const vars = getUrlVars()
+          let url = 'index.php?'
+          for (const i in vars) {
             if (i != 'id' && i != 'saveSuccessFull' && i != 'removeSuccessFull') {
               url += i + '=' + vars[i].replace('#', '') + '&'
             }
           }
 
-          var id
+          let id
           if (Array.isArray(data)) {
             id = data[0].id
           } else {
@@ -358,8 +358,8 @@ if (!jeeFrontEnd.pluginTemplate) {
       return false
     },
     copyEqLogic: function() {
-      var name = document.querySelector('.eqLogicAttr[data-l1key="name"]').jeeValue()
-      var id = document.querySelector('.eqLogicAttr[data-l1key="id"]').jeeValue()
+      const name = document.querySelector('.eqLogicAttr[data-l1key="name"]').jeeValue()
+      const id = document.querySelector('.eqLogicAttr[data-l1key="id"]').jeeValue()
       if (id != undefined && id != '') {
         jeeDialog.prompt({
           value: name + ' {{copie}}',
@@ -378,9 +378,9 @@ if (!jeeFrontEnd.pluginTemplate) {
                 success: function(data) {
                   jeeFrontEnd.modifyWithoutSave = false
                   modifyWithoutSave = false
-                  var vars = getUrlVars()
-                  var url = 'index.php?'
-                  for (var i in vars) {
+                  const vars = getUrlVars()
+                  let url = 'index.php?'
+                  for (const i in vars) {
                     if (i != 'id' && i != 'saveSuccessFull' && i != 'removeSuccessFull') {
                       url += i + '=' + vars[i].replace('#', '') + '&'
                     }
@@ -396,10 +396,10 @@ if (!jeeFrontEnd.pluginTemplate) {
       }
     },
     removeEqLogic: function() {
-      var eqLogicId = document.querySelector('.eqLogicAttr[data-l1key="id"]').jeeValue()
+      const eqLogicId = document.querySelector('.eqLogicAttr[data-l1key="id"]').jeeValue()
       if (eqLogicId != undefined) {
-        let thisEqType = document.querySelector('.eqLogicDisplayCard[data-eqlogic_id="' + eqLogicId + '"]')?.getAttribute('data-eqLogic_type')
-        let textEqtype = thisEqType || eqType
+        const thisEqType = document.querySelector('.eqLogicDisplayCard[data-eqlogic_id="' + eqLogicId + '"]')?.getAttribute('data-eqLogic_type')
+        const textEqtype = thisEqType || eqType
         jeedom.eqLogic.getUseBeforeRemove({
           id: eqLogicId,
           error: function(error) {
@@ -409,11 +409,11 @@ if (!jeeFrontEnd.pluginTemplate) {
             })
           },
           success: function(data) {
-            var text = '{{Êtes-vous sûr de vouloir supprimer l\'équipement}} ' + textEqtype + ' <b>' + document.querySelector('.eqLogicAttr[data-l1key="name"]').jeeValue() + '</b> ?'
+            let text = '{{Êtes-vous sûr de vouloir supprimer l\'équipement}} ' + textEqtype + ' <b>' + document.querySelector('.eqLogicAttr[data-l1key="name"]').jeeValue() + '</b> ?'
             if (Object.keys(data).length > 0) {
               text += ' </br> {{Il est utilisé par:}}</br>'
-              var complement = null
-              for (var i in data) {
+              let complement = null
+              for (const i in data) {
                 complement = ''
                 if ('sourceName' in data[i]) {
                   complement = ' (' + data[i].sourceName + ')'
@@ -434,9 +434,9 @@ if (!jeeFrontEnd.pluginTemplate) {
                     })
                   },
                   success: function() {
-                    var vars = getUrlVars()
-                    var url = 'index.php?'
-                    for (var i in vars) {
+                    const vars = getUrlVars()
+                    let url = 'index.php?'
+                    for (const i in vars) {
                       if (i != 'id' && i != 'removeSuccessFull' && i != 'saveSuccessFull') {
                         url += i + '=' + vars[i].replace('#', '') + '&'
                       }
@@ -465,14 +465,14 @@ jeeFrontEnd.pluginTemplate.init()
 
 //searching
 document.getElementById('in_searchEqlogic')?.addEventListener('keyup', function(event) {
-  var search = event.target.value
+  let search = event.target.value
   if (search == '') {
     document.querySelectorAll('.eqLogicDisplayCard').seen()
     return
   }
   document.querySelectorAll('.eqLogicDisplayCard').unseen()
   search = jeedomUtils.normTextLower(search)
-  var text
+  let text
   document.querySelectorAll('.eqLogicDisplayCard .name').forEach(_name => {
     text = jeedomUtils.normTextLower(_name.textContent)
     if (text.includes(search)) {
@@ -487,7 +487,7 @@ domUtils(function() {
     if (typeof Core_noEqContextMenu !== 'undefined') return false
     if (document.querySelector('.nav.nav-tabs') == null) return false
 
-    var pluginId = document.body.getAttribute('data-page') || getUrlVars('p')
+    const pluginId = document.body.getAttribute('data-page') || getUrlVars('p')
     jeedom.eqLogic.byType({
       type: pluginId,
       error: function(error) {
@@ -500,9 +500,9 @@ domUtils(function() {
         if (_eqs.length == 0) {
           return
         }
-        var eqsGroups = []
-        var humanName, humanCut, group, name
-        for (var i = 0; i < _eqs.length; i++) {
+        let eqsGroups = []
+        let humanName, humanCut, group, name
+        for (let i = 0; i < _eqs.length; i++) {
           humanName = _eqs[i].humanName
           humanCut = humanName.split(']')
           group = humanCut[0].substr(1)
@@ -511,11 +511,12 @@ domUtils(function() {
         }
         eqsGroups = Array.from(new Set(eqsGroups))
         eqsGroups.sort()
-        var eqsList = [], group, eqGroup
-        for (var i = 0; i < eqsGroups.length; i++) {
+        const eqsList = []
+        let eqGroup
+        for (let i = 0; i < eqsGroups.length; i++) {
           group = eqsGroups[i]
           eqsList[group] = []
-          for (var j = 0; j < _eqs.length; j++) {
+          for (let j = 0; j < _eqs.length; j++) {
             humanName = _eqs[j].humanName
             humanCut = humanName.split(']')
             eqGroup = humanCut[0].substr(1)
@@ -525,12 +526,12 @@ domUtils(function() {
           }
         }
         //set context menu!
-        var contextmenuitems = {}
-        var uniqId = 0, groupEq, items
-        for (var group in eqsList) {
+        const contextmenuitems = {}
+        let uniqId = 0, groupEq, items
+        for (const group in eqsList) {
           groupEq = eqsList[group]
           items = {}
-          for (var index in groupEq) {
+          for (const index in groupEq) {
             items[uniqId] = {
               'name': groupEq[index][0],
               'id': groupEq[index][1]
@@ -561,8 +562,8 @@ domUtils(function() {
                 }
                 jeedomUtils.hideAlert()
                 if (event.ctrlKey || event.which == 2) {
-                  var type = document.body.getAttribute('data-page')
-                  var url = 'index.php?v=d&m=' + type + '&p=' + type + '&id=' + options.commands[key].id
+                  const type = document.body.getAttribute('data-page')
+                  let url = 'index.php?v=d&m=' + type + '&p=' + type + '&id=' + options.commands[key].id
                   if (tabObj) url += tab
                   window.open(url).focus()
                 } else {
@@ -587,7 +588,7 @@ domUtils(function() {
     $("#table_cmd").sortable("destroy")
   }
 
-  var tableCmd = document.getElementById('table_cmd')
+  const tableCmd = document.getElementById('table_cmd')
   if (!tableCmd) return
   jeeFrontEnd.pluginTemplate.cmdSortable = Sortable.create(tableCmd.tBodies[0], {
     delay: 100,
@@ -612,7 +613,7 @@ document.registerEvent('keydown', function(event) {
   if (jeedomUtils.getOpenedModal()) return
   if ((event.ctrlKey || event.metaKey) && event.which == 83) { //s
     event.preventDefault()
-    let bt = document.querySelector('.eqLogicAction[data-action="save"]')
+    const bt = document.querySelector('.eqLogicAction[data-action="save"]')
     if (bt != null && bt.isVisible()) {
       jeeFrontEnd.pluginTemplate.saveEqLogic()
     }
@@ -623,7 +624,7 @@ document.registerEvent('keydown', function(event) {
 /*Events delegations
 */
 document.getElementById('div_pageContainer').addEventListener('click', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('#bt_resetSearch')) {
     document.getElementById('in_searchEqlogic').jeeValue('').triggerEvent('keyup')
     return
@@ -641,7 +642,7 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
 
   if (_target = event.target.closest('.eqLogicAction[data-action="returnToThumbnailDisplay"]')) {
     setTimeout(function() {
-      let id = document.querySelector('.tab-pane.active')?.getAttribute('id')
+      const id = document.querySelector('.tab-pane.active')?.getAttribute('id')
       document.querySelectorAll('.nav li.active').removeClass('active')
       document.querySelector('a[data-target="#' + id + '"]')?.closest('li').addClass('active')
     }, 500)
@@ -656,12 +657,12 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
 
   if (_target = event.target.closest('.eqLogicDisplayCard')) {
     jeedomUtils.hideAlert()
-    let type = document.body.getAttribute('data-page')
-    let thisEqId = _target.getAttribute('data-eqlogic_id')
+    const type = document.body.getAttribute('data-page')
+    const thisEqId = _target.getAttribute('data-eqlogic_id')
     if ((isset(event.detail) && event.detail.ctrlKey) || event.ctrlKey || event.metaKey) {
       window.open('index.php?v=d&m=' + type + '&p=' + type + '&id=' + thisEqId).focus()
     } else {
-      let thisEqType = _target.getAttribute('data-eqLogic_type')
+      const thisEqType = _target.getAttribute('data-eqLogic_type')
       jeeFrontEnd.pluginTemplate.displayEqlogic(thisEqType, thisEqId)
     }
     return
@@ -718,9 +719,9 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
   }
 
   if (_target = event.target.closest('.cmd .cmdAction[data-l1key="chooseIcon"]')) {
-    let cmd = _target.closest('.cmd')
-    let icon = cmd.querySelector('[data-l2key="icon"] > i')
-    let params = {}
+    const cmd = _target.closest('.cmd')
+    const icon = cmd.querySelector('[data-l2key="icon"] > i')
+    const params = {}
     if (icon) params.icon = icon.attributes.class.value
     jeedomUtils.chooseIcon(function(_icon) {
       cmd.querySelector('.cmdAttr[data-l1key="display"][data-l2key="icon"]').empty().innerHTML = _icon
@@ -738,7 +739,7 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
   }
 
   if (_target = event.target.closest('.cmd .cmdAction[data-action="copy"]')) {
-    let cmd = _target.closest('.cmd').getJeeValues('.cmdAttr')[0]
+    const cmd = _target.closest('.cmd').getJeeValues('.cmdAttr')[0]
     cmd.id = ''
     if (typeof addCmdToTable === 'function') {
       addCmdToTable(cmd)
@@ -778,11 +779,11 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
 
 
 document.getElementById('div_pageContainer').addEventListener('mouseup', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('.eqLogicDisplayCard')) {
     if (event.which == 2) {
       event.preventDefault()
-      let id = _target.getAttribute('data-eqlogic_id')
+      const id = _target.getAttribute('data-eqlogic_id')
       document.querySelector('.eqLogicDisplayCard[data-eqlogic_id="' + id + '"]')?.triggerEvent('click', { detail: { ctrlKey: true } })
     }
     return
@@ -790,7 +791,7 @@ document.getElementById('div_pageContainer').addEventListener('mouseup', functio
 })
 
 document.getElementById('div_pageContainer').addEventListener('dblclick', function(event) {
-  var _target = null
+  let _target = null
   if (event.target.matches('.cmd input, textarea, select, span, a')) {
     event.stopPropagation()
     return
@@ -814,7 +815,7 @@ document.getElementById('div_pageContainer').addEventListener('dblclick', functi
 })
 
 document.getElementById('div_pageContainer').addEventListener('change', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('.eqLogic .eqLogicAttr')) {
     if (_target.isVisible()) {
       jeeFrontEnd.modifyWithoutSave = true

--- a/core/js/timeline.class.js
+++ b/core/js/timeline.class.js
@@ -17,16 +17,16 @@
 jeedom.timeline = function() {};
 
 jeedom.timeline.getLength = function(_params) {
-  var paramsRequired = [];
-  var paramsSpecifics = {};
+  const paramsRequired = [];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/timeline.ajax.php';
   paramsAJAX.data = {
     action: 'getLength',
@@ -36,16 +36,16 @@ jeedom.timeline.getLength = function(_params) {
 }
 
 jeedom.timeline.byFolder = function(_params) {
-  var paramsRequired = [];
-  var paramsSpecifics = {};
+  const paramsRequired = [];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/timeline.ajax.php';
   paramsAJAX.data = {
     action: 'byFolder',
@@ -57,16 +57,16 @@ jeedom.timeline.byFolder = function(_params) {
 }
 
 jeedom.timeline.deleteAll = function(_params) {
-  var paramsRequired = [];
-  var paramsSpecifics = {};
+  const paramsRequired = [];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/timeline.ajax.php';
   paramsAJAX.data = {
     action: 'deleteAll'
@@ -75,16 +75,16 @@ jeedom.timeline.deleteAll = function(_params) {
 }
 
 jeedom.timeline.listFolder = function(_params) {
-  var paramsRequired = [];
-  var paramsSpecifics = {};
+  const paramsRequired = [];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/timeline.ajax.php';
   paramsAJAX.data = {
     action: 'listFolder'
@@ -93,16 +93,16 @@ jeedom.timeline.listFolder = function(_params) {
 }
 
 jeedom.timeline.removeEventInFutur = function(_params) {
-  var paramsRequired = []
-  var paramsSpecifics = {}
+  const paramsRequired = []
+  const paramsSpecifics = {}
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
     return
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  var paramsAJAX = jeedom.private.getParamsAJAX(params)
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
   paramsAJAX.url = 'core/ajax/timeline.ajax.php'
   paramsAJAX.data = {
     action: 'removeEventInFutur'
@@ -114,8 +114,8 @@ jeedom.timeline.autocompleteFolder = function() {
   jeedom.timeline.listFolder({
     global: false,
     success: function(data) {
-      var availableTags = []
-      for (var i in data) {
+      const availableTags = []
+      for (const i in data) {
         if (data[i] != 'main') {
           availableTags.push(data[i])
         }
@@ -130,16 +130,16 @@ jeedom.timeline.autocompleteFolder = function() {
           },
           select: function(event, data) {
             //Ensure timeline folders comma sperated:
-            var inputValue = data.item.value
-            var term = data.value
+            let inputValue = data.item.value
+            const term = data.value
             if (inputValue.includes(' ')) {
-              var values = inputValue.split(' ')
+              const values = inputValue.split(' ')
               values.pop()
               inputValue = values.join(',') + ',' + data.value
             }
-            var values = inputValue.split(',')
+            const values = inputValue.split(',')
             values.pop()
-            var newValue = values.join(',') + ',' + data.value
+            let newValue = values.join(',') + ',' + data.value
             if (newValue.substring(0, 1) == ',') newValue = newValue.substr(1)
 
             data.item.value = newValue

--- a/core/js/view.class.js
+++ b/core/js/view.class.js
@@ -18,8 +18,8 @@ jeedom.view = function() {};
 jeedom.view.cache = Array();
 
 jeedom.view.all = function(_params) {
-  var paramsRequired = [];
-  var paramsSpecifics = {
+  const paramsRequired = [];
+  const paramsSpecifics = {
     pre_success: function(data) {
       jeedom.view.cache.all = data.result;
       return data;
@@ -35,8 +35,8 @@ jeedom.view.all = function(_params) {
     _params.success(jeedom.view.cache.all);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/view.ajax.php';
   paramsAJAX.data = {
     action: 'all',
@@ -45,10 +45,10 @@ jeedom.view.all = function(_params) {
 }
 
 jeedom.view.toHtml = function(_params) {
-  var paramsRequired = ['id', 'version'];
-  var paramsSpecifics = {
+  const paramsRequired = ['id', 'version'];
+  const paramsSpecifics = {
     pre_success: function(data) {
-      result = jeedom.view.handleViewAjax({
+      const result = jeedom.view.handleViewAjax({
         view: data.result
       });
       result.raw = data.result;
@@ -62,8 +62,8 @@ jeedom.view.toHtml = function(_params) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/view.ajax.php';
   paramsAJAX.data = {
     action: "get",
@@ -75,16 +75,16 @@ jeedom.view.toHtml = function(_params) {
 }
 
 jeedom.view.copy = function(_params) {
-  var paramsRequired = ['id', 'name'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['id', 'name'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/view.ajax.php';
   paramsAJAX.data = {
     action: 'copy',
@@ -95,19 +95,19 @@ jeedom.view.copy = function(_params) {
 }
 
 jeedom.view.handleViewAjax = function(_params) {
-  var result = {
+  const result = {
     html: '',
     scenario: [],
     cmd: [],
     eqLogic: []
   };
-  var colIdx = 0
-  var viewZone = null;
-  var div_class = null;
-  var div_id = null;
-  var viewData = null;
-  var configuration = null;
-  for (var i in _params.view.viewZone) {
+  let colIdx = 0
+  let viewZone = null;
+  let div_class = null;
+  let div_id = null;
+  let viewData = null;
+  let configuration = null;
+  for (const i in _params.view.viewZone) {
     viewZone = _params.view.viewZone[i];
     if (colIdx == 0) result.html += '<div class="col-xs-12 div_rowZones">';
     div_class = 'div_viewZone ';
@@ -123,7 +123,7 @@ jeedom.view.handleViewAjax = function(_params) {
     /*         * *****************viewZone widget***************** */
     if (viewZone.type == 'widget') {
       result.html += '<div id="' + div_id + '" class="eqLogicZone posEqWidthRef" data-viewZone-id="' + viewZone.id + '">';
-      for (var j in viewZone.viewData) {
+      for (const j in viewZone.viewData) {
         viewData = viewZone.viewData[j];
         result.html += viewData.html;
         result[viewData.type].push(viewData.id);
@@ -132,10 +132,10 @@ jeedom.view.handleViewAjax = function(_params) {
     } else if (viewZone.type == 'graph') {
       result.html += '<div id="' + div_id + '" class="chartContainer"></div>';
       result.html += '<div class="chartToDraw">';
-      for (var j in viewZone.viewData) {
+      for (const j in viewZone.viewData) {
         viewData = viewZone.viewData[j];
         configuration = JSON.stringify(viewData.configuration);
-        option = configuration.replace(/"/g, "'");
+        const option = configuration.replace(/"/g, "'");
         result.html += '<div class="viewZoneData hidden" data-cmdId="'+viewData.link_id+'" data-option="'+option+'" data-el="'+div_id+'" data-height="'+viewZone.configuration.height+'" data-dateRange="'+viewZone.configuration.dateRange+'"></div>';
       }
       result.html += '</div>';
@@ -152,16 +152,16 @@ jeedom.view.handleViewAjax = function(_params) {
 }
 
 jeedom.view.remove = function(_params) {
-  var paramsRequired = ['id'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['id'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/view.ajax.php';
   paramsAJAX.data = {
     action: 'remove',
@@ -171,16 +171,16 @@ jeedom.view.remove = function(_params) {
 }
 
 jeedom.view.save = function(_params) {
-  var paramsRequired = ['id', 'view'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['id', 'view'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/view.ajax.php';
   paramsAJAX.data = {
     action: 'save',
@@ -191,16 +191,16 @@ jeedom.view.save = function(_params) {
 }
 
 jeedom.view.get = function(_params) {
-  var paramsRequired = ['id'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['id'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/view.ajax.php';
   paramsAJAX.data = {
     action: 'get',
@@ -210,16 +210,16 @@ jeedom.view.get = function(_params) {
 }
 
 jeedom.view.setComponentOrder = function(_params) {
-  var paramsRequired = ['components'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['components'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/view.ajax.php';
   paramsAJAX.data = {
     action: 'setComponentOrder',
@@ -229,16 +229,16 @@ jeedom.view.setComponentOrder = function(_params) {
 }
 
 jeedom.view.setOrder = function(_params) {
-  var paramsRequired = ['views'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['views'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/view.ajax.php';
   paramsAJAX.data = {
     action: 'setOrder',
@@ -248,16 +248,16 @@ jeedom.view.setOrder = function(_params) {
 }
 
 jeedom.view.removeImage = function(_params) {
-  var paramsRequired = ['id'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['id'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/view.ajax.php';
   paramsAJAX.data = {
     action: 'removeImage',

--- a/core/js/widgets.class.js
+++ b/core/js/widgets.class.js
@@ -17,16 +17,16 @@
 jeedom.widgets = function() {};
 
 jeedom.widgets.remove = function(_params) {
-  var paramsRequired = ['id'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['id'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/widgets.ajax.php';
   paramsAJAX.data = {
     action: "remove",
@@ -36,16 +36,16 @@ jeedom.widgets.remove = function(_params) {
 }
 
 jeedom.widgets.byId = function(_params) {
-  var paramsRequired = ['id'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['id'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/widgets.ajax.php';
   paramsAJAX.data = {
     action: "byId",
@@ -55,16 +55,16 @@ jeedom.widgets.byId = function(_params) {
 }
 
 jeedom.widgets.save = function(_params) {
-  var paramsRequired = ['widgets'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['widgets'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/widgets.ajax.php';
   paramsAJAX.data = {
     action: 'save',
@@ -74,16 +74,16 @@ jeedom.widgets.save = function(_params) {
 }
 
 jeedom.widgets.all = function(_params) {
-  var paramsRequired = [];
-  var paramsSpecifics = {};
+  const paramsRequired = [];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/widgets.ajax.php';
   paramsAJAX.data = {
     action: 'all'
@@ -92,16 +92,16 @@ jeedom.widgets.all = function(_params) {
 }
 
 jeedom.widgets.getTemplateConfiguration = function(_params) {
-  var paramsRequired = ['template'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['template'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/widgets.ajax.php';
   paramsAJAX.data = {
     action: 'getTemplateConfiguration',
@@ -111,16 +111,16 @@ jeedom.widgets.getTemplateConfiguration = function(_params) {
 }
 
 jeedom.widgets.getPreview = function(_params) {
-  var paramsRequired = ['id'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['id'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/widgets.ajax.php';
   paramsAJAX.data = {
     action: "getPreview",
@@ -130,16 +130,16 @@ jeedom.widgets.getPreview = function(_params) {
 }
 
 jeedom.widgets.replacement = function(_params) {
-  var paramsRequired = ['version', 'replace', 'by'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['version', 'replace', 'by'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/widgets.ajax.php';
   paramsAJAX.data = {
     action: "replacement",


### PR DESCRIPTION
## Summary

Third of four migration PRs splitting #3297 by functional domain. This batch covers **7 files handling UI rendering** (views, plans, timeline, history charts, widgets, plugin templates):

```
view.class.js    plan.class.js     plan3d.class.js
timeline.class.js   history.class.js     widgets.class.js
plugin.template.js
```

## Incidental fixes (caught during migration)

- **`history.class.js`** — `var series` was declared in two mutually-exclusive `if/else` blocks (`if (data.result.timelineOnly) { var series = {...} } else { var series = {...} }`) but referenced in code located after the block (in `addSeries(series)` calls, in chart config object, etc.). With `var`, function-scoped hoisting unified the two declarations and made the reference work. Migrated to `const`/`let`, it became block-scoped and threw `ReferenceError: series is not defined`. Fix: hoisted to a single `let series` declared before the `if/else`, with assignments in each branch.
- **`plugin.template.js`** — `const eqLogic` at line 300 was reassigned at line 311 by `eqLogic = saveEqLogic(eqLogic)`. Changed to `let eqLogic` to avoid `TypeError: Assignment to constant variable` on equipment save flow.

## Test plan

- [ ] Open the History page and select a command — verify charts render
- [ ] Toggle the History 'compare' mode — verify both series render correctly (this is the path that exercises the `series` hoist fix)
- [ ] Open a View page that contains a graph zone — verify rendering and `data-option` attributes are populated
- [ ] Open a 2D Plan and a 3D Plan if you have them — verify display
- [ ] Open the Timeline page — verify timeline renders
- [ ] Open a plugin equipment, modify a setting, click 'Sauvegarder' — verify save flow (this is the path that exercises the `eqLogic` const→let fix)

Part of the split following #3297 discussion.