### PR TITLE
feat(log): multi-term comma-separated search with :not() exclusion

### DIFF
--- a/desktop/js/log.js
+++ b/desktop/js/log.js
@@ -37,28 +37,26 @@ if (!jeeFrontEnd.log) {
 
 //searching
 document.getElementById('in_searchLogFilter')?.addEventListener('keyup', function(event) {
-  var search = event.target.value
-  if (search == '') {
+  var raw = event.target.value
+  if (raw == '') {
     jeeP.logListButtons.seen()
     return
   }
-  var not = search.startsWith(":not(")
-  if (not) {
-    search = search.replace(':not(', '')
-  }
-  search = jeedomUtils.normTextLower(search)
+
+  // Multi-term: comma-separated terms, each term can be prefixed with :not()
+  // e.g. "error,warning" → show entries matching either
+  //      "error,:not(daemon)" → show entries matching "error" but not "daemon"
+  var terms = raw.split(',').map(function(t) { return t.trim() }).filter(function(t) { return t.length > 0 })
+
   jeeP.logListButtons.unseen()
-  var match, text
   jeeP.logListButtons.forEach(_bt => {
-    match = false
-    text = jeedomUtils.normTextLower(_bt.textContent)
-    if (text.includes(search)) {
-      match = true
-    }
-    if (not) match = !match
-    if (match) {
-      _bt.seen()
-    }
+    var text = jeedomUtils.normTextLower(_bt.textContent)
+    var match = terms.some(function(term) {
+      var not = term.startsWith(':not(')
+      var search = jeedomUtils.normTextLower(not ? term.slice(5, -1) : term)
+      return not ? !text.includes(search) : text.includes(search)
+    })
+    if (match) _bt.seen()
   })
 })
 

--- a/desktop/js/log.js
+++ b/desktop/js/log.js
@@ -37,7 +37,7 @@ if (!jeeFrontEnd.log) {
 
 //searching
 document.getElementById('in_searchLogFilter')?.addEventListener('keyup', function(event) {
-  var raw = event.target.value
+  const raw = event.target.value
   if (raw == '') {
     jeeP.logListButtons.seen()
     return
@@ -46,14 +46,14 @@ document.getElementById('in_searchLogFilter')?.addEventListener('keyup', functio
   // Multi-term: comma-separated terms, each term can be prefixed with :not()
   // e.g. "error,warning" → show entries matching either
   //      "error,:not(daemon)" → show entries matching "error" but not "daemon"
-  var terms = raw.split(',').map(function(t) { return t.trim() }).filter(function(t) { return t.length > 0 })
+  const terms = raw.split(',').map(function(t) { return t.trim() }).filter(function(t) { return t.length > 0 })
 
   jeeP.logListButtons.unseen()
   jeeP.logListButtons.forEach(_bt => {
-    var text = jeedomUtils.normTextLower(_bt.textContent)
-    var match = terms.some(function(term) {
-      var not = term.startsWith(':not(')
-      var search = jeedomUtils.normTextLower(not ? term.slice(5, -1) : term)
+    const text = jeedomUtils.normTextLower(_bt.textContent)
+    const match = terms.some(function(term) {
+      const not = term.startsWith(':not(')
+      const search = jeedomUtils.normTextLower(not ? term.slice(5, -1) : term)
       return not ? !text.includes(search) : text.includes(search)
     })
     if (match) _bt.seen()


### PR DESCRIPTION
## Summary

Enhances the log filter search to support multiple comma-separated terms, each optionally negated with `:not()`.

### Before
Single-term search: `error` or `:not(daemon)`

### After
Multi-term, comma-separated:
- `error,warning` → show entries matching **error** OR **warning**
- `error,:not(daemon)` → show entries matching **error** OR **not** matching **daemon**
- `:not(debug),:not(info)` → hide debug and info entries

### Logic
Each comma-separated term is evaluated independently against the log name. An entry is shown if **any** term matches (OR semantics). Each term can be negated individually.

### Suggested changelog entry
> Log filter now supports multiple comma-separated terms and per-term `:not()` exclusion (e.g. `error,warning` or `error,:not(daemon)`).

### Known risks / side effects
- Only `desktop/js/log.js` is modified — no PHP changes, no impact on other pages.
- The existing single `:not()` syntax continues to work as before (backward compatible).
- No plugin impact (filter is UI-only, client-side).

## Notes
- Initially proposed in #3270 (closed, superseded by this PR)
- Extracted from #3303 at request of @Salvialf and @Mips2648 to keep functional changes separate from the `var→const/let` refactoring
- As noted by @Mips2648, this opens the door to a more global search improvement across pages

## Types of changes
- [ ] Bug fix
- [x] New feature *(non-breaking change which adds functionality)*
- [ ] Breaking change
- [ ] Documentation improvement

## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the contribution guidelines.
- [x] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.

## Testing
1. Open Logs page
2. Type `error,warning` → only logs containing "error" or "warning" shown
3. Type `:not(debug)` → logs NOT containing "debug" shown
4. Type `http,:not(daemon)` → logs containing "http" OR not containing "daemon" shown
5. Clear filter → all logs shown again