### PR TITLE
Chore: secure parameter typehints

### DIFF
--- a/core/class/jeedom.class.php
+++ b/core/class/jeedom.class.php
@@ -23,7 +23,6 @@ class jeedom {
 	/*     * *************************Attributs****************************** */
 
 	private static $jeedomConfiguration;
-	private static $jeedom_encryption = null;
 	private static $cache = array();
 
 	/*     * ***********************Methode static*************************** */
@@ -533,7 +532,7 @@ class jeedom {
 		system::php($cmd);
 	}
 
-	public static function getApiKey($_plugin = 'core', $_mode = 'enable') {
+	public static function getApiKey(string $_plugin = 'core', string $_mode = 'enable') {
 		if ($_plugin == 'core') {
 			if (config::byKey('api') == '') {
 				config::save('api', config::genKey());
@@ -577,7 +576,7 @@ class jeedom {
 		return config::byKey('api', $_plugin);
 	}
 
-	public static function apiModeResult($_mode = 'enable') {
+	public static function apiModeResult(string $_mode = 'enable') {
 		if ($_mode == 'localhost' && jeedom::getHardwareName() == 'docker') {
 			$_mode = 'whiteip';
 		}
@@ -608,7 +607,7 @@ class jeedom {
 		return true;
 	}
 
-	public static function apiAccess($_apikey = '', $_plugin = 'core') {
+	public static function apiAccess(string $_apikey = '', string $_plugin = 'core') {
 		if (trim($_apikey) == '' || strlen($_apikey) < 16) {
 			return false;
 		}
@@ -658,10 +657,9 @@ class jeedom {
 	}
 
 	/*************************************************USB********************************************************/
-	public static function getUsbDetails($_usb = '', $_usbMapping = array()) {
+	public static function getUsbDetails(string $_usb = '', array $_usbMapping = []): array {
 		$vendor = '';
 		$model = '';
-		$serial = '';
 		$serial_by_id = '';
 		foreach (explode("\n", shell_exec('udevadm info --name=/dev/' . $_usb . ' --query=all')) as $line) {
 			if (strpos($line, 'E: ID_USB_MODEL=') !== false) {
@@ -712,7 +710,7 @@ class jeedom {
 		return $_usbMapping;
 	}
 
-	public static function getUsbLegacy($_usbMapping = array()) {
+	public static function getUsbLegacy(array $_usbMapping = []): array {
 		foreach (ls('/dev/', 'ttyUSB*') as $usb) {
 			$_usbMapping['/dev/' . $usb] = '/dev/' . $usb;
 		}
@@ -722,7 +720,7 @@ class jeedom {
 		return $_usbMapping;
 	}
 
-	public static function getUsbMapping($_name = '', $_getGPIO = false) {
+	public static function getUsbMapping(string $_name = '', bool $_getGPIO = false) {
 		$cache = cache::byKey('jeedom::usbMapping');
 		if (!is_json($cache->getValue()) || $_name == '') {
 			$usbMapping = array();
@@ -791,7 +789,7 @@ class jeedom {
 		return $usbMapping;
 	}
 
-	public static function getBluetoothMapping($_name = '') {
+	public static function getBluetoothMapping(string $_name = '') {
 		$cache = cache::byKey('jeedom::bluetoothMapping');
 		if (!is_json($cache->getValue()) || $_name == '') {
 			$bluetoothMapping = array();
@@ -831,7 +829,7 @@ class jeedom {
 
 	/********************************************BACKUP*****************************************************************/
 
-	public static function backup($_background = false) {
+	public static function backup(bool $_background = false) {
 		if ($_background) {
 			log::clear('backup');
 			$cmd = __DIR__ . '/../../install/backup.php';
@@ -856,7 +854,7 @@ class jeedom {
 		return $return;
 	}
 
-	public static function removeBackup($_backup) {
+	public static function removeBackup(string $_backup) {
 		if (file_exists($_backup)) {
 			unlink($_backup);
 		} else {
@@ -864,7 +862,7 @@ class jeedom {
 		}
 	}
 
-	public static function restore($_backup = '', $_background = false) {
+	public static function restore(string $_backup = '', bool $_background = false) {
 		if ($_background) {
 			log::clear('restore');
 			$cmd = __DIR__ . '/../../install/restore.php "backup=' . $_backup . '"';
@@ -879,10 +877,10 @@ class jeedom {
 
 	/****************************UPDATE*****************************************************************/
 
-	public static function update($_options = array()) {
+	public static function update(array $_options = []) {
 		log::clear('update');
 		$params = '';
-		if (is_array($_options) && count($_options) > 0) {
+		if (count($_options) > 0) {
 			foreach ($_options as $key => $value) {
 				$params .= '"' . $key . '"="' . $value . '" ';
 			}
@@ -894,7 +892,7 @@ class jeedom {
 
 	/****************************CONFIGURATION MANAGEMENT*****************************************************************/
 
-	public static function getConfiguration($_key = '', $_default = false) {
+	public static function getConfiguration(string $_key = '', bool $_default = false) {
 		global $JEEDOM_INTERNAL_CONFIG;
 		if ($_key == '') {
 			return $JEEDOM_INTERNAL_CONFIG;
@@ -920,7 +918,7 @@ class jeedom {
 		return self::$jeedomConfiguration[$_key];
 	}
 
-	private static function checkValueInconfiguration($_key, $_value) {
+	private static function checkValueInconfiguration(string $_key, $_value) {
 		if (!is_array(self::$jeedomConfiguration)) {
 			self::$jeedomConfiguration = array();
 		}
@@ -1387,17 +1385,20 @@ class jeedom {
 
 	/***************************************THREAD MANGEMENT**********************************************/
 
-	public static function checkOngoingThread($_cmd) {
+	public static function checkOngoingThread(string $_cmd) {
 		return shell_exec('(ps ax || ps w) | grep "' . $_cmd . '$" | grep -v "grep" | wc -l');
 	}
 
-	public static function retrievePidThread($_cmd) {
+	public static function retrievePidThread(string $_cmd) {
 		return shell_exec('(ps ax || ps w) | grep "' . $_cmd . '$" | grep -v "grep" | awk \'{print $1}\'');
 	}
 
 	/******************************************UTILS******************************************************/
 
-	public static function versionAlias($_version, $_lightMode = true) {
+	/**
+	 * @param boolean $_lightMode DEPRECATED, this parameter is not used anymore and will be removed in future versions
+	 */
+	public static function versionAlias(string $_version, bool $_lightMode = true): string {
 		if ($_version == 'mview') {
 			return 'mobile';
 		}
@@ -1423,19 +1424,19 @@ class jeedom {
 		}
 	}
 
-	public static function calculStat($_calcul, $_values, $_round = 1) {
+	public static function calculStat(string $_calcul, array $_values, int $_precision = 1) {
 		switch ($_calcul) {
 			case 'sum':
-				return round(array_sum($_values), $_round);
+				return round(array_sum($_values), $_precision);
 			case 'avg':
-				return round(array_sum($_values) / count($_values), $_round);
+				return round(array_sum($_values) / count($_values), $_precision);
 			case 'text':
 				return trim(implode(',', $_values), ',');
 		}
 		return null;
 	}
 
-	public static function getTypeUse($_string = '') {
+	public static function getTypeUse(string $_string = '') {
 		$return = array('cmd' => array(), 'scenario' => array(), 'eqLogic' => array(), 'dataStore' => array(), 'plan' => array(), 'plan3d' => array(), 'view' => array());
 		preg_match_all("/#([0-9]*)#/", $_string, $matches);
 		foreach ($matches[1] as $cmd_id) {
@@ -1549,10 +1550,7 @@ class jeedom {
 		return $remove_history;
 	}
 
-	public static function massReplace($_options = array(), $_eqlogics = array(), $_cmds = array()) {
-		if (!is_array($_options) || !is_array($_eqlogics) || !is_array($_cmds)) {
-			throw new Exception('Missmatch arguments');
-		}
+	public static function massReplace(array $_options = [], array $_eqlogics = [], array $_cmds = []) {
 		if (count($_eqlogics) == 0 && count($_cmds) == 0) {
 			throw new Exception('{{Aucun équipement ou commande à remplacer ou copier}}');
 		}
@@ -1744,16 +1742,12 @@ class jeedom {
 		exec($cmd);
 	}
 
-	public static function checkSpaceLeft($_dir = null) {
-		if ($_dir == null) {
-			$path = __DIR__ . '/../../';
-		} else {
-			$path = $_dir;
-		}
+	public static function checkSpaceLeft(?string $_dir = null) {
+		$path = $_dir ?? (__DIR__ . '/../../');
 		return round(disk_free_space($path) / disk_total_space($path) * 100);
 	}
 
-	public static function getTmpFolder($_plugin = '') {
+	public static function getTmpFolder(string $_plugin = '') {
 		if (isset(self::$cache['getTmpFolder::' . $_plugin])) {
 			return self::$cache['getTmpFolder::' . $_plugin];
 		}
@@ -1818,7 +1812,7 @@ class jeedom {
 		return config::byKey('hardware_name');
 	}
 
-	public static function isCapable($_function, $_forceRefresh = false) {
+	public static function isCapable($_function, bool $_forceRefresh = false) {
 		global $JEEDOM_COMPATIBILIY_CONFIG;
 		if ($_function == 'sudo') {
 			if (!$_forceRefresh) {

--- a/core/class/scenario.class.php
+++ b/core/class/scenario.class.php
@@ -415,7 +415,7 @@ class scenario {
 		if (count($scenarios) > 0) {
 			foreach ($scenarios as $scenario_) {
 				$scenario_->addTag('trigger_message',$trigger_message);
-				
+
 				$scenario_->addTag('trigger_value',$_value);
 				if (is_object($_event)) {
 					$scenario_->addTag('trigger_name',trim($_event->getHumanName(),'#'));
@@ -640,9 +640,8 @@ class scenario {
 	}
 
 	/**
-	 * @name toHumanReadable()
-	 * @param object $_input
-	 * @return string
+	 * @param string|object|array $_input
+	 * @return string|object|array
 	 */
 	public static function toHumanReadable($_input) {
 		if (is_object($_input)) {
@@ -1028,13 +1027,12 @@ class scenario {
 		return $html;
 	}
 	/**
-	 *
+	 * @deprecated don't use this function anymore, it is only here for backward compatibility
 	 */
 	public function emptyCacheWidget() {
-		
 	}
+
 	/**
-	 *
 	 * @param bool $_only_class
 	 * @return string
 	 */
@@ -1225,7 +1223,7 @@ class scenario {
 			} catch (Error $exc) {
 			}
 		}
-		
+
 		return $calculatedDate;
 	}
 
@@ -1990,7 +1988,7 @@ class scenario {
 		$this->configuration = $configuration;
 		return $this;
 	}
-	
+
 	/**
 	 * getReturn
 	 *

--- a/core/class/system.class.php
+++ b/core/class/system.class.php
@@ -65,7 +65,7 @@ class system {
 		return self::$_distrib;
 	}
 
-	public static function get($_key = '') {
+	public static function get(string $_key = '') {
 		$return = '';
 		if (isset(self::$_command[self::getDistrib()][$_key])) {
 			$return = self::$_command[self::getDistrib()][$_key];
@@ -93,9 +93,7 @@ class system {
 		return 'sudo ';
 	}
 
-	public static function fuserk($_port, $_protocol = 'tcp'): void {
-		if (!is_string($_port)) return;
-
+	public static function fuserk(string $_port, string $_protocol = 'tcp'): void {
 		if (file_exists($_port)) {
 			exec(system::getCmdSudo() . 'fuser -k ' . $_port . ' > /dev/null 2>&1');
 		} else {
@@ -103,7 +101,7 @@ class system {
 		}
 	}
 
-	public static function ps($_find, $_without = null) {
+	public static function ps(string $_find, $_without = null) {
 		$return = array();
 		$cmd = '(ps ax || ps w) | grep -ie "' . $_find . '" | grep -v "grep"';
 		if ($_without != null) {
@@ -179,7 +177,7 @@ class system {
 		exec($cmd);
 	}
 
-	public static function php($arguments, $_sudo = false) {
+	public static function php(string $arguments, bool $_sudo = false) {
 		if ($_sudo) {
 			return exec(self::getCmdSudo() . ' php ' . $arguments);
 		}
@@ -200,7 +198,7 @@ class system {
 		return $arch;
 	}
 
-	public static function getUpgradablePackage($_type, $_forceRefresh = false) {
+	public static function getUpgradablePackage(string $_type, bool $_forceRefresh = false) {
 		$return = array($_type => array());
 		switch ($_type) {
 			case 'apt':
@@ -264,7 +262,7 @@ class system {
 		return $return;
 	}
 
-	public static function upgradePackage($_type, $_package = null) {
+	public static function upgradePackage(string $_type, $_package = null) {
 		$cmd = "set -x\n";
 		$cmd .= "echo '*******************Begin of package upgrade type " . $_type . "******************'\n";
 		switch ($_type) {
@@ -317,12 +315,12 @@ class system {
 		self::launchScriptPackage();
 	}
 
-	private static function getPython3VenvDir($_plugin) {
+	private static function getPython3VenvDir(string $_plugin) {
 		if ($_plugin == '') return '';
 		return __DIR__ . "/../../plugins/{$_plugin}/resources/python_venv";
 	}
 
-	public static function getCmdPython3($_plugin) {
+	public static function getCmdPython3(string $_plugin) {
 		if ($_plugin == '') return 'python3 ';
 
 		if (version_compare(self::getOsVersion(), '12', '<')) {
@@ -332,7 +330,7 @@ class system {
 		}
 	}
 
-	private static function splitpackageByPlugin($_type, $_plugin = '') {
+	private static function splitpackageByPlugin(string $_type, string $_plugin = '') {
 		if (version_compare(self::getOsVersion(), '12', '>=') && in_array($_type, ['pip3']) && $_plugin != '') {
 			return true;
 		} else {
@@ -340,7 +338,7 @@ class system {
 		}
 	}
 
-	public static function getInstallPackage($_type, $_plugin) {
+	public static function getInstallPackage(string $_type, string $_plugin) {
 		if (self::splitpackageByPlugin($_type, $_plugin)) {
 			$type_key = $_type . '::' . $_plugin;
 		} else {
@@ -448,7 +446,7 @@ class system {
 		return self::$_installPackage[$type_key];
 	}
 
-	public static function os_incompatible($_type, $_package, $_info): bool {
+	public static function os_incompatible(string $_type, string $_package, array $_info): bool {
 		if (isset($_info['denyDebianHigherEqual']) && self::getDistrib() == 'debian' && version_compare(self::getOsVersion(), $_info['denyDebianHigherEqual'], '>=')) {
 			return true;
 		}
@@ -466,7 +464,7 @@ class system {
 		return false;
 	}
 
-	public static function checkAndInstall($_packages, $_fix = false, $_foreground = false, $_plugin = '', $_force = false) {
+	public static function checkAndInstall(array $_packages, bool $_fix = false, bool $_foreground = false, string $_plugin = '', bool $_force = false) {
 		$return = array();
 		foreach ($_packages as $type => $value) {
 			if ($type == 'post-install' || $type == 'pre-install') {
@@ -773,7 +771,7 @@ class system {
 		self::launchScriptPackage($_plugin, $_force);
 	}
 
-	public static function installPackageInProgress($_plugin = ''): bool {
+	public static function installPackageInProgress(string $_plugin = ''): bool {
 		if (count(self::ps('^dpkg ')) > 0 || count(self::ps('^apt ')) > 0) {
 			return true;
 		}
@@ -799,7 +797,7 @@ class system {
 		return false;
 	}
 
-	public static function launchScriptPackage($_plugin = '', $_force = false) {
+	public static function launchScriptPackage(string $_plugin = '', bool $_force = false) {
 		if (!$_force && self::installPackageInProgress($_plugin)) {
 			throw new \Exception(__('Installation de package impossible car il y a déjà une installation en cours', __FILE__));
 		}
@@ -825,7 +823,7 @@ class system {
 		}
 	}
 
-	public static function installPackage($_type, $_package, $_version = '', $_plugin = '') {
+	public static function installPackage(string $_type, string $_package, string $_version = '', string $_plugin = '') {
 		switch ($_type) {
 			case 'apt':
 				if ($_package == 'node' || $_package == 'nodejs' || $_package == 'npm') {
@@ -842,7 +840,7 @@ class system {
 					if (preg_match('/[<>]/', $_version)) {
 						$_package .= $_version;
 						return self::getCmdSudo() . self::getCmdPython3($_plugin) . ' -m pip install --force-reinstall ' . $_package;
-					} 
+					}
 					$_package .= '==' . $_version;
 					return self::getCmdSudo() . self::getCmdPython3($_plugin) . ' -m pip install --force-reinstall --upgrade ' . $_package;
 				}
@@ -876,7 +874,7 @@ class system {
 		}
 	}
 
-	public static function checkHasExec($_exec) {
+	public static function checkHasExec(string $_exec) {
 		if (isset(self::$_hasExec[$_exec])) {
 			return self::$_hasExec[$_exec];
 		}
@@ -895,7 +893,7 @@ class system {
 		return self::$_os_version;
 	}
 
-	public static function checkInstallationLog($_plugin = ''): string {
+	public static function checkInstallationLog(string $_plugin = ''): string {
 		if (class_exists('log')) {
 			if ($_plugin != '') {
 				$log = log::getPathToLog($_plugin . '_packages');


### PR DESCRIPTION
## Description
This pull request refactors several methods in the `jeedom` and `system` classes to add explicit type declarations for parameters and return types. This improves code clarity, type safety, and prepares the codebase for future PHP versions where strict typing is more common. Additionally, some default values and minor logic have been adjusted to align with these changes.

Overall, these changes enhance code maintainability and reliability by leveraging PHP's type system.

_**Types have only be added when it is sure that it couldn't break anything; meaning that receiving another type was already throwing an exception anyway**_

### Suggested changelog entry
Chore: secure parameter typehints

### Related issues/external references

Fixes #


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement

