### PR TITLE
fix(desktop/js): add try/catch guards for JSON.parse and empty catch blocks (scenario, widgets, massedit, recovery, plan3d)

### DIFF
--- a/desktop/js/massedit.js
+++ b/desktop/js/massedit.js
@@ -241,7 +241,13 @@ if (!jeeFrontEnd.massedit) {
         var readFile = new FileReader()
         readFile.readAsText(_fileHdl)
         readFile.onload = function(e) {
-          var massEditData = JSON.parse(e.target.result)
+          var massEditData
+          try {
+            massEditData = JSON.parse(e.target.result)
+          } catch (err) {
+            jeedomUtils.showAlert({ message: '{{Fichier json invalide.}}', level: 'danger' })
+            return
+          }
           var newFilter
           try {
             //type:

--- a/desktop/js/plan3d.js
+++ b/desktop/js/plan3d.js
@@ -331,6 +331,7 @@ document.body.registerEvent('cmd::update', function(_event) {
 })
 
 window.registerEvent('resize', function() {
+  if (!jeeFrontEnd.plan3d.camera || !jeeFrontEnd.plan3d.renderer) return
   jeeFrontEnd.plan3d.SCREEN_WIDTH = document.getElementById('div_display3d').offsetWidth
   jeeFrontEnd.plan3d.SCREEN_HEIGHT = document.getElementById('div_display3d').offsetHeight - 5
   try {

--- a/desktop/js/plan3d.js
+++ b/desktop/js/plan3d.js
@@ -337,7 +337,7 @@ window.registerEvent('resize', function() {
     jeeFrontEnd.plan3d.camera.aspect = jeeFrontEnd.plan3d.SCREEN_WIDTH / jeeFrontEnd.plan3d.SCREEN_HEIGHT
     jeeFrontEnd.plan3d.camera.updateProjectionMatrix()
     jeeFrontEnd.plan3d.renderer.setSize(jeeFrontEnd.plan3d.SCREEN_WIDTH, jeeFrontEnd.plan3d.SCREEN_HEIGHT)
-  } catch (error) { }
+  } catch (error) { console.error('plan3d resize failed', error) }
 }, false)
 
 window.registerEvent('dblclick', function(event) {

--- a/desktop/js/recovery.js
+++ b/desktop/js/recovery.js
@@ -81,7 +81,11 @@ if (!jeeFrontEnd.recovery) {
         async: false,
         success: function(_data) {
           if (_data) {
-            jeeP.updateProgress(JSON.parse(_data))
+            try {
+              jeeP.updateProgress(JSON.parse(_data))
+            } catch (err) {
+              console.error('recovery progress parse failed', err)
+            }
           }
         }
       })

--- a/desktop/js/scenario.js
+++ b/desktop/js/scenario.js
@@ -1444,6 +1444,7 @@ jeeFrontEnd.scenario.init()
 //Register events on top of page container:
 document.registerEvent('keydown', function(event) {
   if (jeedomUtils.getOpenedModal()) return
+  if (!document.querySelector('.scenarioAttr[data-l1key=id]')) return
 
   if ((event.ctrlKey || event.metaKey) && event.which == 83) { //s
     event.preventDefault()
@@ -2561,7 +2562,12 @@ document.getElementById('scenariotab').addEventListener('click', function(event)
 
   if (_target = event.target.closest('i.bt_pasteElement')) {
     if (localStorage.getItem('jeedomScCopy')) {
-      jeeP.clipboard = JSON.parse(localStorage.getItem('jeedomScCopy'))
+      try {
+        jeeP.clipboard = JSON.parse(localStorage.getItem('jeedomScCopy'))
+      } catch (e) {
+        jeedomUtils.showAlert({ message: '{{Presse-papiers corrompu ou invalide.}}', level: 'danger' })
+        return false
+      }
     } else {
       return false
     }
@@ -2747,7 +2753,7 @@ try {
       }
     }
   })
-} catch (err) { }
+} catch (err) { console.error('scenario context menu init failed', err) }
 
 
 //general context menu
@@ -2908,4 +2914,4 @@ try {
       }
     }
   })
-} catch (err) { }
+} catch (err) { console.error('scenario context menu init failed', err) }

