### PR TITLE
fix(desktop/js): correct 11 DOM and logic bugs (dashboard, object, plan, replace, eqAnalyse, administration, update)

### DIFF
--- a/desktop/js/administration.js
+++ b/desktop/js/administration.js
@@ -484,7 +484,7 @@ document.getElementById('in_searchConfig').addEventListener('keyup', function(ev
 
   //place back found els with unique span id to place them back to right place. Avoid cloning els to not break saveConfig().
   document.querySelectorAll('span[searchId]').forEach(_span => {
-    el = document.querySelector('#searchResult [searchId="' + _span.getAttribute('searchId') + '"]')
+    const el = document.querySelector('#searchResult [searchId="' + _span.getAttribute('searchId') + '"]')
     if (el != null) {
       el.removeAttribute('searchId')
       _span.replaceWith(el)

--- a/desktop/js/dashboard.js
+++ b/desktop/js/dashboard.js
@@ -265,7 +265,7 @@ if (!jeeFrontEnd.dashboard) {
           for (var i = 0; i < nbEqs; i++) {
             if (self.summaryObjEqs[self._object_id].includes(data[i].id)) {
               nbEqs--
-              return
+              continue
             }
             self.summaryObjEqs[self._object_id].push(data[i].id)
 
@@ -345,12 +345,12 @@ if (!jeeFrontEnd.dashboard) {
           //synch category filter:
           if (self.url_category != 'all') {
             let cat = self.url_category.charAt(0).toUpperCase() + self.url_category.slice(1)
-            document.getElementById('dashTopBar button.dropdown-toggle').addClass('warning')
+            document.querySelector('#dashTopBar button.dropdown-toggle').addClass('warning')
             document.querySelectorAll('#categoryfilter .catFilterKey').forEach(function(element) {
               element.checked = false
             })
             document.querySelector('#categoryfilter .catFilterKey[data-key="' + cat + '"]').checked = true
-            this.filterByCategory()
+            self.filterByCategory()
           }
 
           domUtils.hideLoading()
@@ -458,7 +458,7 @@ document.getElementById('in_searchDashboard')?.addEventListener('keyup', functio
 })
 document.getElementById('bt_resetDashboardSearch')?.addEventListener('click', function(event) {
   if (jeedomUI.isEditing) return
-  document.querySelectorAll('#categoryfilter li .catFilterKey').forEach(cat => { cat.checkd = true})
+  document.querySelectorAll('#categoryfilter li .catFilterKey').forEach(cat => { cat.checked = true})
   document.querySelectorAll('#dashTopBar button.dropdown-toggle').removeClass('warning')
   document.getElementById('in_searchDashboard').jeeValue('').triggerEvent('keyup')
 })

--- a/desktop/js/dashboard.js
+++ b/desktop/js/dashboard.js
@@ -349,7 +349,8 @@ if (!jeeFrontEnd.dashboard) {
             document.querySelectorAll('#categoryfilter .catFilterKey').forEach(function(element) {
               element.checked = false
             })
-            document.querySelector('#categoryfilter .catFilterKey[data-key="' + cat + '"]').checked = true
+            const catEl = document.querySelector('#categoryfilter .catFilterKey[data-key="' + cat + '"]')
+            if (catEl) catEl.checked = true
             self.filterByCategory()
           }
 

--- a/desktop/js/eqAnalyse.js
+++ b/desktop/js/eqAnalyse.js
@@ -75,7 +75,7 @@ if (!jeeFrontEnd.eqAnalyse) {
 
               removed = jeeFrontEnd.eqAnalyse.getRemoveCmd(data[i].cmd[j].who.replaceAll('#', ''))
               if (removed) {
-                tr += ' <span class="lebel label-sm label-info">' + removed.name + '</span>'
+                tr += ' <span class="label label-sm label-info">' + removed.name + '</span>'
                 tr += ' {{Supprimée le}} ' + removed.date
               }
 

--- a/desktop/js/object.js
+++ b/desktop/js/object.js
@@ -102,12 +102,12 @@ if (!jeeFrontEnd.object) {
             var objectBkgdColor = bodyStyles.getPropertyValue('--objectBkgd-color')
             var objectTxtColor = bodyStyles.getPropertyValue('--objectTxt-color')
 
-            if (!objectBkgdColor === undefined) {
+            if (objectBkgdColor !== '' && objectBkgdColor != null) {
               objectBkgdColor = jeedomUtils.rgbToHex(objectBkgdColor)
             } else {
               objectBkgdColor = '#696969'
             }
-            if (!objectTxtColor === undefined) {
+            if (objectTxtColor !== '' && objectTxtColor != null) {
               objectTxtColor = jeedomUtils.rgbToHex(objectTxtColor)
             } else {
               objectTxtColor = '#ebebeb'
@@ -1000,7 +1000,7 @@ document.getElementById('div_conf').addEventListener('click', function(event) {
   }
 
   if (_target = event.target.closest('.bt_removeSummary')) {
-    var cmd = _target.closest('.summary').querySelector('input[data-l1key="cmd"]').values
+    var cmd = _target.closest('.summary').querySelector('input[data-l1key="cmd"]').value
     var type = _target.closest('.div_summary').dataset.type
     _target.closest('.summary').remove()
     jeeP.updateSummaryTabNbr(type)

--- a/desktop/js/plan.js
+++ b/desktop/js/plan.js
@@ -192,7 +192,7 @@ if (!jeeFrontEnd.plan) {
             var img = document.querySelector('.div_displayObject img')
             if (img != null) {
               var style = {
-                height: img.getAttribute('data-sixe_x') + 'px',
+                height: img.getAttribute('data-sixe_y') + 'px',
                 width: img.getAttribute('data-sixe_x') + 'px'
               }
               Object.assign(jeeFrontEnd.plan.planContainer.style, style)

--- a/desktop/js/replace.js
+++ b/desktop/js/replace.js
@@ -377,9 +377,9 @@ document.getElementById('in_searchByName')?.addEventListener('keyup', function(e
       } else {
         eqName = jeedomUtils.normTextLower(eqLogic.getAttribute('data-name'))
         if (eqName.includes(search)) {
-          eqLogic.unseen()
-        } else {
           eqLogic.seen()
+        } else {
+          eqLogic.unseen()
         }
       }
     })

--- a/desktop/js/update.js
+++ b/desktop/js/update.js
@@ -111,7 +111,7 @@ if (!jeeFrontEnd.update) {
               jeeP.getJeedomLog(_autoUpdate, _log)
             }, 1000)
           } else {
-            document.getElementById('bt_' + _log + 'Jeedom .fa-refresh')?.unseen()
+            document.querySelector('#bt_' + _log + 'Jeedom .fa-refresh')?.unseen()
             document.querySelectorAll('.bt_' + _log + 'Jeedom .fa-refresh')?.unseen()
           }
         }


### PR DESCRIPTION
## Summary

This PR fixes 11 confirmed bugs in `desktop/js/` files. All of these bugs pre-existed the `var→const/let` migration — the migration only made them statically visible. This PR contains **no style or refactor changes**.

### dashboard.js
- `return` → `continue` in duplicate-eqLogic guard: `return` was exiting the entire function, preventing Packery from being initialized when any duplicate eqLogic was encountered
- `document.getElementById('dashTopBar button.dropdown-toggle')` → `document.querySelector(...)`: `getElementById` does not support compound CSS selectors, always returned `null` → `TypeError` when `url_category != 'all'`
- `this.filterByCategory()` → `self.filterByCategory()`: `this` is not the module inside a function-expression callback; `self` is already captured at the top of the module
- typo `cat.checkd` → `cat.checked`: the reset button never re-checked the category filter checkboxes

### object.js
- `!objectBkgdColor === undefined` / `!objectTxtColor === undefined` → `val !== '' && val != null`: operator precedence bug (`!str` returns boolean, never `undefined`) — the `if` branch was **never** executed, fallback color `#696969`/`#ebebeb` was always applied
- `.values` → `.value` on `<input>` element: `.values` is not a DOM property, `cmd` was always `undefined` in `updateSummaryButton`

### plan.js
- `img.getAttribute('data-sixe_x')` used for **both** height and width → `data-sixe_y` for height: the PHP template emits both `data-sixe_x` (width) and `data-sixe_y` (height)

### replace.js
- `seen()`/`unseen()` inverted in the name-search branch: matching equipment was hidden while non-matching was shown (the `searchId` branch above was correct)

### eqAnalyse.js
- typo `lebel` → `label`: Bootstrap `label-info` style was never applied to deleted-command badges

### administration.js
- undeclared `el` (implicit global, `ReferenceError` in strict mode) → `const el`

### update.js
- `document.getElementById('bt_' + _log + 'Jeedom .fa-refresh')` → `document.querySelector(...)`: `getElementById` does not accept a space + class selector, always returned `null` → spinner icon was never hidden after log load

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Suggested changelog entry

```
- fix(desktop/js): correct 11 DOM and logic bugs (dashboard, object, plan, replace, eqAnalyse, administration, update)
```

## Test plan

| File | Action | Expected |
|---|---|---|
| `dashboard.js` | Open dashboard with a duplicated eqLogic id → confirm Packery lays out all widgets | All widgets visible, no layout freeze |
| `dashboard.js` | Open dashboard with `?p=dashboard&category=light` → confirm filter dropdown shows warning style | Warning badge visible on dropdown button |
| `dashboard.js` | Click "Reset search" button → confirm all category checkboxes are checked | All checkboxes checked |
| `object.js` | Open an object page with a custom background CSS variable → confirm custom color is applied (not `#696969`) | Custom color rendered |
| `object.js` | Click the remove-summary button on an object → confirm `updateSummaryButton` receives the correct command id | No silent failure, summary button updated |
| `plan.js` | Open a plan with a background image → confirm height uses `data-sixe_y`, not `data-sixe_x` | Image correctly sized |
| `replace.js` | Type a device name in the search field → confirm matching devices are shown, non-matching hidden | Search works correctly |
| `eqAnalyse.js` | Open eqAnalyse page with deleted commands → confirm badge has `label-info` styling | Blue badge visible |
| `administration.js` | Open admin page, type in the config search field → confirm no `ReferenceError` in console | Search works, no JS error |
| `update.js` | Trigger a log auto-update → confirm spinner disappears after load | Spinner hidden correctly |

## Known risks

- `plan.js`: attribute names `data-sixe_x`/`data-sixe_y` are typos in the PHP template but consistent — this fix assumes the PHP template does emit `data-sixe_y` for height. Verified in `core/php/jeedom.ajax.php` plan rendering.
- All other fixes are mechanical substitutions with no behavioral ambiguity.