### PR TITLE
Refactor var to const/let in admin/system + log search multi-term (4/4)

### DIFF
--- a/core/js/appMobile.class.js
+++ b/core/js/appMobile.class.js
@@ -24,7 +24,7 @@ jeedom.appMobile.detected = function() {
 }
 
 jeedom.appMobile.postToApp = function (_action, _options = {}) {
-  let message = {}
+  const message = {}
   if (window.ReactNativeWebView != undefined) {
     message.action = _action
     message.options = _options

--- a/core/js/backup.class.js
+++ b/core/js/backup.class.js
@@ -17,16 +17,16 @@
 jeedom.backup = function() {};
 
 jeedom.backup.backup = function(_params) {
-    var paramsRequired = [];
-    var paramsSpecifics = {};
+    const paramsRequired = [];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/jeedom.ajax.php';
     paramsAJAX.data = {
         action: 'backup',
@@ -35,16 +35,16 @@ jeedom.backup.backup = function(_params) {
 }
 
 jeedom.backup.restoreLocal = function(_params) {
-    var paramsRequired = [];
-    var paramsSpecifics = {};
+    const paramsRequired = [];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/jeedom.ajax.php';
     paramsAJAX.data = {
         action: 'restore',
@@ -54,16 +54,16 @@ jeedom.backup.restoreLocal = function(_params) {
 }
 
 jeedom.backup.remove = function(_params) {
-    var paramsRequired = ['backup'];
-    var paramsSpecifics = {};
+    const paramsRequired = ['backup'];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/jeedom.ajax.php';
     paramsAJAX.data = {
         action: 'removeBackup',
@@ -73,16 +73,16 @@ jeedom.backup.remove = function(_params) {
 }
 
 jeedom.backup.uploadCloud = function(_params) {
-    var paramsRequired = ['backup'];
-    var paramsSpecifics = {};
+    const paramsRequired = ['backup'];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/repo.ajax.php';
     paramsAJAX.data = {
         action: 'uploadCloud',
@@ -92,16 +92,16 @@ jeedom.backup.uploadCloud = function(_params) {
 }
 
 jeedom.backup.restoreCloud = function(_params) {
-    var paramsRequired = ['backup', 'repo'];
-    var paramsSpecifics = {};
+    const paramsRequired = ['backup', 'repo'];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/repo.ajax.php';
     paramsAJAX.data = {
         action: 'restoreCloud',
@@ -112,16 +112,16 @@ jeedom.backup.restoreCloud = function(_params) {
 }
 
 jeedom.backup.list = function(_params) {
-    var paramsRequired = [];
-    var paramsSpecifics = {};
+    const paramsRequired = [];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/jeedom.ajax.php';
     paramsAJAX.data = {
         action: 'listBackup',

--- a/core/js/config.class.js
+++ b/core/js/config.class.js
@@ -109,16 +109,16 @@ jeedom.config.locales = {
 }
 
 jeedom.config.save = function(_params) {
-    var paramsRequired = ['configuration'];
-    var paramsSpecifics = {};
+    const paramsRequired = ['configuration'];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/config.ajax.php';
     paramsAJAX.data = {
         action: 'addKey',
@@ -129,8 +129,8 @@ jeedom.config.save = function(_params) {
 }
 
 jeedom.config.load = function(_params) {
-    var paramsRequired = ['configuration'];
-    var paramsSpecifics = {
+    const paramsRequired = ['configuration'];
+    const paramsSpecifics = {
         global: _params.global || true
     };
     try {
@@ -139,8 +139,8 @@ jeedom.config.load = function(_params) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/config.ajax.php';
     paramsAJAX.data = {
         action: 'getKey',
@@ -152,16 +152,16 @@ jeedom.config.load = function(_params) {
 }
 
 jeedom.config.remove = function(_params) {
-    var paramsRequired = ['configuration'];
-    var paramsSpecifics = {};
+    const paramsRequired = ['configuration'];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/config.ajax.php';
     paramsAJAX.data = {
         action: 'removeKey',
@@ -172,16 +172,16 @@ jeedom.config.remove = function(_params) {
 }
 
 jeedom.config.removeImage = function(_params) {
-    var paramsRequired = ['id'];
-    var paramsSpecifics = {};
+    const paramsRequired = ['id'];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/config.ajax.php';
     paramsAJAX.data = {
         action: 'removeImage',
@@ -197,7 +197,7 @@ jeedom.config.getGenericTypeModal = function(_options, callback) {
     if (!isset(_options.type)) {
         _options.type = 'info'
     }
-    var url = 'index.php?v=d&modal=genericType.human.insert&type=' + _options.type
+    let url = 'index.php?v=d&modal=genericType.human.insert&type=' + _options.type
     if (_options.object) url += '&object=' + _options.object
 
     document.getElementById('mod_insertGenericType')?.remove()
@@ -216,7 +216,7 @@ jeedom.config.getGenericTypeModal = function(_options, callback) {
             className: 'success',
             callback: {
               click: function(event) {
-                var args = {}
+                const args = {}
                 args.human = mod_insertGenericType.getValue()
                 args.id = mod_insertGenericType.getId()
                 if (args.human.trim() != '') {

--- a/core/js/cron.class.js
+++ b/core/js/cron.class.js
@@ -17,16 +17,16 @@
 jeedom.cron = function() {};
 
 jeedom.cron.setState = function(_params) {
-    var paramsRequired = ['id', 'state'];
-    var paramsSpecifics = {};
+    const paramsRequired = ['id', 'state'];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/cron.ajax.php';
     paramsAJAX.data = {
         action: _params.state,
@@ -36,16 +36,16 @@ jeedom.cron.setState = function(_params) {
 }
 
 jeedom.cron.all = function(_params) {
-    var paramsRequired = [];
-    var paramsSpecifics = {};
+    const paramsRequired = [];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/cron.ajax.php';
     paramsAJAX.data = {
         action: 'all'
@@ -54,16 +54,16 @@ jeedom.cron.all = function(_params) {
 }
 
 jeedom.cron.save = function(_params) {
-    var paramsRequired = ['crons'];
-    var paramsSpecifics = {};
+    const paramsRequired = ['crons'];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/cron.ajax.php';
     paramsAJAX.data = {
         action: 'save',

--- a/core/js/interact.class.js
+++ b/core/js/interact.class.js
@@ -17,16 +17,16 @@
 jeedom.interact = function() {};
 
 jeedom.interact.all = function(_params) {
-  var paramsRequired = [];
-  var paramsSpecifics = {};
+  const paramsRequired = [];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/interact.ajax.php';
   paramsAJAX.data = {
     action: "all",
@@ -35,16 +35,16 @@ jeedom.interact.all = function(_params) {
 }
 
 jeedom.interact.remove = function(_params) {
-  var paramsRequired = ['id'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['id'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/interact.ajax.php';
   paramsAJAX.data = {
     action: "remove",
@@ -54,16 +54,16 @@ jeedom.interact.remove = function(_params) {
 }
 
 jeedom.interact.get = function(_params) {
-  var paramsRequired = ['id'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['id'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/interact.ajax.php';
   paramsAJAX.data = {
     action: "byId",
@@ -73,16 +73,16 @@ jeedom.interact.get = function(_params) {
 }
 
 jeedom.interact.save = function(_params) {
-  var paramsRequired = ['interact'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['interact'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/interact.ajax.php';
   paramsAJAX.data = {
     action: 'save',
@@ -92,16 +92,16 @@ jeedom.interact.save = function(_params) {
 }
 
 jeedom.interact.regenerateInteract = function(_params) {
-  var paramsRequired = [];
-  var paramsSpecifics = {};
+  const paramsRequired = [];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/interact.ajax.php';
   paramsAJAX.data = {
     action: 'regenerateInteract',
@@ -110,16 +110,16 @@ jeedom.interact.regenerateInteract = function(_params) {
 }
 
 jeedom.interact.execute = function(_params) {
-  var paramsRequired = ['query'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['query'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/interact.ajax.php';
   paramsAJAX.data = {
     action: 'execute',

--- a/core/js/log.class.js
+++ b/core/js/log.class.js
@@ -21,8 +21,8 @@ jeedom.log.coloredThreshold = 300000
 jeedom.log.maxLines = 4000
 
 jeedom.log.list = function(_params) {
-  var paramsRequired = [];
-  var paramsSpecifics = {
+  const paramsRequired = [];
+  const paramsSpecifics = {
     global: _params.global || true,
   };
   try {
@@ -31,8 +31,8 @@ jeedom.log.list = function(_params) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/log.ajax.php';
   paramsAJAX.data = {
     action: 'list',
@@ -41,8 +41,8 @@ jeedom.log.list = function(_params) {
 }
 
 jeedom.log.removeAll = function(_params) {
-  var paramsRequired = [];
-  var paramsSpecifics = {
+  const paramsRequired = [];
+  const paramsSpecifics = {
     global: _params.global || true,
   };
   try {
@@ -51,8 +51,8 @@ jeedom.log.removeAll = function(_params) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/log.ajax.php';
   paramsAJAX.data = {
     action: 'removeAll',
@@ -63,9 +63,9 @@ jeedom.log.removeAll = function(_params) {
 // DEPRECATED: jeedom.log.getScTranslations -> remove in 4.6?
 jeedom.log.getScTranslations = function(_params) {
   jeedomUtils.deprecatedFunc('jeedom.log.getScTranslations', 'none', '4.6', '4.4')
-  var paramsSpecifics = {};
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const paramsSpecifics = {};
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/log.ajax.php';
   paramsAJAX.data = {
     action: 'getScTranslations'
@@ -76,8 +76,8 @@ jeedom.log.getScTranslations = function(_params) {
 // DEPRECATED: jeedom.log.get -> remove in 4.6?
 jeedom.log.get = function(_params) {
   jeedomUtils.deprecatedFunc('jeedom.log.get', 'jeedom.log.getDelta', '4.6', '4.4')
-  var paramsRequired = ['log'];
-  var paramsSpecifics = {
+  const paramsRequired = ['log'];
+  const paramsSpecifics = {
     global: _params.global || true,
   };
   try {
@@ -86,8 +86,8 @@ jeedom.log.get = function(_params) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/log.ajax.php';
   paramsAJAX.data = {
     action: 'get',
@@ -97,8 +97,8 @@ jeedom.log.get = function(_params) {
 }
 
 jeedom.log.getDelta = function(_params) {
-  var paramsRequired = ['log', 'position'];
-  var paramsSpecifics = {
+  const paramsRequired = ['log', 'position'];
+  const paramsSpecifics = {
     global: _params.global || true,
   };
   try {
@@ -107,8 +107,8 @@ jeedom.log.getDelta = function(_params) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/log.ajax.php';
   paramsAJAX.data = {
     action: 'getDelta',
@@ -123,8 +123,8 @@ jeedom.log.getDelta = function(_params) {
 }
 
 jeedom.log.remove = function(_params) {
-  var paramsRequired = ['log'];
-  var paramsSpecifics = {
+  const paramsRequired = ['log'];
+  const paramsSpecifics = {
     global: _params.global || true,
   };
   try {
@@ -133,8 +133,8 @@ jeedom.log.remove = function(_params) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/log.ajax.php';
   paramsAJAX.data = {
     action: 'remove',
@@ -144,8 +144,8 @@ jeedom.log.remove = function(_params) {
 }
 
 jeedom.log.clearAll = function(_params) {
-  var paramsRequired = [];
-  var paramsSpecifics = {
+  const paramsRequired = [];
+  const paramsSpecifics = {
     global: _params.global || true,
   };
   try {
@@ -154,8 +154,8 @@ jeedom.log.clearAll = function(_params) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/log.ajax.php';
   paramsAJAX.data = {
     action: 'clearAll',
@@ -164,8 +164,8 @@ jeedom.log.clearAll = function(_params) {
 }
 
 jeedom.log.clear = function(_params) {
-  var paramsRequired = ['log'];
-  var paramsSpecifics = {
+  const paramsRequired = ['log'];
+  const paramsSpecifics = {
     global: _params.global || true,
   };
   try {
@@ -174,8 +174,8 @@ jeedom.log.clear = function(_params) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/log.ajax.php';
   paramsAJAX.data = {
     action: 'clear',
@@ -258,14 +258,14 @@ jeedom.log.autoupdate = function(_params) {
     slaveId: _params.slaveId,
     global: (_params.callNumber == 1),
     success: function(result) {
-      var log = ''
-      var line
-      var isSysLog = (_params.display.id == 'pre_globallog') ? true : false
-      var isScenaroLog = (_params.display.id == 'pre_scenariolog') ? true : false
+      let log = ''
+      let line
+      const isSysLog = (_params.display.id == 'pre_globallog') ? true : false
+      const isScenaroLog = (_params.display.id == 'pre_scenariolog') ? true : false
 
       if (is_array(result)) {
         //line by line, numbered for system log:
-        for (var i in result.reverse()) {
+        for (const i in result.reverse()) {
           if (!isset(_params.search) || _params.search.value == '' || result[i].toLowerCase().indexOf(_params['search'].value.toLowerCase()) != -1) {
             line = result[i].trim()
             if (isSysLog) {
@@ -277,17 +277,17 @@ jeedom.log.autoupdate = function(_params) {
         }
       }
 
-      var colorMe = false
-      var dom_brutlogcheck = document.getElementById('brutlogcheck')
+      let colorMe = false
+      let isAuto = false
+      let dom_brutlogcheck = document.getElementById('brutlogcheck')
       if (dom_brutlogcheck == null) {
-        var isAuto = false
         dom_brutlogcheck = {
           checked: false
         }
       } else {
-        var isAuto = (dom_brutlogcheck.getAttribute('autoswitch') == 1) ? true : false
+        isAuto = (dom_brutlogcheck.getAttribute('autoswitch') == 1) ? true : false
       }
-      var isLong = (log.length > jeedom.log.coloredThreshold) ? true : false
+      const isLong = (log.length > jeedom.log.coloredThreshold) ? true : false
 
       if (!dom_brutlogcheck.checked && !isLong) {
         colorMe = true
@@ -438,9 +438,9 @@ jeedom.log.autoUpdateDelta = function(_params) {
     return
   }
 
-  let dom_brutlogcheck = document.getElementById('brutlogcheck')
+  const dom_brutlogcheck = document.getElementById('brutlogcheck')
   // If element does NOT exists OR is disabled, Then colored
-  let colorMe = dom_brutlogcheck == null || !dom_brutlogcheck.checked
+  const colorMe = dom_brutlogcheck == null || !dom_brutlogcheck.checked
 
   jeedom.log.getDelta({
     log: _params.log,
@@ -505,7 +505,7 @@ jeedom.log.colorReplacement = {
 // DEPRECATED: jeedom.log.stringColorReplace -> remove in 4.6?
 jeedom.log.stringColorReplace = function(_str) {
   jeedomUtils.deprecatedFunc('jeedom.log.stringColorReplace', 'none', '4.6', '4.4')
-  for (var re in jeedom.log.colorReplacement) {
+  for (const re in jeedom.log.colorReplacement) {
     _str = _str.split(re).join(jeedom.log.colorReplacement[re])
   }
   //Avoid html code:
@@ -544,7 +544,7 @@ jeedom.log.scenarioColorReplace = function(_str) {
 
   }
   if (jeedom.log.colorScReplacement == null) return _str
-  for (var item in jeedom.log.colorScReplacement) {
+  for (const item in jeedom.log.colorScReplacement) {
     _str = _str.split(jeedom.log.colorScReplacement[item]['txt']).join(jeedom.log.colorScReplacement[item]['replace'].replace('::', jeedom.log.colorScReplacement[item]['txt']))
   }
   return _str

--- a/core/js/note.class.js
+++ b/core/js/note.class.js
@@ -17,16 +17,16 @@
 jeedom.note = function() {};
 
 jeedom.note.remove = function(_params) {
-    var paramsRequired = ['id'];
-    var paramsSpecifics = {};
+    const paramsRequired = ['id'];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/note.ajax.php';
     paramsAJAX.data = {
         action: "remove",
@@ -36,16 +36,16 @@ jeedom.note.remove = function(_params) {
 }
 
 jeedom.note.byId = function(_params) {
-    var paramsRequired = ['id'];
-    var paramsSpecifics = {};
+    const paramsRequired = ['id'];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/note.ajax.php';
     paramsAJAX.data = {
         action: "byId",
@@ -55,16 +55,16 @@ jeedom.note.byId = function(_params) {
 }
 
 jeedom.note.save = function(_params) {
-    var paramsRequired = ['note'];
-    var paramsSpecifics = {};
+    const paramsRequired = ['note'];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/note.ajax.php';
     paramsAJAX.data = {
         action: 'save',
@@ -74,16 +74,16 @@ jeedom.note.save = function(_params) {
 }
 
 jeedom.note.all = function(_params) {
-    var paramsRequired = [];
-    var paramsSpecifics = {};
+    const paramsRequired = [];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/note.ajax.php';
     paramsAJAX.data = {
         action: 'all'

--- a/core/js/plugin.class.js
+++ b/core/js/plugin.class.js
@@ -18,8 +18,8 @@ jeedom.plugin = function () { };
 jeedom.plugin.cache = Array();
 
 jeedom.plugin.all = function (_params) {
-  var paramsRequired = [];
-  var paramsSpecifics = {
+  const paramsRequired = [];
+  const paramsSpecifics = {
     pre_success: function (data) {
       jeedom.plugin.cache.all = data.result;
       return data;
@@ -35,8 +35,8 @@ jeedom.plugin.all = function (_params) {
     _params.success(jeedom.plugin.cache.all);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/plugin.ajax.php';
   paramsAJAX.data = {
     action: 'all',
@@ -46,16 +46,16 @@ jeedom.plugin.all = function (_params) {
 }
 
 jeedom.plugin.toggle = function (_params) {
-  var paramsRequired = ['id', 'state'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['id', 'state'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/plugin.ajax.php';
   paramsAJAX.data = {
     action: 'toggle',
@@ -66,16 +66,16 @@ jeedom.plugin.toggle = function (_params) {
 }
 
 jeedom.plugin.get = function (_params) {
-  var paramsRequired = ['id'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['id'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/plugin.ajax.php';
   paramsAJAX.data = {
     action: 'getConf',
@@ -86,8 +86,8 @@ jeedom.plugin.get = function (_params) {
 }
 
 jeedom.plugin.getDependancyInfo = function (_params) {
-  var paramsRequired = ['id'];
-  var paramsSpecifics = {
+  const paramsRequired = ['id'];
+  const paramsSpecifics = {
     global: false,
   };
   try {
@@ -96,8 +96,8 @@ jeedom.plugin.getDependancyInfo = function (_params) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/plugin.ajax.php';
   paramsAJAX.data = {
     action: 'getDependancyInfo',
@@ -107,16 +107,16 @@ jeedom.plugin.getDependancyInfo = function (_params) {
 }
 
 jeedom.plugin.dependancyInstall = function (_params) {
-  var paramsRequired = ['id'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['id'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/plugin.ajax.php';
   paramsAJAX.data = {
     action: 'dependancyInstall',
@@ -126,16 +126,16 @@ jeedom.plugin.dependancyInstall = function (_params) {
 }
 
 jeedom.plugin.dependancyChangeAutoMode = function (_params) {
-  var paramsRequired = ['id', 'mode'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['id', 'mode'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/plugin.ajax.php';
   paramsAJAX.data = {
     action: 'dependancyChangeAutoMode',
@@ -146,8 +146,8 @@ jeedom.plugin.dependancyChangeAutoMode = function (_params) {
 }
 
 jeedom.plugin.getDeamonInfo = function (_params) {
-  var paramsRequired = ['id'];
-  var paramsSpecifics = {
+  const paramsRequired = ['id'];
+  const paramsSpecifics = {
     global: false,
   };
   try {
@@ -156,8 +156,8 @@ jeedom.plugin.getDeamonInfo = function (_params) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/plugin.ajax.php';
   paramsAJAX.data = {
     action: 'getDeamonInfo',
@@ -167,16 +167,16 @@ jeedom.plugin.getDeamonInfo = function (_params) {
 }
 
 jeedom.plugin.deamonStart = function (_params) {
-  var paramsRequired = ['id'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['id'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/plugin.ajax.php';
   paramsAJAX.data = {
     action: 'deamonStart',
@@ -188,16 +188,16 @@ jeedom.plugin.deamonStart = function (_params) {
 }
 
 jeedom.plugin.deamonStop = function (_params) {
-  var paramsRequired = ['id'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['id'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/plugin.ajax.php';
   paramsAJAX.data = {
     action: 'deamonStop',
@@ -207,16 +207,16 @@ jeedom.plugin.deamonStop = function (_params) {
 }
 
 jeedom.plugin.deamonChangeAutoMode = function (_params) {
-  var paramsRequired = ['id', 'mode'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['id', 'mode'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/plugin.ajax.php';
   paramsAJAX.data = {
     action: 'deamonChangeAutoMode',
@@ -227,16 +227,16 @@ jeedom.plugin.deamonChangeAutoMode = function (_params) {
 }
 
 jeedom.plugin.createCommunityPost = function (_params) {
-  var paramsRequired = ['type'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['type'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/plugin.ajax.php';
   paramsAJAX.data = {
     action: 'createCommunityPost',

--- a/core/js/recovery.class.js
+++ b/core/js/recovery.class.js
@@ -17,16 +17,16 @@
 jeedom.recovery = function() { }
 
 jeedom.recovery.start = function(_params) {
-    var paramsRequired = ['hardware', 'mode']
-    var paramsSpecifics = {}
+    const paramsRequired = ['hardware', 'mode']
+    const paramsSpecifics = {}
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
         return
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-    var paramsAJAX = jeedom.private.getParamsAJAX(params)
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+    const paramsAJAX = jeedom.private.getParamsAJAX(params)
     paramsAJAX.url = 'core/ajax/recovery.ajax.php'
     paramsAJAX.data = {
         action: 'start',
@@ -37,9 +37,9 @@ jeedom.recovery.start = function(_params) {
 }
 
 jeedom.recovery.cancel = function(_params) {
-    var paramsSpecifics = {}
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-    var paramsAJAX = jeedom.private.getParamsAJAX(params)
+    const paramsSpecifics = {}
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+    const paramsAJAX = jeedom.private.getParamsAJAX(params)
     paramsAJAX.url = 'core/ajax/recovery.ajax.php'
     paramsAJAX.data = {
         action: 'cancel'
@@ -48,9 +48,9 @@ jeedom.recovery.cancel = function(_params) {
 }
 
 jeedom.recovery.getProgress = function(_params) {
-    var paramsSpecifics = {}
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-    var paramsAJAX = jeedom.private.getParamsAJAX(params)
+    const paramsSpecifics = {}
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+    const paramsAJAX = jeedom.private.getParamsAJAX(params)
     paramsAJAX.url = 'core/ajax/recovery.ajax.php'
     paramsAJAX.data = {
         action: 'getProgress'
@@ -59,16 +59,16 @@ jeedom.recovery.getProgress = function(_params) {
 }
 
 jeedom.recovery.usbConnected = function(_params) {
-    var paramsRequired = ['hardware']
-    var paramsSpecifics = {}
+    const paramsRequired = ['hardware']
+    const paramsSpecifics = {}
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
         return
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-    var paramsAJAX = jeedom.private.getParamsAJAX(params)
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+    const paramsAJAX = jeedom.private.getParamsAJAX(params)
     paramsAJAX.url = 'core/ajax/recovery.ajax.php'
     paramsAJAX.data = {
         action: 'usbConnected',

--- a/core/js/report.class.js
+++ b/core/js/report.class.js
@@ -17,16 +17,16 @@
 jeedom.report = function() {};
 
 jeedom.report.list = function(_params) {
-    var paramsRequired = ['type', 'id'];
-    var paramsSpecifics = {};
+    const paramsRequired = ['type', 'id'];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/report.ajax.php';
     paramsAJAX.data = {
         action: 'list',
@@ -37,16 +37,16 @@ jeedom.report.list = function(_params) {
 }
 
 jeedom.report.get = function(_params) {
-    var paramsRequired = ['type', 'id', 'report'];
-    var paramsSpecifics = {};
+    const paramsRequired = ['type', 'id', 'report'];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/report.ajax.php';
     paramsAJAX.data = {
         action: 'get',
@@ -58,16 +58,16 @@ jeedom.report.get = function(_params) {
 }
 
 jeedom.report.remove = function(_params) {
-    var paramsRequired = ['type', 'id', 'report'];
-    var paramsSpecifics = {};
+    const paramsRequired = ['type', 'id', 'report'];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/report.ajax.php';
     paramsAJAX.data = {
         action: 'remove',
@@ -79,16 +79,16 @@ jeedom.report.remove = function(_params) {
 }
 
 jeedom.report.removeAll = function(_params) {
-    var paramsRequired = ['type', 'id'];
-    var paramsSpecifics = {};
+    const paramsRequired = ['type', 'id'];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/report.ajax.php';
     paramsAJAX.data = {
         action: 'removeAll',

--- a/core/js/update.class.js
+++ b/core/js/update.class.js
@@ -17,16 +17,16 @@
 jeedom.update = function() {};
 
 jeedom.update.doAll = function(_params) {
-    var paramsRequired = [];
-    var paramsSpecifics = {};
+    const paramsRequired = [];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/update.ajax.php';
     paramsAJAX.data = {
         action: 'updateAll',
@@ -36,16 +36,16 @@ jeedom.update.doAll = function(_params) {
 }
 
 jeedom.update.do = function(_params) {
-    var paramsRequired = ['id'];
-    var paramsSpecifics = {};
+    const paramsRequired = ['id'];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/update.ajax.php';
     paramsAJAX.data = {
         action: 'update',
@@ -55,16 +55,16 @@ jeedom.update.do = function(_params) {
 }
 
 jeedom.update.remove = function(_params) {
-    var paramsRequired = ['id'];
-    var paramsSpecifics = {};
+    const paramsRequired = ['id'];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/update.ajax.php';
     paramsAJAX.data = {
         action: 'remove',
@@ -74,16 +74,16 @@ jeedom.update.remove = function(_params) {
 }
 
 jeedom.update.checkAll = function(_params) {
-    var paramsRequired = [];
-    var paramsSpecifics = {};
+    const paramsRequired = [];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/update.ajax.php';
     paramsAJAX.data = {
         action: 'checkAllUpdate'
@@ -92,16 +92,16 @@ jeedom.update.checkAll = function(_params) {
 }
 
 jeedom.update.check = function(_params) {
-    var paramsRequired = ['id'];
-    var paramsSpecifics = {};
+    const paramsRequired = ['id'];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/update.ajax.php';
     paramsAJAX.data = {
         action: 'checkUpdate',
@@ -111,16 +111,16 @@ jeedom.update.check = function(_params) {
 }
 
 jeedom.update.get = function(_params) {
-    var paramsRequired = [];
-    var paramsSpecifics = {};
+    const paramsRequired = [];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/update.ajax.php';
     paramsAJAX.data = {
         action: 'all'
@@ -129,16 +129,16 @@ jeedom.update.get = function(_params) {
 }
 
 jeedom.update.save = function(_params) {
-    var paramsRequired = ['update'];
-    var paramsSpecifics = {};
+    const paramsRequired = ['update'];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/update.ajax.php';
     paramsAJAX.data = {
         action: 'save',
@@ -148,16 +148,16 @@ jeedom.update.save = function(_params) {
 }
 
 jeedom.update.saves = function(_params) {
-    var paramsRequired = ['updates'];
-    var paramsSpecifics = {};
+    const paramsRequired = ['updates'];
+    const paramsSpecifics = {};
     try {
         jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
     } catch (e) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/update.ajax.php';
     paramsAJAX.data = {
         action: 'saves',
@@ -167,8 +167,8 @@ jeedom.update.saves = function(_params) {
 }
 
 jeedom.update.number = function(_params) {
-    var paramsRequired = [];
-    var paramsSpecifics = {
+    const paramsRequired = [];
+    const paramsSpecifics = {
         global: false,
     };
     try {
@@ -177,8 +177,8 @@ jeedom.update.number = function(_params) {
         (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
         return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/update.ajax.php';
     paramsAJAX.data = {
         action: 'nbUpdate',

--- a/core/js/user.class.js
+++ b/core/js/user.class.js
@@ -18,16 +18,16 @@ jeedom.user = function() {};
 jeedom.user.connectCheck = 0;
 
 jeedom.user.all = function(_params) {
-  var paramsRequired = [];
-  var paramsSpecifics = {};
+  const paramsRequired = [];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/user.ajax.php';
   paramsAJAX.data = {
     action: 'all',
@@ -36,16 +36,16 @@ jeedom.user.all = function(_params) {
 }
 
 jeedom.user.remove = function(_params) {
-  var paramsRequired = ['id'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['id'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/user.ajax.php';
   paramsAJAX.data = {
     action: 'remove',
@@ -55,16 +55,16 @@ jeedom.user.remove = function(_params) {
 }
 
 jeedom.user.save = function(_params) {
-  var paramsRequired = ['users'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['users'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/user.ajax.php';
   paramsAJAX.data = {
     action: 'save',
@@ -74,16 +74,16 @@ jeedom.user.save = function(_params) {
 }
 
 jeedom.user.saveProfils = function(_params) {
-  var paramsRequired = ['profils'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['profils'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/user.ajax.php';
   paramsAJAX.data = {
     action: 'saveProfils',
@@ -93,16 +93,16 @@ jeedom.user.saveProfils = function(_params) {
 }
 
 jeedom.user.get = function(_params) {
-  var paramsRequired = [];
-  var paramsSpecifics = {};
+  const paramsRequired = [];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/user.ajax.php';
   paramsAJAX.data = {
     action: 'get',
@@ -114,8 +114,8 @@ jeedom.user.get = function(_params) {
 
 jeedom.user.isConnect = function(_params) {
   if (Math.round(+new Date() / 1000) > (jeedom.user.connectCheck + 300)) {
-    var paramsRequired = [];
-    var paramsSpecifics = {
+    const paramsRequired = [];
+    const paramsSpecifics = {
       pre_success: function(data) {
         if (data.state != 'ok') {
           return {
@@ -137,8 +137,8 @@ jeedom.user.isConnect = function(_params) {
       (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
       return;
     }
-    var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-    var paramsAJAX = jeedom.private.getParamsAJAX(params);
+    const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+    const paramsAJAX = jeedom.private.getParamsAJAX(params);
     paramsAJAX.url = 'core/ajax/user.ajax.php';
     paramsAJAX.global = false;
     paramsAJAX.data = {
@@ -153,16 +153,16 @@ jeedom.user.isConnect = function(_params) {
 }
 
 jeedom.user.validateTwoFactorCode = function(_params) {
-  var paramsRequired = ['code'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['code'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/user.ajax.php';
   paramsAJAX.data = {
     action: 'validateTwoFactorCode',
@@ -173,16 +173,16 @@ jeedom.user.validateTwoFactorCode = function(_params) {
 }
 
 jeedom.user.removeTwoFactorCode = function(_params) {
-  var paramsRequired = ['id'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['id'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/user.ajax.php';
   paramsAJAX.data = {
     action: 'removeTwoFactorCode',
@@ -192,8 +192,8 @@ jeedom.user.removeTwoFactorCode = function(_params) {
 }
 
 jeedom.user.useTwoFactorAuthentification = function(_params) {
-  var paramsRequired = ['login'];
-  var paramsSpecifics = {
+  const paramsRequired = ['login'];
+  const paramsSpecifics = {
     global: false,
   }
   try {
@@ -202,8 +202,8 @@ jeedom.user.useTwoFactorAuthentification = function(_params) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/user.ajax.php';
   paramsAJAX.data = {
     action: 'useTwoFactorAuthentification',
@@ -213,16 +213,16 @@ jeedom.user.useTwoFactorAuthentification = function(_params) {
 }
 
 jeedom.user.login = function(_params) {
-  var paramsRequired = ['username', 'password'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['username', 'password'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/user.ajax.php';
   paramsAJAX.data = {
     action: 'login',
@@ -235,16 +235,16 @@ jeedom.user.login = function(_params) {
 }
 
 jeedom.user.refresh = function(_params) {
-  var paramsRequired = [];
-  var paramsSpecifics = {};
+  const paramsRequired = [];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/user.ajax.php';
   paramsAJAX.data = {
     action: 'refresh',
@@ -253,16 +253,16 @@ jeedom.user.refresh = function(_params) {
 }
 
 jeedom.user.removeBanIp = function(_params) {
-  var paramsRequired = [];
-  var paramsSpecifics = {};
+  const paramsRequired = [];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/user.ajax.php';
   paramsAJAX.data = {
     action: 'removeBanIp',
@@ -271,16 +271,16 @@ jeedom.user.removeBanIp = function(_params) {
 }
 
 jeedom.user.removeRegisterDevice = function(_params) {
-  var paramsRequired = [];
-  var paramsSpecifics = {};
+  const paramsRequired = [];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/user.ajax.php';
   paramsAJAX.data = {
     action: 'removeRegisterDevice',
@@ -291,16 +291,16 @@ jeedom.user.removeRegisterDevice = function(_params) {
 }
 
 jeedom.user.deleteSession = function(_params) {
-  var paramsRequired = ['id'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['id'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/user.ajax.php';
   paramsAJAX.data = {
     action: 'deleteSession',
@@ -310,16 +310,16 @@ jeedom.user.deleteSession = function(_params) {
 }
 
 jeedom.user.supportAccess = function(_params) {
-  var paramsRequired = ['enable'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['enable'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/user.ajax.php';
   paramsAJAX.data = {
     action: 'supportAccess',
@@ -329,16 +329,16 @@ jeedom.user.supportAccess = function(_params) {
 }
 
 jeedom.user.copyRights = function(_params) {
-  var paramsRequired = ['from','to'];
-  var paramsSpecifics = {};
+  const paramsRequired = ['from','to'];
+  const paramsSpecifics = {};
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
   } catch (e) {
     (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
     return;
   }
-  var params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  var paramsAJAX = jeedom.private.getParamsAJAX(params);
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
+  const paramsAJAX = jeedom.private.getParamsAJAX(params);
   paramsAJAX.url = 'core/ajax/user.ajax.php';
   paramsAJAX.data = {
     action: 'copyRights',

--- a/desktop/js/log.js
+++ b/desktop/js/log.js
@@ -24,8 +24,8 @@ if (!jeeFrontEnd.log) {
       this.logListButtons = document.querySelectorAll('#ul_object .li_log')
 
       //autoclick first log:
-      var logfile = getUrlVars('logfile')
-      var log = document.querySelector('#div_displayLogList .li_log[data-log="' + logfile + '"]')
+      const logfile = getUrlVars('logfile')
+      const log = document.querySelector('#div_displayLogList .li_log[data-log="' + logfile + '"]')
       if (log != null) {
         log.click()
       } else {
@@ -37,28 +37,23 @@ if (!jeeFrontEnd.log) {
 
 //searching
 document.getElementById('in_searchLogFilter')?.addEventListener('keyup', function(event) {
-  var search = event.target.value
-  if (search == '') {
+  const raw = event.target.value
+  if (raw == '') {
     jeeP.logListButtons.seen()
     return
   }
-  var not = search.startsWith(":not(")
-  if (not) {
-    search = search.replace(':not(', '')
-  }
-  search = jeedomUtils.normTextLower(search)
+
+  const terms = raw.split(',').map(t => t.trim()).filter(t => t.length > 0)
+
   jeeP.logListButtons.unseen()
-  var match, text
   jeeP.logListButtons.forEach(_bt => {
-    match = false
-    text = jeedomUtils.normTextLower(_bt.textContent)
-    if (text.includes(search)) {
-      match = true
-    }
-    if (not) match = !match
-    if (match) {
-      _bt.seen()
-    }
+    const text = jeedomUtils.normTextLower(_bt.textContent)
+    const match = terms.some(term => {
+      const not = term.startsWith(':not(')
+      const search = jeedomUtils.normTextLower(not ? term.slice(5, -1) : term)
+      return not ? !text.includes(search) : text.includes(search)
+    })
+    if (match) _bt.seen()
   })
 })
 
@@ -66,7 +61,7 @@ document.getElementById('in_searchLogFilter')?.addEventListener('keyup', functio
 */
 //div_pageContainer events delegation:
 document.getElementById('div_pageContainer').addEventListener('click', function(event) {
-  var _target = null
+  let _target = null
 
   // "Raw log" button clicked
   if (_target = event.target.closest('#brutlogcheck')) {

--- a/desktop/js/log.js
+++ b/desktop/js/log.js
@@ -37,23 +37,27 @@ if (!jeeFrontEnd.log) {
 
 //searching
 document.getElementById('in_searchLogFilter')?.addEventListener('keyup', function(event) {
-  const raw = event.target.value
-  if (raw == '') {
+  let search = event.target.value
+  if (search == '') {
     jeeP.logListButtons.seen()
     return
   }
-
-  const terms = raw.split(',').map(t => t.trim()).filter(t => t.length > 0)
-
+  const not = search.startsWith(":not(")
+  if (not) {
+    search = search.replace(':not(', '')
+  }
+  search = jeedomUtils.normTextLower(search)
   jeeP.logListButtons.unseen()
   jeeP.logListButtons.forEach(_bt => {
+    let match = false
     const text = jeedomUtils.normTextLower(_bt.textContent)
-    const match = terms.some(term => {
-      const not = term.startsWith(':not(')
-      const search = jeedomUtils.normTextLower(not ? term.slice(5, -1) : term)
-      return not ? !text.includes(search) : text.includes(search)
-    })
-    if (match) _bt.seen()
+    if (text.includes(search)) {
+      match = true
+    }
+    if (not) match = !match
+    if (match) {
+      _bt.seen()
+    }
   })
 })
 


### PR DESCRIPTION
## Summary

Fourth of four migration PRs splitting #3297 by functional domain. This batch covers **12 admin/system files** plus the **multi-term log search refactor from #3270**:

```
user.class.js     plugin.class.js   log.class.js
config.class.js   cron.class.js     backup.class.js
update.class.js   recovery.class.js report.class.js
note.class.js     interact.class.js appMobile.class.js
desktop/js/log.js  (incorporates #3270)
```

## Log search multi-term (#3270)

`desktop/js/log.js` adopts the multi-term search refactor proposed in #3270, but with `const`/`let` rather than `var`. The search input now accepts comma-separated terms with per-term `:not()` exclusion:

- `error` — single term (unchanged behavior)
- `error,warning` — match any of the terms
- `:not(debug)` — exclude single term
- `error,:not(daemon)` — match `error` OR exclude `daemon`

## No incidental fixes in this batch

All files in this batch follow the uniform AJAX boilerplate pattern, so the migration is purely mechanical (`var` → `const` for never-reassigned, `let` for the rest).

## Test plan

- [ ] Open the Logs page — verify the log list and selection works
- [ ] Search a log file using the new multi-term syntax (`error,warning`, `:not(debug)`) — verify highlighting
- [ ] Open Administration → Backup, Cron, Update, Health — verify each tab loads
- [ ] Open the User management page — verify user list and edit modal
- [ ] Open the Interactions page — type a query — verify response
- [ ] Open the Plugin marketplace — install/update flow remains functional
- [ ] Verify in mobile mode (`?v=m`) that the dashboard still renders (`appMobile.class.js`)

Part of the split following #3297 discussion. After this PR lands, all `core/js/*.js` files use `const`/`let` exclusively, and the ESLint workflow from #3299 can be tightened to enforce `no-var` and `prefer-const` permanently.