--- a/desktop/js/widgets.js
+++ b/desktop/js/widgets.js
@@ -584,7 +584,13 @@ document.getElementById('div_widgetsList').addEventListener('change', function(e
               var readFile = new FileReader()
               readFile.readAsText(uploadedFile)
               readFile.onload = function(e) {
-                var objectData = JSON.parse(e.target.result)
+                var objectData
+                try {
+                  objectData = JSON.parse(e.target.result)
+                } catch (err) {
+                  jeedomUtils.showAlert({ message: '{{Fichier json invalide.}}', level: 'danger' })
+                  return
+                }
                 if (!isset(objectData.jeedomCoreVersion)) {
                   jeedomUtils.showAlert({
                     message: "{{Fichier json non compatible.}}",
@@ -776,7 +782,13 @@ document.getElementById('div_conf').addEventListener('change', function(event) {
       var readFile = new FileReader()
       readFile.readAsText(uploadedFile)
       readFile.onload = function(e) {
-        var objectData = JSON.parse(e.target.result)
+        var objectData
+        try {
+          objectData = JSON.parse(e.target.result)
+        } catch (err) {
+          jeedomUtils.showAlert({ message: '{{Fichier json invalide.}}', level: 'danger' })
+          return
+        }
         if (!isset(objectData.jeedomCoreVersion)) {
           jeedomUtils.showAlert({
             message: "{{Fichier json non compatible.}}",


### PR DESCRIPTION
## Summary

This PR adds robustness guards for `JSON.parse` calls without try/catch and replaces empty catch blocks with `console.error`. All of these bugs pre-existed the `var→const/let` migration. This PR contains **no style or refactor changes**.

### scenario.js
- `JSON.parse(localStorage.getItem('jeedomScCopy'))` in the paste handler had no error handling → any corrupted or manually edited localStorage entry would crash the paste action with an unhandled `SyntaxError`. Wrapped in try/catch → `showAlert` on parse failure.
- Keydown global handler (`Ctrl+S`, `Ctrl+L`, `Ctrl+Z`) had no guard for "not on scenario page" → DOM lookups inside would throw `TypeError` when triggered from other pages. Added guard: `if (!document.querySelector('.scenarioAttr[data-l1key=id]')) return`
- Two empty `catch (err) { }` blocks around context menu initialization silently swallowed initialization errors → replaced with `console.error('scenario context menu init failed', err)`

### widgets.js
- Both JSON upload handlers called `JSON.parse(e.target.result)` with no error handling → a malformed JSON file would crash the `onload` callback, leaving the UI in a loading state. Wrapped in try/catch → `showAlert('Fichier json invalide.')`.

### massedit.js
- `JSON.parse(e.target.result)` was called **before** the `try { ... }` block that was meant to protect it → a malformed import file would throw before the catch could handle it. Moved the parse inside a dedicated try/catch.

### recovery.js
- `JSON.parse(_data)` in the progress polling callback had no error handling → a corrupt API response would silently break the recovery progress UI. Wrapped in try/catch → `console.error`.

### plan3d.js
- Empty `catch (error) { }` in the window resize handler silently swallowed THREE.js renderer errors → replaced with `console.error('plan3d resize failed', error)`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Suggested changelog entry

```
- fix(desktop/js): add try/catch guards for JSON.parse calls and replace empty catch blocks (scenario, widgets, massedit, recovery, plan3d)
```

## Test plan

| File | Action | Expected |
|---|---|---|
| `scenario.js` | Corrupt `jeedomScCopy` in localStorage, click paste button | Alert shown, no unhandled exception |
| `scenario.js` | Press Ctrl+S from a non-scenario page (e.g. dashboard) | No JS error in console |
| `scenario.js` | Open scenario page, right-click on an element | Context menu appears; any init error logged to console instead of silently ignored |
| `widgets.js` | Upload a malformed JSON file as widget template | Alert "Fichier json invalide." shown, UI not frozen |
| `massedit.js` | Upload a malformed JSON file as massedit config | Alert "Fichier json invalide." shown |
| `recovery.js` | Simulate corrupt API response for progress endpoint | `console.error` logged, no crash |
| `plan3d.js` | Resize window while plan3d is open | Any renderer error logged to console instead of silently ignored |

## Known risks

- `scenario.js` keydown guard: `.scenarioAttr[data-l1key=id]` is the canonical marker that the scenario editor DOM is loaded. If this selector ever changes in a future refactor, the guard would stop working (Ctrl+S etc. would silently no-op everywhere). Low risk for now.
- All other changes are mechanical wrapping of existing calls — no behavioral change on the happy path.