### PR TITLE
refactor(desktop/js): replace var with const/let in display modules (dashboard, widgets, plan, plan3d, eqAnalyse)

### DIFF
--- a/desktop/js/dashboard.js
+++ b/desktop/js/dashboard.js
@@ -35,12 +35,12 @@ if (!jeeFrontEnd.dashboard) {
           element.parentNode.remove()
         })
         document.querySelectorAll('div.div_object').forEach(function(div_object) {
-          var objId = div_object.getAttribute('data-object_id')
+          const objId = div_object.getAttribute('data-object_id')
           jeeFrontEnd.dashboard.getObjectHtmlFromSummary(objId)
         })
       } else {
         document.querySelectorAll('div.div_object').forEach(function(div_object) {
-          var objId = div_object.getAttribute('data-object_id')
+          const objId = div_object.getAttribute('data-object_id')
           jeeFrontEnd.dashboard.getObjectHtml(objId)
         })
       }
@@ -73,13 +73,13 @@ if (!jeeFrontEnd.dashboard) {
     },
     filterByCategory: function() {
       //get defined categories:
-      var cats = []
+      const cats = []
       document.querySelectorAll('#categoryfilter .catFilterKey').forEach(function(element) {
         if (element.checked) cats.push(element.getAttribute('data-key'))
       })
 
       //check eqLogics cats:
-      var eqCats, catFound
+      let eqCats, catFound
       document.querySelectorAll('div.eqLogic-widget').forEach(function(eqLogic) {
         catFound = false
         if (eqLogic.hasAttribute('data-translate-category')) {
@@ -108,7 +108,7 @@ if (!jeeFrontEnd.dashboard) {
       }
 
       document.querySelectorAll('.div_displayEquipement').forEach(function(element) {
-        var visibles = [...element.querySelectorAll('div.eqLogic-widget, div.scenario-widget')].filter(el => el.isVisible())
+        const visibles = [...element.querySelectorAll('div.eqLogic-widget, div.scenario-widget')].filter(el => el.isVisible())
         if (visibles.length == 0) {
           element.closest('.div_object').unseen()
         } else {
@@ -186,10 +186,10 @@ if (!jeeFrontEnd.dashboard) {
         if (jeeFrontEnd.dashboard.draggables.length == 0) {
           //No draggies set yet:
           document.querySelectorAll('div.div_displayEquipement').forEach(_divObject => {
-            var pckry = Packery.data(_divObject)
+            const pckry = Packery.data(_divObject)
             pckry.getItemElements().forEach(function(itemElem, idx) {
               itemElem.setAttribute('data-order', idx + 1)
-              var draggie = new Draggabilly(itemElem)
+              const draggie = new Draggabilly(itemElem)
               jeeFrontEnd.dashboard.draggables.push(draggie)
               pckry.bindDraggabillyEvents(draggie)
 
@@ -210,7 +210,7 @@ if (!jeeFrontEnd.dashboard) {
         }
 
         //show orders:
-        var value
+        let value
         document.querySelectorAll('.jeedomAlreadyPosition').forEach(function(element) {
           value = element.getAttribute('data-order')
           if (element.querySelector('.counterReorderJeedom')) {
@@ -237,7 +237,7 @@ if (!jeeFrontEnd.dashboard) {
     },
     getObjectHtmlFromSummary: function(_object_id) {
       if (_object_id == null) return
-      let self = this
+      const self = this
       self._object_id = _object_id
       self.summaryObjEqs = []
       self.summaryObjEqs[_object_id] = []
@@ -254,15 +254,15 @@ if (!jeeFrontEnd.dashboard) {
           })
         },
         success: function(data) {
-          var dom_divDisplayEq = document.getElementById('div_ob' + _object_id)
-          var nbEqs = data.length
+          const dom_divDisplayEq = document.getElementById('div_ob' + _object_id)
+          let nbEqs = data.length
           if (nbEqs == 0) {
             dom_divDisplayEq.closest('.div_object').parentNode.remove()
             return
           } else {
             dom_divDisplayEq.closest('.div_object').removeClass('hidden')
           }
-          for (var i = 0; i < nbEqs; i++) {
+          for (let i = 0; i < nbEqs; i++) {
             if (self.summaryObjEqs[self._object_id].includes(data[i].id)) {
               nbEqs--
               return
@@ -303,7 +303,7 @@ if (!jeeFrontEnd.dashboard) {
       })
     },
     getObjectHtml: function(_object_id) {
-      let self = this
+      const self = this
       jeedom.object.toHtml({
         id: _object_id,
         hideOnMain: (getUrlVars('childs') === false) ? 1 : 0,
@@ -318,7 +318,7 @@ if (!jeeFrontEnd.dashboard) {
           })
         },
         success: function(html) {
-          var dom_divDisplayEq = document.getElementById('div_ob' + _object_id)
+          const dom_divDisplayEq = document.getElementById('div_ob' + _object_id)
           try {
             if (html == '') {
               dom_divDisplayEq.closest('.div_object').parentNode.remove()
@@ -344,7 +344,7 @@ if (!jeeFrontEnd.dashboard) {
 
           //synch category filter:
           if (self.url_category != 'all') {
-            let cat = self.url_category.charAt(0).toUpperCase() + self.url_category.slice(1)
+            const cat = self.url_category.charAt(0).toUpperCase() + self.url_category.slice(1)
             document.getElementById('dashTopBar button.dropdown-toggle').addClass('warning')
             document.querySelectorAll('#categoryfilter .catFilterKey').forEach(function(element) {
               element.checked = false
@@ -389,7 +389,7 @@ if (typeof jeephp2js.rootObjectId != 'undefined') {
       jeedomUtils.setBackgroundImage(_path)
     }
   })
-  let lia = document.querySelector('#dashOverviewPrev a[data-object_id="' + jeephp2js.rootObjectId + '"]')
+  const lia = document.querySelector('#dashOverviewPrev a[data-object_id="' + jeephp2js.rootObjectId + '"]')
   if (lia) lia.parentNode.addClass('active')
 }
 
@@ -398,7 +398,7 @@ jeeP.postInit()
 //searching
 document.getElementById('in_searchDashboard')?.addEventListener('keyup', function(event) {
   if (jeedomUI.isEditing) return
-  var search = this.value
+  let search = this.value
   document.querySelectorAll('.div_object:not(.hideByObjectSel)').seen()
   if (search == '') {
     document.querySelectorAll('div.eqLogic-widget, div.scenario-widget').seen()
@@ -407,11 +407,11 @@ document.getElementById('in_searchDashboard')?.addEventListener('keyup', functio
   }
 
   search = jeedomUtils.normTextLower(search)
-  var not = search.startsWith(":not(")
+  const not = search.startsWith(":not(")
   if (not) {
     search = search.replace(':not(', '')
   }
-  var match, text
+  let match, text
   document.querySelectorAll('div.eqLogic-widget').forEach(function(element) {
     match = false
     text = jeedomUtils.normTextLower(element.querySelector('.widget-name > a')?.textContent)
@@ -451,7 +451,7 @@ document.getElementById('in_searchDashboard')?.addEventListener('keyup', functio
     }
   })
   document.querySelectorAll('.div_displayEquipement').forEach(function(element) {
-    var visibles = [...element.querySelectorAll('div.eqLogic-widget, div.scenario-widget')].filter(el => el.isVisible())
+    const visibles = [...element.querySelectorAll('div.eqLogic-widget, div.scenario-widget')].filter(el => el.isVisible())
     if (visibles.length == 0) element.closest('.div_object').unseen()
   })
   document.querySelectorAll('div.div_displayEquipement').forEach(_div => { Packery.data(_div).layout() })
@@ -466,7 +466,7 @@ document.getElementById('bt_resetDashboardSearch')?.addEventListener('click', fu
 /*Events delegations
 */
 document.getElementById('div_pageContainer').addEventListener('click', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('#bt_editDashboardWidgetOrder')) {
     if (_target.getAttribute('data-mode') == 1) {
         _target.setAttribute('data-mode', 0)
@@ -487,7 +487,7 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
   }
 
   if (_target = event.target.closest('.editOptions')) { //Edit mode tile icon
-    var eqId = _target.closest('div.eqLogic-widget').getAttribute('data-eqlogic_id')
+    const eqId = _target.closest('div.eqLogic-widget').getAttribute('data-eqlogic_id')
     jeeDialog.dialog({
       id: 'md_dashEdit',
       width: '600px',
@@ -516,13 +516,13 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
   }
 
   if (_target = event.target.closest('.bt_editDashboardTilesAutoResizeUp')) { //Edit mode resize up button
-    var id_object = _target.getAttribute('data-obecjtid')
-    var objectContainer = document.querySelector('#div_ob' + id_object + '.div_displayEquipement')
-    var arHeights = []
+    const id_object = _target.getAttribute('data-obecjtid')
+    const objectContainer = document.querySelector('#div_ob' + id_object + '.div_displayEquipement')
+    const arHeights = []
     objectContainer.querySelectorAll('div.eqLogic-widget, div.scenario-widget').forEach(function(element) {
       arHeights.push(element.offsetHeight)
     })
-    var maxHeight = Math.max(...arHeights)
+    const maxHeight = Math.max(...arHeights)
     objectContainer.querySelectorAll('div.eqLogic-widget, div.scenario-widget').forEach(function(element) {
       element.style.height = maxHeight + 'px'
     })
@@ -531,13 +531,13 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
   }
 
   if (_target = event.target.closest('.bt_editDashboardTilesAutoResizeDown')) { //Edit mode resize down button
-    var id_object = _target.getAttribute('data-obecjtid')
-    var objectContainer = document.querySelector('#div_ob' + id_object + '.div_displayEquipement')
-    var arHeights = []
+    const id_object = _target.getAttribute('data-obecjtid')
+    const objectContainer = document.querySelector('#div_ob' + id_object + '.div_displayEquipement')
+    const arHeights = []
     objectContainer.querySelectorAll('div.eqLogic-widget, div.scenario-widget').forEach(function(element) {
       arHeights.push(element.offsetHeight)
     })
-    var minHeight = Math.min(...arHeights)
+    const minHeight = Math.min(...arHeights)
     objectContainer.querySelectorAll('div.eqLogic-widget, div.scenario-widget').forEach(function(element) {
       element.style.height = minHeight + 'px'
     })
@@ -557,7 +557,7 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
   }
 
   if (_target = event.target.closest('.objectPreview')) { //
-    var url = 'index.php?v=d&p=dashboard&object_id=' + _target.getAttribute('data-object_id') + '&childs=0&btover=1'
+    const url = 'index.php?v=d&p=dashboard&object_id=' + _target.getAttribute('data-object_id') + '&childs=0&btover=1'
     if ((isset(event.detail) && event.detail.ctrlKey) || event.ctrlKey || event.metaKey) {
       window.open(url).focus()
     } else {
@@ -567,7 +567,7 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
   }
 
   if (_target = event.target.closest('.li_object')) { //Dashboard mode list:
-    var object_id = _target.querySelector('a[data-object_id]')?.getAttribute('data-object_id')
+    const object_id = _target.querySelector('a[data-object_id]')?.getAttribute('data-object_id')
     if (document.querySelector('.div_object[data-object_id="' + object_id + '"]') != null && getUrlVars('summary') === false) { //Object already there as child
       jeedom.object.getImgPath({
         id: object_id,
@@ -608,7 +608,7 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
 }, {buble: true})
 
 document.getElementById('div_pageContainer').addEventListener('mouseenter', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('#bt_overview')) { //bt_overview arrow:
     event.stopImmediatePropagation()
     event.stopPropagation()
@@ -622,9 +622,9 @@ document.getElementById('div_pageContainer').addEventListener('mouseenter', func
 
   if (_target = event.target.closest('.objectPreview')) { //Show summary in overview preview tiles
     document.querySelectorAll('#dashOverviewPrevSummaries > .objectSummaryContainer').unseen()
-    var width = window.outerWidth
-    var position = event.target.getBoundingClientRect()
-    var css = {
+    const width = window.outerWidth
+    const position = event.target.getBoundingClientRect()
+    const css = {
       top: position.top - 95 + 'px'
     }
     if (position.left > width / 2) {
@@ -634,7 +634,7 @@ document.getElementById('div_pageContainer').addEventListener('mouseenter', func
       css.left = position.left + 'px'
       css.right = 'unset'
     }
-    var summary = document.querySelector('.objectSummaryContainer.objectSummary' + _target.getAttribute('data-object_id'))
+    const summary = document.querySelector('.objectSummaryContainer.objectSummary' + _target.getAttribute('data-object_id'))
     summary.seen()
     Object.assign(summary.style, css)
     return
@@ -642,7 +642,7 @@ document.getElementById('div_pageContainer').addEventListener('mouseenter', func
 }, {capture: true})
 
 document.getElementById('div_pageContainer').addEventListener('mouseleave', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('#bt_overview')) { //bt_overview arrow:
     clearTimeout(jeeP.btOverviewTimer)
     event.stopImmediatePropagation()
@@ -660,18 +660,18 @@ document.getElementById('div_pageContainer').addEventListener('mouseleave', func
 }, {capture: true})
 
 document.getElementById('div_pageContainer').addEventListener('mouseup', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('.objectPreview')) {
     if (event.which == 2) {
       event.preventDefault()
-      var id = _target.getAttribute('data-object_id')
+      const id = _target.getAttribute('data-object_id')
       document.querySelector('.objectPreview[data-object_id="' + id + '"] .name').triggerEvent('click', {detail: {ctrlKey: true}})
     }
     return
   }
 
   if (event.target.matches('#categoryfilter input.catFilterKey')) {
-    var checkbox = event.target.closest('li').querySelector('input.catFilterKey')
+    const checkbox = event.target.closest('li').querySelector('input.catFilterKey')
     if (checkbox == null) return
     event.preventDefault()
     event.stopPropagation()
@@ -694,10 +694,7 @@ document.getElementById('div_pageContainer').addEventListener('mousedown', funct
     event.stopImmediatePropagation()
     event.stopPropagation()
     event.preventDefault()
-    var checkbox = event.target.closest('li').querySelector('.catFilterKey')
-    if (checkbox == null) return
-
-    var checkbox = event.target.closest('li').querySelector('.catFilterKey')
+    const checkbox = event.target.closest('li').querySelector('.catFilterKey')
     if (checkbox == null) return
     if (event.which == 2) {
       if (document.querySelectorAll('.catFilterKey:checked').length == 1 && checkbox.checked) {
@@ -715,7 +712,7 @@ document.getElementById('div_pageContainer').addEventListener('mousedown', funct
 
 //Event for App Mobile:
 document.body.addEventListener('jeeObject::summary::update', function(_event) {
-  for (var i in _event.detail) {
+  for (const i in _event.detail) {
     if(isset(_event.detail[i].force) && _event.detail[i].force == 1) continue
     if(_event.detail[i].object_id == 'global') {
       /* SEND UPDATE SUMMARY TO APP */

--- a/desktop/js/eqAnalyse.js
+++ b/desktop/js/eqAnalyse.js
@@ -43,7 +43,7 @@ if (!jeeFrontEnd.eqAnalyse) {
       this.eqlogicsEls = document.querySelectorAll('div.batteryListContainer > div.eqLogic-widget')
     },
     getRemoveCmd: function(_id) {
-      for (var i in jeephp2js.removeHistory) {
+      for (const i in jeephp2js.removeHistory) {
         if (jeephp2js.removeHistory[i].type == 'cmd' && jeephp2js.removeHistory[i].id == _id) return jeephp2js.removeHistory[i]
       }
       return false
@@ -57,10 +57,10 @@ if (!jeeFrontEnd.eqAnalyse) {
           })
         },
         success: function(data) {
-          var tr = ''
-          var removed
-          for (var i in data) {
-            for (var j in data[i].cmd) {
+          let tr = ''
+          let removed
+          for (const i in data) {
+            for (const j in data[i].cmd) {
               tr += '<tr>'
               tr += '<td>'
               tr += data[i].name
@@ -87,7 +87,7 @@ if (!jeeFrontEnd.eqAnalyse) {
               tr += '</tr>'
             }
           }
-          let tableDeadCmd = document.getElementById('table_deadCmd')
+          const tableDeadCmd = document.getElementById('table_deadCmd')
           tableDeadCmd.tBodies[0].empty().insertAdjacentHTML('beforeend', tr)
           if (tableDeadCmd._dataTable) tableDeadCmd._dataTable.refresh()
         }
@@ -103,18 +103,18 @@ document.getElementById('in_search')?.addEventListener('keyup', function(event) 
   if (jeeP.eqlogicsEls.length == 0) {
     return
   }
-  var search = event.target.closest('#in_search').value
+  let search = event.target.closest('#in_search').value
   if (search == '') {
     jeeP.eqlogicsEls.seen()
     return
   }
   search = jeedomUtils.normTextLower(search)
-  var not = search.startsWith(":not(")
+  const not = search.startsWith(":not(")
   if (not) {
     search = search.replace(':not(', '')
   }
 
-  var match, text
+  let match, text
   jeeP.eqlogicsEls.forEach(_el => {
     match = false
     text = jeedomUtils.normTextLower(_el.querySelector('.widget-name').textContent)
@@ -143,7 +143,7 @@ window.registerEvent("resize", function eqAnalyse(event) {
 
 //Manage events outside parents delegations:
 document.getElementById('bt_massConfigureEqLogic')?.addEventListener('click', function(event) {
-  var field = "{{Alertes Communications}}"
+  const field = "{{Alertes Communications}}"
   jeeDialog.dialog({
     id: 'jee_modal',
     title: "{{Configuration en masse}}",
@@ -155,7 +155,7 @@ document.getElementById('bt_massConfigureEqLogic')?.addEventListener('click', fu
 /*Events delegations
 */
 document.getElementById('div_pageContainer').addEventListener('click', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('#tab_alerts')) {
     setTimeout(function() {
       jeedomUtils.positionEqLogic()

--- a/desktop/js/plan.js
+++ b/desktop/js/plan.js
@@ -58,7 +58,7 @@ if (!jeeFrontEnd.plan) {
       })
     },
     postInit: function() {
-      for (var i in jeephp2js.planHeader) {
+      for (const i in jeephp2js.planHeader) {
         jeeP.planHeaderContextMenu[jeephp2js.planHeader[i].id] = {
           name: jeephp2js.planHeader[i].name,
           callback: function(key, opt) {
@@ -148,7 +148,7 @@ if (!jeeFrontEnd.plan) {
         code: _code,
         error: function(error) {
           if (error.code == -32005) {
-            var result = prompt("{{Veuillez indiquer le code ?}}", "")
+            const result = prompt("{{Veuillez indiquer le code ?}}", "")
             if (result == null) {
               jeedomUtils.showAlert({
                 message: error.message,
@@ -182,16 +182,17 @@ if (!jeeFrontEnd.plan) {
             jeeFrontEnd.plan.planContainer.style.backgroundColor = 'rgb(--bg-color)'
           }
           if (data.configuration != null && init(data.configuration.desktopSizeX) != '' && init(data.configuration.desktopSizeY) != '') {
-            var style = {
+            const style = {
               height: data.configuration.desktopSizeY + 'px',
               width: data.configuration.desktopSizeX + 'px'
             }
             Object.assign(jeeFrontEnd.plan.planContainer.style, style)
-            var img = document.querySelector('.div_displayObject img') ? Object.assign(img.style, style) : null
+            const img = document.querySelector('.div_displayObject img')
+            if (img) Object.assign(img.style, style)
           } else {
-            var img = document.querySelector('.div_displayObject img')
+            const img = document.querySelector('.div_displayObject img')
             if (img != null) {
-              var style = {
+              const style = {
                 height: img.getAttribute('data-sixe_x') + 'px',
                 width: img.getAttribute('data-sixe_x') + 'px'
               }
@@ -218,7 +219,7 @@ if (!jeeFrontEnd.plan) {
           }
 
           //display design components:
-          var selector = '.eqLogic-widget, .div_displayObject > .cmd-widget, .scenario-widget'
+          let selector = '.eqLogic-widget, .div_displayObject > .cmd-widget, .scenario-widget'
           selector += ',.plan-link-widget, .view-link-widget, .graph-widget, .text-widget, .image-widget, .zone-widget, .summary-widget'
           document.querySelectorAll(selector).remove()
           jeeFrontEnd.modifyWithoutSave = false
@@ -232,8 +233,8 @@ if (!jeeFrontEnd.plan) {
             },
             success: function(plans) {
               try {
-                var object
-                for (var i in plans) {
+                let object
+                for (const i in plans) {
                   object = jeeP.displayObject(plans[i].plan, plans[i].html, true)
                   if (object != undefined) {
                     jeeFrontEnd.plan.planContainer.appendChild(object)
@@ -264,8 +265,8 @@ if (!jeeFrontEnd.plan) {
       _plan = init(_plan, {})
       _plan.position = init(_plan.position, {})
       _plan.css = init(_plan.css, {})
-      var css_selector = ''
-      var another_css = ''
+      let css_selector = ''
+      let another_css = ''
 
       //get css selector:
       if (['eqLogic', 'scenario', 'text', 'image', 'zone', 'summary'].includes(_plan.link_type)) {
@@ -287,13 +288,13 @@ if (!jeeFrontEnd.plan) {
           _html = _html.replace('class="graph-widget"', 'class="graph-widget transparent"')
         }
       }
-      var node = domUtils.DOMparseHTML(_html)
+      const node = domUtils.DOMparseHTML(_html)
       node.setAttribute('data-plan_id', _plan.id)
       node.setAttribute('data-zoom', init(_plan.css.zoom, 1))
       node.addClass('jeedomAlreadyPosition', 'noResize')
 
       //set widget style:
-      var style = {}
+      const style = {}
       style['z-index'] = '1000'
       style['position'] = 'absolute'
       style['top'] = init(_plan.position.top, '10') + 'px'
@@ -314,7 +315,7 @@ if (!jeeFrontEnd.plan) {
         }
       }
 
-      for (var key in _plan.css) {
+      for (const key in _plan.css) {
         if (_plan.css[key] === '' || key == 'zoom' || key == 'rotate') continue
         if (key == 'z-index' && _plan.css[key] < 999) continue
 
@@ -361,7 +362,7 @@ if (!jeeFrontEnd.plan) {
 
       if (_plan.css['opacity'] && _plan.css['opacity'] !== '' && style['background-color'] && style['background-color'] != 'transparent') {
         if (style['background-color'].indexOf('#') != -1) {
-          var rgb = jeedomUtils.hexToRgb(style['background-color'])
+          const rgb = jeedomUtils.hexToRgb(style['background-color'])
           style['background-color'] = 'rgba(' + rgb.r + ',' + rgb.g + ',' + rgb.b + ',' + _plan.css['opacity'] + ')'
         } else {
           style['background-color'] = style['background-color'].replace(')', ',' + _plan.css['opacity'] + ')').replace('rgb', 'rgba')
@@ -377,7 +378,7 @@ if (!jeeFrontEnd.plan) {
           node.addClass('displayObjectName')
         }
         if (isset(_plan.display.cmdHide)) {
-          for (var i in _plan.display.cmdHide) {
+          for (const i in _plan.display.cmdHide) {
             if (_plan.display.cmdHide[i] == 0) {
               continue
             }
@@ -385,7 +386,7 @@ if (!jeeFrontEnd.plan) {
           }
         }
         if (isset(_plan.display.cmdHideName)) {
-          for (var i in _plan.display.cmdHideName) {
+          for (const i in _plan.display.cmdHideName) {
             if (_plan.display.cmdHideName[i] == 0) {
               continue
             }
@@ -394,7 +395,7 @@ if (!jeeFrontEnd.plan) {
           }
         }
         if (isset(_plan.display.cmdTransparentBackground)) {
-          for (var i in _plan.display.cmdTransparentBackground) {
+          for (const i in _plan.display.cmdTransparentBackground) {
             if (_plan.display.cmdTransparentBackground[i] == 0) {
               continue
             }
@@ -414,7 +415,7 @@ if (!jeeFrontEnd.plan) {
       }
 
       if (_plan.link_type == 'cmd') {
-        var center = document.createElement('center')
+        const center = document.createElement('center')
         center.append(...node.childNodes)
         node.appendChild(center)
 
@@ -437,11 +438,11 @@ if (!jeeFrontEnd.plan) {
       }
 
       document.querySelector('#style_' + _plan.link_type + '_' + _plan.id)?.remove()
-      var style_el = '<style class="style_plan_specific" id="style_' + _plan.link_type + '_' + _plan.id + '">'
+      let style_el = '<style class="style_plan_specific" id="style_' + _plan.link_type + '_' + _plan.id + '">'
       if (_plan.display.css && _plan.display.css != '') {
         if (_plan.display.cssApplyOn && _plan.display.cssApplyOn != '') {
-          var cssApplyOn = _plan.display.cssApplyOn.split(',')
-          for (var i in cssApplyOn) {
+          const cssApplyOn = _plan.display.cssApplyOn.split(',')
+          for (const i in cssApplyOn) {
             style_el += css_selector + ' ' + cssApplyOn[i] + '{' + _plan.display.css + '}'
           }
         } else {
@@ -451,7 +452,7 @@ if (!jeeFrontEnd.plan) {
       style_el += css_selector + '{'
 
 
-      for (var i in style) {
+      for (const i in style) {
         if (['left', 'top', 'bottom', 'right', 'height', 'width', 'box-shadow'].includes(i)) {
           style_el += i + ':' + style[i] + ';'
         } else {
@@ -464,8 +465,8 @@ if (!jeeFrontEnd.plan) {
         jeeFrontEnd.plan.pageContainer.insertAdjacentHTML('beforeend', style_el)
         jeeFrontEnd.plan.planContainer.appendChild(node)
         if (isset(_plan.display) && isset(_plan.display.graph)) {
-          var done = 0
-          for (var i in _plan.display.graph) {
+          let done = 0
+          for (const i in _plan.display.graph) {
             if (init(_plan.display.graph[i].link_id) != '') {
               done += 1
               jeedom.history.drawChart({
@@ -523,13 +524,13 @@ if (!jeeFrontEnd.plan) {
     },
     //Events setter
     setGraphResizes: function () {
-      for (var obs of this.resizeObservers) {
+      for (const obs of this.resizeObservers) {
         obs.disconnect()
       }
       this.resizeObservers = []
       document.querySelectorAll('.graph-widget').forEach(function(_graph) {
-        var obs = new ResizeObserver(entries => {
-          var graphWidget = entries[0].target
+        const obs = new ResizeObserver(entries => {
+          const graphWidget = entries[0].target
           if (isset(jeedom.history.chart['div_designGraph' + graphWidget.getAttribute('data-graph_id')])) {
             jeedom.history.chart['div_designGraph' + graphWidget.getAttribute('data-graph_id')].chart.reflow()
           }
@@ -540,9 +541,9 @@ if (!jeeFrontEnd.plan) {
     },
     //Edit mode:
     initEditOption: function(_state) {
-      var editSelector = '.plan-link-widget, .view-link-widget, .graph-widget, .div_displayObject >.eqLogic-widget'
+      let editSelector = '.plan-link-widget, .view-link-widget, .graph-widget, .div_displayObject >.eqLogic-widget'
       editSelector += ', .div_displayObject > .cmd-widget, .scenario-widget, .text-widget, .image-widget, .zone-widget,.summary-widget'
-      var editItems = document.querySelectorAll(editSelector)
+      const editItems = document.querySelectorAll(editSelector)
 
       if (_state) { //Enter Edit mode
         jeeFrontEnd.planEditOption.state = true
@@ -558,7 +559,7 @@ if (!jeeFrontEnd.plan) {
 
         //Set draggies:
         editItems.forEach(item => {
-          var draggie = new Draggabilly(item, {
+          const draggie = new Draggabilly(item, {
             containment: 'div.div_displayObject',
           })
           jeeFrontEnd.plan.draggables.push(draggie)
@@ -657,7 +658,7 @@ if (!jeeFrontEnd.plan) {
         }
 
         //Set Resizing:
-        let selector = '.plan-link-widget, .view-link-widget, .graph-widget, .div_displayObject >.eqLogic-widget, .scenario-widget, .text-widget, .image-widget, .zone-widget, .summary-widget'
+        const selector = '.plan-link-widget, .view-link-widget, .graph-widget, .div_displayObject >.eqLogic-widget, .scenario-widget, .text-widget, .image-widget, .zone-widget, .summary-widget'
         new jeeResize(selector, {
           cancel: 'locked',
           containment: document.querySelector('.div_displayObject'),
@@ -721,8 +722,8 @@ if (!jeeFrontEnd.plan) {
           if (item._jeeResize) item._jeeResize.destroy()
         })
         jeeFrontEnd.plan.draggables.forEach(draggie => {
-          let left = draggie.element.style.left
-          let top = draggie.element.style.top
+          const left = draggie.element.style.left
+          const top = draggie.element.style.top
           draggie.destroy()
           draggie.element.style.left = left
           draggie.element.style.top = top
@@ -742,10 +743,10 @@ if (!jeeFrontEnd.plan) {
     savePlan: function(_refreshDisplay, _async) {
       if (jeephp2js.planHeader_id == -1) return
       domUtils.showLoading()
-      var plans = []
-      var info, plan, position
+      const plans = []
+      let info, plan, position
 
-      var selector = '.div_displayObject >.eqLogic-widget, .div_displayObject > .cmd-widget, .scenario-widget'
+      let selector = '.div_displayObject >.eqLogic-widget, .div_displayObject > .cmd-widget, .scenario-widget'
       selector += ', .plan-link-widget, .view-link-widget, .graph-widget, .text-widget, .image-widget, .zone-widget, .summary-widget'
       document.querySelectorAll(selector).forEach(function(_element) {
         info = jeeP.getElementInfo(_element)
@@ -847,13 +848,13 @@ if (jeedomUtils.userDevice.type == 'desktop' && user_isAdmin == 1) {
         name: '{{Configuration avancée}}',
         icon: 'fas fa-cog',
         disabled: function(key, opt) {
-          var info = jeeP.getElementInfo(this)
+          const info = jeeP.getElementInfo(this)
           return !(info.type == 'eqLogic' || info.type == 'cmd' || info.type == 'graph')
         },
         callback: function(key, opt) {
-          var info = jeeP.getElementInfo(this)
+          const info = jeeP.getElementInfo(this)
           if (info.type == 'graph') {
-            var dom_el = this
+            let dom_el = this
             if (dom_el.length) dom_el = dom_el[0]
             jeeDialog.dialog({
               id: 'jee_modalGraph',
@@ -864,7 +865,7 @@ if (jeedomUtils.userDevice.type == 'desktop' && user_isAdmin == 1) {
                   className: 'success',
                   callback: {
                     click: function(event) {
-                      var options = jeeFrontEnd.md_cmdGraphSelect.getOptions()
+                      const options = jeeFrontEnd.md_cmdGraphSelect.getOptions()
 
                       dom_el.querySelector('.graphOptions').empty().append(JSON.stringify(options))
                       jeeP.savePlan(true)
@@ -886,7 +887,7 @@ if (jeedomUtils.userDevice.type == 'desktop' && user_isAdmin == 1) {
               contentUrl: 'index.php?v=d&modal=cmd.graph.select',
               callback: function() {
                 document.querySelectorAll('#table_addViewData tbody tr .enable').forEach(_check => { _check.checked = false})
-                var options = json_decode(dom_el.querySelector('.graphOptions').jeeValue())
+                const options = json_decode(dom_el.querySelector('.graphOptions').jeeValue())
                 jeeFrontEnd.md_cmdGraphSelect.displayOptions(options)
               }
             })
@@ -922,11 +923,11 @@ if (jeedomUtils.userDevice.type == 'desktop' && user_isAdmin == 1) {
         name: '{{Dupliquer}}',
         icon: 'far fa-copy',
         disabled: function(key, opt) {
-          var info = jeeP.getElementInfo(this)
+          const info = jeeP.getElementInfo(this)
           return !(info.type == 'text' || info.type == 'graph' || info.type == 'zone')
         },
         callback: function(key, opt) {
-          var info = jeeP.getElementInfo(this)
+          const info = jeeP.getElementInfo(this)
           jeedom.plan.copy({
             id: this.getAttribute('data-plan_id'),
             version: 'dashboard',
@@ -1307,7 +1308,7 @@ if (jeedomUtils.userDevice.type == 'desktop' && user_isAdmin == 1) {
         },
         callback: function(key, opt) {
           let name = "";
-          for(let i in jeephp2js.planHeader){
+          for(const i in jeephp2js.planHeader){
             if(jeephp2js.planHeader[i].id == jeephp2js.planHeader_id){
               name = jeephp2js.planHeader[i].name+ " copie";
             }
@@ -1392,21 +1393,21 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
     event.preventDefault()
     return
   }
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('#bt_createNewDesign')) {
     jeeP.createNewDesign()
     return
   }
 
   if (_target = event.target.closest('.view-link-widget')) {
-    var link = _target.querySelector('a')
+    const link = _target.querySelector('a')
     link.click()
     return
   }
 
   if (_target = event.target.closest('.plan-link-widget')) {
     if (!jeeFrontEnd.planEditOption.state) {
-      var linkId = _target.getAttribute('data-link_id')
+      const linkId = _target.getAttribute('data-link_id')
       if (linkId == undefined) return
       jeephp2js.planHeader_id = linkId
       jeeP.displayPlan()
@@ -1449,7 +1450,7 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
         success: function(data) {
           if (data.html) {
             _target.html(data.html, true)
-            let inserted = _target.childNodes[0]
+            const inserted = _target.childNodes[0]
             inserted.style = inserted.style.cssText + _target.getAttribute('data-position')
             inserted.style.position = 'absolute'
             jeedomUtils.positionEqLogic(_target.getAttribute('data-eqLogic_id'), false)
@@ -1465,7 +1466,7 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
 document.querySelector('.div_displayObject').addEventListener('mouseenter', function(event) {
   if (event.target.matches('.zone-widget.zoneEqLogic.zoneEqLogicOnFly')) {
     if (!jeeFrontEnd.planEditOption.state && event.target.getAttribute('data-flying') != '1') {
-      var el = event.target
+      const el = event.target
       el.setAttribute('data-flying', '1')
       jeeP.clickedOpen = true
       jeedom.eqLogic.toHtml({
@@ -1475,7 +1476,7 @@ document.querySelector('.div_displayObject').addEventListener('mouseenter', func
         success: function(data) {
           if (data.html) {
             el.html(data.html, true)
-            let inserted = el.childNodes[0]
+            const inserted = el.childNodes[0]
             inserted.style = inserted.style.cssText + el.getAttribute('data-position')
             inserted.style.position = 'absolute'
             jeedomUtils.positionEqLogic(el.getAttribute('data-eqLogic_id'), false)
@@ -1501,7 +1502,7 @@ document.querySelector('.div_displayObject').addEventListener('mouseleave', func
 
 //Event for App Mobile:
 document.body.addEventListener('jeeObject::summary::update', function(_event) {
-  for (var i in _event.detail) {
+  for (const i in _event.detail) {
     if(isset(_event.detail[i].force) && _event.detail[i].force == 1) continue
     if(_event.detail[i].object_id == 'global') {
       /* SEND UPDATE SUMMARY TO APP */

--- a/desktop/js/plan3d.js
+++ b/desktop/js/plan3d.js
@@ -55,7 +55,7 @@ if (!jeeFrontEnd.plan3d) {
         jeeFrontEnd.plan3d.mouse.x = ((event.clientX - document.getElementById('div_display3d').offsetLeft) / jeeFrontEnd.plan3d.SCREEN_WIDTH) * 2 - 1
         jeeFrontEnd.plan3d.mouse.y = -((event.clientY - document.getElementById('div_display3d').offsetTop) / jeeFrontEnd.plan3d.SCREEN_HEIGHT) * 2 + 1
         jeeFrontEnd.plan3d.raycaster.setFromCamera(jeeFrontEnd.plan3d.mouse, jeeFrontEnd.plan3d.camera)
-        var intersects = jeeFrontEnd.plan3d.raycaster.intersectObjects(jeeFrontEnd.plan3d.scene.children, true)
+        const intersects = jeeFrontEnd.plan3d.raycaster.intersectObjects(jeeFrontEnd.plan3d.scene.children, true)
         if (intersects.length > 0) {
           jeedom.plan3d.byName({
             global: false,
@@ -87,8 +87,8 @@ if (!jeeFrontEnd.plan3d) {
     },
     refresh3dObject: function() {
       jeeFrontEnd.plan3d.CMDS = {}
-      for (var i in jeeFrontEnd.plan3d.JEEDOM_OBJECT) {
-        var object = jeeFrontEnd.plan3d.scene.getObjectByProperty('uuid', jeeFrontEnd.plan3d.JEEDOM_OBJECT[i])
+      for (const i in jeeFrontEnd.plan3d.JEEDOM_OBJECT) {
+        const object = jeeFrontEnd.plan3d.scene.getObjectByProperty('uuid', jeeFrontEnd.plan3d.JEEDOM_OBJECT[i])
         if (object) {
           jeeFrontEnd.plan3d.scene.remove(object)
         }
@@ -100,7 +100,7 @@ if (!jeeFrontEnd.plan3d) {
       if (!_info.configuration || !_info.configuration['3d::widget'] || _info.configuration['3d::widget'] == '') {
         return
       }
-      var object = jeeFrontEnd.plan3d.scene.getObjectByName(_info.name)
+      const object = jeeFrontEnd.plan3d.scene.getObjectByName(_info.name)
       if (!object) {
         return
       }
@@ -121,7 +121,7 @@ if (!jeeFrontEnd.plan3d) {
           })
         },
         success: function(data) {
-          for (var i in data) {
+          for (const i in data) {
             jeeFrontEnd.plan3d.add3dObject(data[i])
           }
           
@@ -158,10 +158,11 @@ if (!jeeFrontEnd.plan3d) {
           }
           jeeFrontEnd.plan3d.camera = new THREE.PerspectiveCamera(45, jeeFrontEnd.plan3d.SCREEN_WIDTH / jeeFrontEnd.plan3d.SCREEN_HEIGHT, 0.1, 99999999)
           jeeFrontEnd.plan3d.scene.add(jeeFrontEnd.plan3d.camera)
+          let hemiLight
           if (data.configuration.globalLightPower) {
-            var hemiLight = new THREE.HemisphereLight(0xffffff, 0xffffff, data.configuration.globalLightPower)
+            hemiLight = new THREE.HemisphereLight(0xffffff, 0xffffff, data.configuration.globalLightPower)
           } else {
-            var hemiLight = new THREE.HemisphereLight(0xffffff, 0xffffff, 0.3)
+            hemiLight = new THREE.HemisphereLight(0xffffff, 0xffffff, 0.3)
           }
           jeeFrontEnd.plan3d.scene.add(hemiLight)
           jeeFrontEnd.plan3d.renderer  = new THREE.WebGLRenderer({
@@ -171,17 +172,17 @@ if (!jeeFrontEnd.plan3d) {
           jeeFrontEnd.plan3d.container.appendChild(jeeFrontEnd.plan3d.renderer.domElement)
           if (data.configuration.mtlfile && data.configuration.mtlfile != '') {
             domUtils.showLoading()
-            var mtlLoader = new THREE.MTLLoader()
+            const mtlLoader = new THREE.MTLLoader()
             mtlLoader.setPath(data.configuration.path)
             mtlLoader.load(data.configuration.mtlfile, function(materials) {
               domUtils.showLoading()
               materials.lights = false
               materials.preload()
-              var objLoader = new THREE.OBJLoader()
+              const objLoader = new THREE.OBJLoader()
               objLoader.setMaterials(materials)
               objLoader.load(data.configuration.path + data.configuration.objfile, function(object) {
                 document.getElementById('span_loadPercent3dPlan')?.remove()
-                var bBox = new THREE.Box3().setFromObject(object)
+                const bBox = new THREE.Box3().setFromObject(object)
                 jeeFrontEnd.plan3d.camera.position.set(bBox.max.x * 1.3, bBox.max.y * 1.3, bBox.max.z * 1.3)
                 object.position.x = -(bBox.max.x - bBox.min.x) / 2
                 object.position.y = -bBox.min.y
@@ -207,10 +208,10 @@ if (!jeeFrontEnd.plan3d) {
             })
           } else {
             domUtils.showLoading()
-            var objLoader = new THREE.OBJLoader()
+            const objLoader = new THREE.OBJLoader()
             objLoader.load(data.configuration.path + data.configuration.objfile, function(object) {
               document.getElementById('span_loadPercent3dPlan')?.remove()
-              var bBox = new THREE.Box3().setFromObject(object)
+              const bBox = new THREE.Box3().setFromObject(object)
               jeeFrontEnd.plan3d.camera.position.set(bBox.max.x * 1.3, bBox.max.y * 1.3, bBox.max.z * 1.3)
               object.position.x = -(bBox.max.x - bBox.min.x) / 2
               object.position.y = -bBox.min.y
@@ -245,7 +246,7 @@ window.registerEvent('click', function(event) {
 })
 
 document.getElementById('bt_editMode').addEventListener('click', function(event) {
-  let _target = event.target.closest('#bt_editMode')
+  const _target = event.target.closest('#bt_editMode')
   jeeFrontEnd.plan3d.EDIT_MODE = (jeeFrontEnd.plan3d.EDIT_MODE == 0) ? 1 : 0
   if (jeeFrontEnd.plan3d.EDIT_MODE) {
     _target.classList.remove('btn-default')
@@ -270,8 +271,8 @@ document.getElementById('bt_showAllObject').addEventListener('click', function(e
         })
       },
       success: function(data) {
-        for (let i in data) {
-          let object = jeeFrontEnd.plan3d.scene.getObjectByName(data[i].name)
+        for (const i in data) {
+          const object = jeeFrontEnd.plan3d.scene.getObjectByName(data[i].name)
           if (object) {
             object.visible = true
           }
@@ -317,9 +318,9 @@ document.body.registerEvent('cmd::update', function(_event) {
   if (jeeFrontEnd.plan3d.EDIT_MODE) {
     return
   }
-  for (var i in _event.detail) {
+  for (const i in _event.detail) {
     if (jeeFrontEnd.plan3d.CMDS[_event.detail[i].cmd_id]) {
-      for (var j in jeeFrontEnd.plan3d.CMDS[_event.detail[i].cmd_id]) {
+      for (const j in jeeFrontEnd.plan3d.CMDS[_event.detail[i].cmd_id]) {
         try {
           jeedom3d[j].update(_event.detail[i])
         } catch (e) {
@@ -347,7 +348,7 @@ window.registerEvent('dblclick', function(event) {
   jeeFrontEnd.plan3d.mouse.x = ((event.clientX - document.getElementById('div_display3d').offsetLeft) / jeeFrontEnd.plan3d.SCREEN_WIDTH) * 2 - 1
   jeeFrontEnd.plan3d.mouse.y = -((event.clientY - document.getElementById('div_display3d').offsetTop) / jeeFrontEnd.plan3d.SCREEN_HEIGHT) * 2 + 1
   jeeFrontEnd.plan3d.raycaster.setFromCamera(jeeFrontEnd.plan3d.mouse, jeeFrontEnd.plan3d.camera)
-  var intersects = jeeFrontEnd.plan3d.raycaster.intersectObjects(jeeFrontEnd.plan3d.scene.children, true)
+  const intersects = jeeFrontEnd.plan3d.raycaster.intersectObjects(jeeFrontEnd.plan3d.scene.children, true)
   if (intersects.length > 0 && intersects[0].object.name != '') {
     jeeDialog.dialog({
       id: 'jee_modal',
@@ -369,7 +370,7 @@ jeedom3d = function() { }
 jeedom3d.light = function() { }
 
 jeedom3d.light.create = function(_info, _object) {
-  var bBox = new THREE.Box3().setFromObject(_object)
+  const bBox = new THREE.Box3().setFromObject(_object)
   light = new THREE.PointLight(new THREE.Color('#ffffff'), 0, 300, 2)
   light.position.set((bBox.max.x - bBox.min.x) / 2 + bBox.min.x, (bBox.max.y - bBox.min.y) / 2 + bBox.min.y, (bBox.max.z - bBox.min.z) / 2 + bBox.min.z)
   light.castShadow = true
@@ -396,11 +397,11 @@ jeedom3d.light.create = function(_info, _object) {
 }
 
 jeedom3d.light.update = function(_options) {
-  var lights = jeeFrontEnd.plan3d.CMDS[_options.cmd_id]['light']
-  for (var i in lights) {
-    var max = lights[i].info.configuration['3d::widget::light::power'] || 6
-    var intensity = 0
-    var color = '#ffffff'
+  const lights = jeeFrontEnd.plan3d.CMDS[_options.cmd_id]['light']
+  for (const i in lights) {
+    const max = lights[i].info.configuration['3d::widget::light::power'] || 6
+    let intensity = 0
+    let color = '#ffffff'
     if (_options.display_value) {
       intensity = max
       if (lights[i].info.additionalData.subType == 'numeric') {
@@ -430,7 +431,7 @@ jeedom3d.text.reset = function(_info, _object) {
   if (!jeedom3d.text.data[_object.uuid]) {
     return
   }
-  for (var j in jeeFrontEnd.plan3d.scene.children) {
+  for (const j in jeeFrontEnd.plan3d.scene.children) {
     if (jeeFrontEnd.plan3d.scene.children[j].uuid == jeedom3d.text.data[_object.uuid]) {
       jeeFrontEnd.plan3d.scene.remove(jeeFrontEnd.plan3d.scene.children[j])
     }
@@ -438,11 +439,11 @@ jeedom3d.text.reset = function(_info, _object) {
 }
 
 jeedom3d.text.create = function(_info, _object) {
-  var text = jeedom3d.text.generate(_info, _object, _info.additionalData.text)
+  const text = jeedom3d.text.generate(_info, _object, _info.additionalData.text)
   jeeFrontEnd.plan3d.scene.add(text)
   jeedom3d.text.data[_object.uuid] = text.uuid
   if (_info.additionalData.cmds) {
-    for (var i in _info.additionalData.cmds) {
+    for (const i in _info.additionalData.cmds) {
       cmd_id = _info.additionalData.cmds[i]
       if (!jeeFrontEnd.plan3d.CMDS[cmd_id]) {
         jeeFrontEnd.plan3d.CMDS[cmd_id] = {
@@ -461,14 +462,14 @@ jeedom3d.text.create = function(_info, _object) {
 }
 
 jeedom3d.text.update = function(_options) {
-  var texts = jeeFrontEnd.plan3d.CMDS[_options.cmd_id]['text']
-  for (var i in texts) {
+  const texts = jeeFrontEnd.plan3d.CMDS[_options.cmd_id]['text']
+  for (const i in texts) {
     if (_options.object && _options.object != texts[i].object) {
       continue
     }
     if (_options.text) {
-      var text = jeedom3d.text.generate(texts[i].info, texts[i].object, data.additionalData.text)
-      for (var j in jeeFrontEnd.plan3d.scene.children) {
+      const text = jeedom3d.text.generate(texts[i].info, texts[i].object, data.additionalData.text)
+      for (const j in jeeFrontEnd.plan3d.scene.children) {
         if (jeeFrontEnd.plan3d.scene.children[j].uuid == texts[i].text.uuid) {
           jeeFrontEnd.plan3d.scene.remove(jeeFrontEnd.plan3d.scene.children[j])
         }
@@ -481,8 +482,8 @@ jeedom3d.text.update = function(_options) {
         global: false,
         async: false,
         success: function(data) {
-          var text = jeedom3d.text.generate(texts[i].info, texts[i].object, data.additionalData.text)
-          for (var j in jeeFrontEnd.plan3d.scene.children) {
+          const text = jeedom3d.text.generate(texts[i].info, texts[i].object, data.additionalData.text)
+          for (const j in jeeFrontEnd.plan3d.scene.children) {
             if (jeeFrontEnd.plan3d.scene.children[j].uuid == texts[i].text.uuid) {
               jeeFrontEnd.plan3d.scene.remove(jeeFrontEnd.plan3d.scene.children[j])
             }
@@ -497,19 +498,19 @@ jeedom3d.text.update = function(_options) {
 }
 
 jeedom3d.text.generate = function(_options, _object, _text) {
-  var borderColor = jeedomUtils.hexToRgb(_options.configuration['3d::widget::text::bordercolor'])
+  const borderColor = jeedomUtils.hexToRgb(_options.configuration['3d::widget::text::bordercolor'])
   borderColor.a = parseFloat(_options.configuration['3d::widget::text::bordertransparency'])
-  var backgroundColor = jeedomUtils.hexToRgb(_options.configuration['3d::widget::text::backgroundcolor'])
+  const backgroundColor = jeedomUtils.hexToRgb(_options.configuration['3d::widget::text::backgroundcolor'])
   backgroundColor.a = parseFloat(_options.configuration['3d::widget::text::backgroundtransparency'])
-  var textColor = jeedomUtils.hexToRgb(_options.configuration['3d::widget::text::textcolor'])
+  const textColor = jeedomUtils.hexToRgb(_options.configuration['3d::widget::text::textcolor'])
   textColor.a = parseFloat(_options.configuration['3d::widget::text::texttransparency'])
-  var spritey = jeedom3d.text.makeTextSprite(_text, {
+  const spritey = jeedom3d.text.makeTextSprite(_text, {
     fontsize: parseInt(_options.configuration['3d::widget::text::fontsize']),
     borderColor: borderColor,
     backgroundColor: backgroundColor,
     textColor: textColor
   })
-  var bBox = new THREE.Box3().setFromObject(_object)
+  const bBox = new THREE.Box3().setFromObject(_object)
   spritey.position.set((bBox.max.x - bBox.min.x) / 2 + bBox.min.x, bBox.max.y + parseInt(_options.configuration['3d::widget::text::space::z']), (bBox.max.z - bBox.min.z) / 2 + bBox.min.z)
   return spritey
 }
@@ -518,55 +519,55 @@ jeedom3d.text.generate = function(_options, _object, _text) {
 jeedom3d.text.makeTextSprite = function(message, parameters) {
   message = " " + message + " "
   if (parameters === undefined) parameters = {}
-  var fontface = parameters.hasOwnProperty("fontface") ? parameters["fontface"] : "Arial"
-  var fontsize = parameters.hasOwnProperty("fontsize") ? parameters["fontsize"] : 18
-  var borderThickness = parameters.hasOwnProperty("borderThickness") ? parameters["borderThickness"] : 2
-  var borderColor = parameters.hasOwnProperty("borderColor") ? parameters["borderColor"] : {
+  const fontface = parameters.hasOwnProperty("fontface") ? parameters["fontface"] : "Arial"
+  const fontsize = parameters.hasOwnProperty("fontsize") ? parameters["fontsize"] : 18
+  const borderThickness = parameters.hasOwnProperty("borderThickness") ? parameters["borderThickness"] : 2
+  const borderColor = parameters.hasOwnProperty("borderColor") ? parameters["borderColor"] : {
     r: 0,
     g: 0,
     b: 0,
     a: 1.0
   }
-  var backgroundColor = parameters.hasOwnProperty("backgroundColor") ? parameters["backgroundColor"] : {
+  const backgroundColor = parameters.hasOwnProperty("backgroundColor") ? parameters["backgroundColor"] : {
     r: 255,
     g: 255,
     b: 255,
     a: 1.0
   }
-  var textColor = parameters.hasOwnProperty("textColor") ? parameters["textColor"] : {
+  const textColor = parameters.hasOwnProperty("textColor") ? parameters["textColor"] : {
     r: 0,
     g: 0,
     b: 0,
     a: 1.0
   }
-  var canvas = document.createElement('canvas')
+  const canvas = document.createElement('canvas')
 
-  var context = canvas.getContext('2d')
+  const context = canvas.getContext('2d')
   context.font = "Bold " + fontsize + "px " + fontface
-  var texts = message.split('\n')
-  var totalLine = texts.length
-  var textWidth = jeedom3d.text.getMaxWidth(context, texts)
-  var size = Math.max(300, textWidth + 2 * borderThickness)
+  const texts = message.split('\n')
+  const totalLine = texts.length
+  const textWidth = jeedom3d.text.getMaxWidth(context, texts)
+  const size = Math.max(300, textWidth + 2 * borderThickness)
   canvas.width = size
   canvas.height = size
   context.font = "Bold " + fontsize + "px " + fontface
   context.fillStyle = "rgba(" + backgroundColor.r + "," + backgroundColor.g + "," + backgroundColor.b + "," + backgroundColor.a + ")"
   context.strokeStyle = "rgba(" + borderColor.r + "," + borderColor.g + "," + borderColor.b + "," + borderColor.a + ")"
   context.lineWidth = borderThickness
-  let totalTextHeight = fontsize * 1.2 * totalLine
+  const totalTextHeight = fontsize * 1.2 * totalLine
   jeedom3d.text.roundRect(context, (size / 2 - textWidth / 2) - borderThickness / 2, size / 2 - fontsize / 2 - totalTextHeight / 2, textWidth + borderThickness, totalTextHeight + fontsize / 2, 6)
   context.fillStyle = "rgba(" + textColor.r + "," + textColor.g + "," + textColor.b + "," + textColor.a + ")"
-  let startY = size / 2 - totalTextHeight / 2 + fontsize / 2
-  for (var i = 0; i < totalLine; i++) {
-    let curWidth = context.measureText(texts[i]).width
+  const startY = size / 2 - totalTextHeight / 2 + fontsize / 2
+  for (let i = 0; i < totalLine; i++) {
+    const curWidth = context.measureText(texts[i]).width
     context.fillText(texts[i], size / 2 - curWidth / 2, startY + fontsize * i * 1.2)
   }
-  var texture = new THREE.Texture(canvas)
+  const texture = new THREE.Texture(canvas)
   texture.needsUpdate = true
-  var spriteMaterial = new THREE.SpriteMaterial({
+  const spriteMaterial = new THREE.SpriteMaterial({
     map: texture
   })
-  var sprite = new THREE.Sprite(spriteMaterial)
+  const sprite = new THREE.Sprite(spriteMaterial)
   sprite.scale.set(300, 150, 1.0)
   return sprite
 }
@@ -589,7 +590,7 @@ jeedom3d.text.roundRect = function(ctx, x, y, w, h, r) {
 
 jeedom3d.text.getMaxWidth = function(context, texts) {
   let maxWidth = 0
-  for (let i in texts)
+  for (const i in texts)
     maxWidth = Math.max(maxWidth, context.measureText(texts[i]).width)
   return maxWidth
 }
@@ -607,7 +608,7 @@ jeedom3d.door.reset = function(_info, _object) {
 
 jeedom3d.door.create = function(_info, _object) {
   _object.material = _object.material.clone()
-  for (var i in _info.additionalData.cmds) {
+  for (const i in _info.additionalData.cmds) {
     if (_info.additionalData.cmds[i] == '') {
       continue
     }
@@ -632,8 +633,8 @@ jeedom3d.door.create = function(_info, _object) {
 }
 
 jeedom3d.door.update = function(_options) {
-  var doors = jeeFrontEnd.plan3d.CMDS[_options.cmd_id]['door']
-  for (var i in doors) {
+  const doors = jeeFrontEnd.plan3d.CMDS[_options.cmd_id]['door']
+  for (const i in doors) {
     if (_options.object && _options.object != doors[i].object) {
       continue
     }
@@ -653,13 +654,13 @@ jeedom3d.door.update = function(_options) {
 }
 
 jeedom3d.door.doUpdate = function(_state, _door) {
-  var result = ''
-  var convert = {
+  let result = ''
+  const convert = {
     0: _door.info.configuration['3d::widget::door::windowopen'],
     1: _door.info.configuration['3d::widget::door::windowclose'],
     2: _door.info.configuration['3d::widget::door::shutterclose']
   }
-  var enable = {
+  const enable = {
     0: _door.info.configuration['3d::widget::door::windowopen::enableColor'],
     1: _door.info.configuration['3d::widget::door::windowclose::enableColor'],
     2: _door.info.configuration['3d::widget::door::shutterclose::enableColor']
@@ -754,15 +755,15 @@ jeedom3d.door.rotate = function(_obj, _params) {
   if (!_params.repeat || !_params.mode) {
     return
   }
-  for (var i = 0; i < _params.repeat; i++) {
-    var bBox = new THREE.Box3().setFromObject(_obj)
-    var size = {
+  for (let i = 0; i < _params.repeat; i++) {
+    const bBox = new THREE.Box3().setFromObject(_obj)
+    const size = {
       x: bBox.max.x - bBox.min.x,
       y: bBox.max.y - bBox.min.y,
       z: bBox.max.z - bBox.min.z
     }
-    var center = _obj.geometry.center()
-    var translate = {}
+    const center = _obj.geometry.center()
+    const translate = {}
     translate.y = -center.y
     _obj.rotation.y += Math.PI / 2
     if (_params.mode[0] == 'left') {
@@ -783,14 +784,14 @@ jeedom3d.door.translate = function(_obj, _params) {
   if (!_params.repeat || !_params.way) {
     return
   }
-  for (var i = 0; i < _params.repeat; i++) {
-    var bBox = new THREE.Box3().setFromObject(_obj)
-    var size = {
+  for (let i = 0; i < _params.repeat; i++) {
+    const bBox = new THREE.Box3().setFromObject(_obj)
+    const size = {
       x: bBox.max.x - bBox.min.x,
       y: bBox.max.y - bBox.min.y,
       z: bBox.max.z - bBox.min.z
     }
-    var translate = {}
+    const translate = {}
     if (_params.way == 'right') {
       translate.x = size.x
       translate.y = 0
@@ -823,7 +824,7 @@ jeedom3d.conditionalColor.reset = function(_info, _object) {
 
 jeedom3d.conditionalColor.create = function(_info, _object) {
   _object.material = _object.material.clone()
-  for (var i in _info.additionalData.cmds) {
+  for (const i in _info.additionalData.cmds) {
     cmd_id = _info.additionalData.cmds[i]
     if (!jeeFrontEnd.plan3d.CMDS[cmd_id]) {
       jeeFrontEnd.plan3d.CMDS[cmd_id] = {
@@ -845,8 +846,8 @@ jeedom3d.conditionalColor.create = function(_info, _object) {
 }
 
 jeedom3d.conditionalColor.update = function(_options) {
-  var conditionalColor = jeeFrontEnd.plan3d.CMDS[_options.cmd_id]['conditionalColor']
-  for (var i in conditionalColor) {
+  const conditionalColor = jeeFrontEnd.plan3d.CMDS[_options.cmd_id]['conditionalColor']
+  for (const i in conditionalColor) {
     if (_options.object && _options.object != conditionalColor[i].object) {
       continue
     }
@@ -891,7 +892,7 @@ jeedom3d.conditionalShow.reset = function(_info, _object) {
 }
 
 jeedom3d.conditionalShow.create = function(_info, _object) {
-  for (var i in _info.additionalData.cmds) {
+  for (const i in _info.additionalData.cmds) {
     cmd_id = _info.additionalData.cmds[i]
     if (!jeeFrontEnd.plan3d.CMDS[cmd_id]) {
       jeeFrontEnd.plan3d.CMDS[cmd_id] = {
@@ -913,8 +914,8 @@ jeedom3d.conditionalShow.create = function(_info, _object) {
 }
 
 jeedom3d.conditionalShow.update = function(_options) {
-  var conditionalShow = jeeFrontEnd.plan3d.CMDS[_options.cmd_id]['conditionalShow']
-  for (var i in conditionalShow) {
+  const conditionalShow = jeeFrontEnd.plan3d.CMDS[_options.cmd_id]['conditionalShow']
+  for (const i in conditionalShow) {
     if (_options.object && _options.object != conditionalShow[i].object) {
       continue
     }

--- a/desktop/js/widgets.js
+++ b/desktop/js/widgets.js
@@ -53,8 +53,8 @@ if (!jeeFrontEnd.widgets) {
           document.getElementById('div_templateReplace').empty()
           if (typeof data.replace != 'undefined' && data.replace.length > 0) {
             document.querySelectorAll('.type_replace').seen()
-            var replace = ''
-            for (var i in data.replace) {
+            let replace = ''
+            for (const i in data.replace) {
               replace += '<div class="form-group">'
               if (jeeP.widget_parameters_opt[data.replace[i]]) {
                 replace += '<label class="col-lg-2 col-md-3 col-sm-4 col-xs-4 control-label">' + jeeP.widget_parameters_opt[data.replace[i]].name + '</label>'
@@ -132,17 +132,17 @@ if (!jeeFrontEnd.widgets) {
 
           document.querySelectorAll('.widgets').setJeeValues(data, '.widgetsAttr')
           if (isset(data.test)) {
-            for (var i in data.test) {
+            for (const i in data.test) {
               jeeP.addTest(data.test[i])
             }
           }
 
-          var usedBy = ''
-          for (var i in data.usedBy) {
+          let usedBy = ''
+          for (const i in data.usedBy) {
             usedBy += '<span class="label label-info cursor cmdAdvanceConfigure" data-cmd_id="' + i + '">' + data.usedBy[i] + '</span> '
           }
           document.getElementById('div_usedBy').empty().insertAdjacentHTML('beforeend', usedBy)
-          var template = 'cmd.'
+          let template = 'cmd.'
           if (data.type && data.type !== null) {
             template += data.type + '.'
           } else {
@@ -170,7 +170,7 @@ if (!jeeFrontEnd.widgets) {
               })
             },
             success: function(data) {
-              let previewEL = document.getElementById('div_widgetPreview')
+              const previewEL = document.getElementById('div_widgetPreview')
               previewEL.empty().html(data.html)
               if (previewEL.querySelector('div.eqLogic-widget') != null) previewEL.querySelector('div.eqLogic-widget').style.position = 'relative'
             }
@@ -187,7 +187,7 @@ if (!jeeFrontEnd.widgets) {
       if (!isset(_test)) {
         _trigger = {}
       }
-      var div = '<div class="test">'
+      let div = '<div class="test">'
       div += '<div class="form-group">'
       div += '<label class="col-lg-2 col-md-3 col-sm-4 col-xs-6 control-label">{{Test}}</label>'
       div += '<div class="col-sm-3">'
@@ -218,14 +218,14 @@ if (!jeeFrontEnd.widgets) {
       div += '</div>'
       div += '</div>'
 
-      let replaceDiv = document.getElementById('div_templateTest')
+      const replaceDiv = document.getElementById('div_templateTest')
       replaceDiv.insertAdjacentHTML('beforeend', div)
       replaceDiv.querySelectorAll('.test').last().setJeeValues(_test, '.testAttr')
 
     },
     downloadObjectAsJson: function(exportObj, exportName) {
-      var dataStr = "data:text/json;charset=utf-8," + encodeURIComponent(JSON.stringify(exportObj))
-      var downloadAnchorNode = document.createElement('a')
+      const dataStr = "data:text/json;charset=utf-8," + encodeURIComponent(JSON.stringify(exportObj))
+      const downloadAnchorNode = document.createElement('a')
       downloadAnchorNode.setAttribute("href", dataStr)
       downloadAnchorNode.setAttribute("target", "_blank")
       downloadAnchorNode.setAttribute("download", exportName + ".json")
@@ -235,12 +235,12 @@ if (!jeeFrontEnd.widgets) {
     },
     applyToCmd: function() {
       //store usedBy:
-      var checkedId = []
+      const checkedId = []
       document.querySelectorAll('#div_usedBy .cmdAdvanceConfigure').forEach(_cmd => {
         checkedId.push(_cmd.getAttribute('data-cmd_id'))
       })
-      let type = document.querySelector('.widgetsAttr[data-l1key="type"]').jeeValue()
-      let subtype = document.querySelector('.widgetsAttr[data-l1key="subtype"]').jeeValue()
+      const type = document.querySelector('.widgetsAttr[data-l1key="type"]').jeeValue()
+      const subtype = document.querySelector('.widgetsAttr[data-l1key="subtype"]').jeeValue()
       jeeDialog.dialog({
         id: 'md_cmdConfigureSelectMultiple',
         title: "{{Appliquer ce widget à}}",
@@ -252,7 +252,7 @@ if (!jeeFrontEnd.widgets) {
             }
           })
           document.getElementById('bt_cmdSelectMultipleApply').addEventListener('click', function(event) {
-            var widgets = document.querySelectorAll('.widgets').getJeeValues('.widgetsAttr')[0]
+            const widgets = document.querySelectorAll('.widgets').getJeeValues('.widgetsAttr')[0]
             widgets.test = document.querySelectorAll('#div_templateTest .test').getJeeValues('.testAttr')
             jeedom.widgets.save({
               widgets: widgets,
@@ -264,13 +264,13 @@ if (!jeeFrontEnd.widgets) {
               },
               success: function(data) {
                 jeeFrontEnd.modifyWithoutSave = false
-                var cmd = {
+                const cmd = {
                   template: {
                     dashboard: 'custom::' + document.querySelector('.widgetsAttr[data-l1key="name"]').jeeValue(),
                     mobile: 'custom::' + document.querySelector('.widgetsAttr[data-l1key="name"]').jeeValue()
                   }
                 }
-                var cmdDefault = {
+                const cmdDefault = {
                   template: {
                     dashboard: 'default',
                     mobile: 'default'
@@ -278,15 +278,15 @@ if (!jeeFrontEnd.widgets) {
                 }
 
                 document.querySelectorAll('#table_cmdConfigureSelectMultiple tbody tr').forEach(_tr => {
-                  var thisId = _tr.getAttribute('data-cmd_id')
+                  const thisId = _tr.getAttribute('data-cmd_id')
                   if (_tr.querySelector('.selectMultipleApplyCmd').checked) {
                     if (!checkedId.includes(thisId)) {
                       //show in usedBy
-                      var thisObject = _tr.childNodes[1].textContent
-                      var thisEq = _tr.childNodes[2].textContent
-                      var thisName = _tr.childNodes[3].textContent
-                      var cmdHumanName = '[' + thisObject + '][' + thisEq + '][' + thisName + ']'
-                      var newSpan = '<span class="label label-info cursor cmdAdvanceConfigure" data-cmd_id="' + thisId + '">' + cmdHumanName + '</span>'
+                      const thisObject = _tr.childNodes[1].textContent
+                      const thisEq = _tr.childNodes[2].textContent
+                      const thisName = _tr.childNodes[3].textContent
+                      const cmdHumanName = '[' + thisObject + '][' + thisEq + '][' + thisName + ']'
+                      const newSpan = '<span class="label label-info cursor cmdAdvanceConfigure" data-cmd_id="' + thisId + '">' + cmdHumanName + '</span>'
                       document.getElementById('div_usedBy').insertAdjacentHTML('beforeend', newSpan)
                     }
                     cmd.id = thisId
@@ -332,7 +332,7 @@ if (!jeeFrontEnd.widgets) {
       })
     },
     saveWidget: function() {
-      var widgets = document.getElementById('div_conf').getJeeValues('.widgetsAttr')[0]
+      const widgets = document.getElementById('div_conf').getJeeValues('.widgetsAttr')[0]
       widgets.test = document.querySelectorAll('#div_templateTest .test').getJeeValues('.testAttr')
       jeedom.widgets.save({
         widgets: widgets,
@@ -365,23 +365,23 @@ try {
     success: function(_widgets) {
       if (_widgets.length == 0) return
 
-      var widgetsList = []
+      const widgetsList = []
       widgetsList['info'] = []
       widgetsList['action'] = []
-      for (var i = 0; i < _widgets.length; i++) {
+      for (let i = 0; i < _widgets.length; i++) {
         wg = _widgets[i]
         if (wg.type == 'info') widgetsList['info'].push([wg.name, wg.id])
         if (wg.type == 'action') widgetsList['action'].push([wg.name, wg.id])
       }
 
       //set context menu!
-      var contextmenuitems = {}
-      var uniqId = 0
-      var groupWidgets, items, wg, wgName, wgId
-      for (var group in widgetsList) {
+      const contextmenuitems = {}
+      let uniqId = 0
+      let groupWidgets, items, wg, wgName, wgId
+      for (const group in widgetsList) {
         groupWidgets = widgetsList[group]
         items = {}
-        for (var index in groupWidgets) {
+        for (const index in groupWidgets) {
           wg = groupWidgets[index]
           wgName = wg[0]
           wgId = wg[1]
@@ -429,20 +429,20 @@ document.registerEvent('keydown', function(event) {
 
 //searching
 document.getElementById('in_searchWidgets')?.addEventListener('keyup', function() {
-  var search = this.value
+  let search = this.value
   if (search == '') {
     document.querySelectorAll('#accordionWidgets .accordion-toggle:not(.collapsed)').forEach(_panel => { _panel.click() })
     document.querySelectorAll('.widgetsDisplayCard').seen()
     return
   }
   search = jeedomUtils.normTextLower(search)
-  var not = search.startsWith(":not(")
+  const not = search.startsWith(":not(")
   if (not) {
     search = search.replace(':not(', '')
   }
   document.querySelectorAll('#accordionWidgets .accordion-toggle').forEach(_panel => { _panel.setAttribute('data-show', 0) })
   document.querySelectorAll('.widgetsDisplayCard').unseen()
-  var match, text
+  let match, text
 
   document.querySelectorAll('.widgetsDisplayCard .name').forEach(scName => {
     match = false
@@ -466,7 +466,7 @@ document.getElementById('in_searchWidgets')?.addEventListener('keyup', function(
 */
 //ThumbnailDisplay
 document.getElementById('div_widgetsList').addEventListener('click', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('#bt_openAll')) {
     document.querySelectorAll('#accordionWidgets .accordion-toggle.collapsed').forEach(_panel => { _panel.click() })
     return
@@ -533,7 +533,7 @@ document.getElementById('div_widgetsList').addEventListener('click', function(ev
 
   if (_target = event.target.closest('.widgetsDisplayCard')) {
     if ((isset(event.detail) && event.detail.ctrlKey) || event.ctrlKey || event.metaKey) {
-      var url = '/index.php?v=d&p=widgets&id=' + _target.getAttribute('data-widgets_id')
+      const url = '/index.php?v=d&p=widgets&id=' + _target.getAttribute('data-widgets_id')
       window.open(url).focus()
     } else {
       jeeP.printWidget(_target.getAttribute('data-widgets_id'))
@@ -543,11 +543,11 @@ document.getElementById('div_widgetsList').addEventListener('click', function(ev
 })
 
 document.getElementById('div_widgetsList').addEventListener('mouseup', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('.widgetsDisplayCard')) {
     if (event.which == 2) {
       event.preventDefault()
-      var id = _target.getAttribute('data-widgets_id')
+      const id = _target.getAttribute('data-widgets_id')
       document.querySelector('.widgetsDisplayCard[data-widgets_id="' + id + '"] .name').triggerEvent('click', { detail: { ctrlKey: true } })
     }
     return
@@ -555,10 +555,10 @@ document.getElementById('div_widgetsList').addEventListener('mouseup', function(
 })
 
 document.getElementById('div_widgetsList').addEventListener('change', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('#uploadFile')) {
     jeedomUtils.hideAlert()
-    var uploadedFile = event.target.files[0]
+    const uploadedFile = event.target.files[0]
     if (uploadedFile.type !== "application/json") {
       jeedomUtils.showAlert({
         message: "{{L'import de widget se fait au format json à partir d'un widget précédemment exporté.}}",
@@ -581,10 +581,10 @@ document.getElementById('div_widgetsList').addEventListener('change', function(e
               })
             },
             success: function(data) {
-              var readFile = new FileReader()
+              const readFile = new FileReader()
               readFile.readAsText(uploadedFile)
               readFile.onload = function(e) {
-                var objectData = JSON.parse(e.target.result)
+                const objectData = JSON.parse(e.target.result)
                 if (!isset(objectData.jeedomCoreVersion)) {
                   jeedomUtils.showAlert({
                     message: "{{Fichier json non compatible.}}",
@@ -595,7 +595,7 @@ document.getElementById('div_widgetsList').addEventListener('change', function(e
                 objectData.id = data.id
                 objectData.name = data.name
                 if (isset(objectData.test)) {
-                  for (var i in objectData.test) {
+                  for (const i in objectData.test) {
                     jeeP.addTest(objectData.test[i])
                   }
                 }
@@ -630,7 +630,7 @@ document.getElementById('div_widgetsList').addEventListener('change', function(e
 
 //Widget
 document.getElementById('div_conf').addEventListener('click', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('#bt_returnToThumbnailDisplay')) {
     setTimeout(function() {
       document.querySelector('.nav li.active').removeClass('active')
@@ -649,7 +649,7 @@ document.getElementById('div_conf').addEventListener('click', function(event) {
   }
 
   if (_target = event.target.closest('#bt_exportWidgets')) {
-    var widgets = document.getElementById('div_conf').getJeeValues('.widgetsAttr')[0]
+    const widgets = document.getElementById('div_conf').getJeeValues('.widgetsAttr')[0]
     widgets.test = document.querySelectorAll('#div_templateTest .test').getJeeValues('.testAttr')
     widgets.id = ""
     jeedom.version({
@@ -659,7 +659,6 @@ document.getElementById('div_conf').addEventListener('click', function(event) {
       }
     })
     return false
-    return
   }
 
   if (_target = event.target.closest('#bt_saveWidgets')) {
@@ -668,7 +667,7 @@ document.getElementById('div_conf').addEventListener('click', function(event) {
   }
 
   if (_target = event.target.closest('#bt_removeWidgets')) {
-    let name = document.querySelector('input[data-l1key="name"]').value
+    const name = document.querySelector('input[data-l1key="name"]').value
     jeeDialog.confirm('{{Êtes-vous sûr de vouloir supprimer le widget}} <span style="font-weight: bold ;">' + name + '</span> ?', function(result) {
       if (result) {
         jeedom.widgets.remove({
@@ -690,7 +689,7 @@ document.getElementById('div_conf').addEventListener('click', function(event) {
   }
 
   if (_target = event.target.closest('#bt_chooseIcon')) {
-    var _icon = document.querySelector('div[data-l2key="icon"] > i')
+    let _icon = document.querySelector('div[data-l2key="icon"] > i')
     if (_icon != null) {
       _icon = _icon.getAttribute('class')
     } else {
@@ -704,8 +703,8 @@ document.getElementById('div_conf').addEventListener('click', function(event) {
   }
 
   if (_target = event.target.closest('#div_templateReplace .chooseIcon')) {
-    var params = { img: true }
-    let input = _target.closest('div').querySelector('input').value
+    const params = { img: true }
+    const input = _target.closest('div').querySelector('input').value
     if (input.startsWith('<i class=')) params.icon = input.substring(10, input.length - 6)
     jeedomUtils.chooseIcon(function(_icon) {
       _target.closest('.form-group').querySelector('.widgetsAttr[data-l1key="replace"]').jeeValue(_icon)
@@ -715,8 +714,8 @@ document.getElementById('div_conf').addEventListener('click', function(event) {
   }
 
   if (_target = event.target.closest('#div_templateTest .chooseIcon')) {
-    var params = { img: true }
-    let input = _target.closest('div').querySelector('input').value
+    const params = { img: true }
+    const input = _target.closest('div').querySelector('input').value
     if (input.startsWith('<i class=')) params.icon = input.substring(10, input.length - 6)
     jeedomUtils.chooseIcon(function(_icon) {
       _target.closest('.input-group').querySelector('.testAttr').jeeValue(_icon)
@@ -748,7 +747,7 @@ document.getElementById('div_conf').addEventListener('click', function(event) {
 })
 
 document.getElementById('div_conf').addEventListener('dblclick', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('.widgetsAttr[data-l1key="display"][data-l2key="icon"]')) {
     _target.innerHTML = ''
     jeeFrontEnd.modifyWithoutSave = true
@@ -757,14 +756,14 @@ document.getElementById('div_conf').addEventListener('dblclick', function(event)
 })
 
 document.getElementById('div_conf').addEventListener('change', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('.widgetsAttr')) {
     jeeFrontEnd.modifyWithoutSave = true
   }
 
   if (_target = event.target.closest('#bt_importWidgets')) {
     jeedomUtils.hideAlert()
-    var uploadedFile = _target.files[0]
+    const uploadedFile = _target.files[0]
     if (uploadedFile.type !== "application/json") {
       jeedomUtils.showAlert({
         message: "{{L'import de widgets se fait au format json à partir de widgets précedemment exporté.}}",
@@ -773,10 +772,10 @@ document.getElementById('div_conf').addEventListener('change', function(event) {
       return false
     }
     if (uploadedFile) {
-      var readFile = new FileReader()
+      const readFile = new FileReader()
       readFile.readAsText(uploadedFile)
       readFile.onload = function(e) {
-        var objectData = JSON.parse(e.target.result)
+        const objectData = JSON.parse(e.target.result)
         if (!isset(objectData.jeedomCoreVersion)) {
           jeedomUtils.showAlert({
             message: "{{Fichier json non compatible.}}",
@@ -788,7 +787,7 @@ document.getElementById('div_conf').addEventListener('change', function(event) {
         objectData.id = document.querySelector('.widgetsAttr[data-l1key=id]').jeeValue()
         objectData.name = document.querySelector('.widgetsAttr[data-l1key=name]').jeeValue()
         if (isset(objectData.test)) {
-          for (var i in objectData.test) {
+          for (const i in objectData.test) {
             jeeP.addTest(objectData.test[i])
           }
         }
@@ -806,8 +805,8 @@ document.getElementById('div_conf').addEventListener('change', function(event) {
 
   if (_target = event.target.closest('.selectWidgetTemplate')) {
     if (jeeP.isLoadging) return
-    let type = document.querySelector('.widgetsAttr[data-l1key="type"]').jeeValue()
-    let subtype = document.querySelector('.widgetsAttr[data-l1key="subtype"]').jeeValue()
+    const type = document.querySelector('.widgetsAttr[data-l1key="type"]').jeeValue()
+    const subtype = document.querySelector('.widgetsAttr[data-l1key="subtype"]').jeeValue()
     jeeP.loadTemplateConfiguration('cmd.' + type + '.' + subtype + '.' + _target.value)
     return
   }
@@ -826,7 +825,7 @@ document.getElementById('div_conf').addEventListener('change', function(event) {
     document.getElementById('div_templateTest').empty()
     document.getElementById('div_usedBy').empty()
     document.querySelectorAll('.selectWidgetTemplate').unseen().removeClass('widgetsAttr')
-    let type = document.querySelector('.widgetsAttr[data-l1key="type"]').jeeValue()
+    const type = document.querySelector('.widgetsAttr[data-l1key="type"]').jeeValue()
     document.querySelector('.selectWidgetTemplate[data-type="' + type + '"][data-subtype="' + event.target.jeeValue() + '"]')?.seen().addClass('widgetsAttr').triggerEvent('change')
     return
   }


### PR DESCRIPTION
## Summary

Replace `var` with `const`/`let` in 5 display-related desktop/js modules.

**Modules:** dashboard, widgets, plan, plan3d, eqAnalyse

### Changes
- All `var` declarations → `const` (not reassigned) or `let` (reassigned)
- `let` declarations → `const` where applicable
- `for (var x in/of ...)` → `for (const x in/of ...)`
- Duplicate `var` redeclarations removed (collapsed by block scoping)
- `var img = querySelector() ? img.style : null` anti-pattern → `const img = querySelector(); if (img) ...` (required by const — TDZ prevents self-reference in initializer)

**No functional changes.** Bug fixes for these files are tracked separately in #3318 (Lot 1) and #3319 (Lot 2).

## Type of change
- [x] Refactor (no functional change)
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Suggested changelog entry
```
- refactor(desktop/js): replace var with const/let in display modules (dashboard, widgets, plan, plan3d, eqAnalyse)
```

## Test plan
- Open dashboard, confirm layout and category filter work normally
- Open plan page, confirm background image displays correctly
- Open widgets page, confirm widget list loads
- Open plan3d page (if available), confirm 3D display works
- Open eqAnalyse page, confirm battery/alert tabs load

## Known risks
- Minimal: block scoping `let`/`const` vs function scoping `var` — verified no variable is referenced before its declaration block
- The `var img = querySelector() ? img.style : null` → `const img = ...; if (img) ...` structural change is a required consequence of the migration, not a behavior change