### PR TITLE
refactor(desktop/js): replace var with const/let in scenario and timeline

### DIFF
--- a/desktop/js/scenario.js
+++ b/desktop/js/scenario.js
@@ -116,7 +116,7 @@ if (!jeeFrontEnd.scenario) {
     },
     //Copy / Paste
     removeObjectProp: function(obj, propToDelete) {
-      for (var property in obj) {
+      for (const property in obj) {
         if (obj.hasOwnProperty(property)) {
           if (typeof obj[property] == 'object') {
             this.removeObjectProp(obj[property], propToDelete)
@@ -129,9 +129,9 @@ if (!jeeFrontEnd.scenario) {
       }
     },
     setSortables: function() {
-      var selector = '.subElementACTION > .expressions, .subElementDO > .expressions, .subElementTHEN > .expressions, .subElementELSE > .expressions'
-      var containers = document.getElementById('div_scenarioElement').querySelectorAll(selector)
-      var commonOptions = {
+      const selector = '.subElementACTION > .expressions, .subElementDO > .expressions, .subElementTHEN > .expressions, .subElementELSE > .expressions'
+      const containers = document.getElementById('div_scenarioElement').querySelectorAll(selector)
+      const commonOptions = {
         group: {
           name: 'expressionSorting',
         },
@@ -177,7 +177,7 @@ if (!jeeFrontEnd.scenario) {
         if (Sortable.get(_Sortcontainer)) Sortable.get(_Sortcontainer).destroy()
         new Sortable(_Sortcontainer, commonOptions)
       })
-      var root = document.getElementById('root')
+      const root = document.getElementById('root')
       if (root) {
         if (Sortable.get(root)) Sortable.get(root).destroy()
         new Sortable(root, commonOptions)
@@ -188,15 +188,15 @@ if (!jeeFrontEnd.scenario) {
       Create same hierarchie for root elements to manage sortables:
       //root -> expressions -> expression -> col-xs-12 -> element
       */
-      var root = document.querySelector('#div_scenarioElement #root')
+      const root = document.querySelector('#div_scenarioElement #root')
       if (!root) {
         document.getElementById('div_scenarioElement').insertAdjacentHTML('afterbegin', '<div id="root" class="expressions"></div>')
         root = document.querySelector('#div_scenarioElement #root')
       }
-      var rootElements = document.querySelectorAll('#div_scenarioElement > div.element')
+      const rootElements = document.querySelectorAll('#div_scenarioElement > div.element')
       if (rootElements.length > 0) {
         rootElements.forEach(_element => {
-          var exp = document.createElement('div')
+          const exp = document.createElement('div')
           exp.addClass('expression sortable col-xs-12')
           exp.insertAdjacentHTML('afterbegin', '<input class="expressionAttr" data-l1key="id" style="display : none;" value=""/>')
           exp.insertAdjacentHTML('afterbegin', '<input class="expressionAttr" data-l1key="scenarioSubElement_id" style="display : none;" value=""/>')
@@ -238,7 +238,7 @@ if (!jeeFrontEnd.scenario) {
         },
         success: function(data) {
           domUtils.showLoading()
-          for (var i in data) {
+          for (const i in data) {
             document.getElementById(data[i].id).html(data[i].html.html, true)
           }
           domUtils.hideLoading()
@@ -249,15 +249,15 @@ if (!jeeFrontEnd.scenario) {
     updateDefinedActions: function(cmdModal = false) {
       //cmdModal called from cmd.configure modal to update ui list!
       if (cmdModal) {
-        var scId = document.querySelector('div#div_editScenario span[data-l1key="id"]').textContent
-        var cmdId = document.querySelector('div#cmd_information span[data-l1key="id"]')?.textContent
+        const scId = document.querySelector('div#div_editScenario span[data-l1key="id"]').textContent
+        const cmdId = document.querySelector('div#cmd_information span[data-l1key="id"]')?.textContent
 
-        var cmdName = jeephp2js.md_cmdConfigure_cmdInfo.eqLogicHumanName + '[' + jeephp2js.md_cmdConfigure_cmdInfo.name + ']'
+        const cmdName = jeephp2js.md_cmdConfigure_cmdInfo.eqLogicHumanName + '[' + jeephp2js.md_cmdConfigure_cmdInfo.name + ']'
 
         //clean actual cmd from list:
         jeeP.dataDefinedAction = jeeP.dataDefinedAction.filter(i => i['cmdId'] != cmdId)
 
-        var action, scenario_id, enable
+        let action, scenario_id, enable
         document.querySelectorAll('.actionCheckCmd').forEach(function(_cmd) {
           action = _cmd.querySelector('input[data-type="actionCheckCmd"]').jeeValue()
           if (action != "scenario") return true
@@ -305,9 +305,9 @@ if (!jeeFrontEnd.scenario) {
       }
 
       document.querySelector('.defined_actions').empty()
-      var htmlActions = ''
-      var prefix = ''
-      for (var i in jeeP.dataDefinedAction) {
+      let htmlActions = ''
+      let prefix = ''
+      for (const i in jeeP.dataDefinedAction) {
         if (jeeP.dataDefinedAction[i]['type'] == 'actionCheckCmd') prefix = 'Value -> '
         if (jeeP.dataDefinedAction[i]['type'] == 'jeedomPreExecCmd') prefix = 'PreExec -> '
         if (jeeP.dataDefinedAction[i]['type'] == 'jeedomPostExecCmd') prefix = 'PostExec -> '
@@ -390,7 +390,7 @@ if (!jeeFrontEnd.scenario) {
 
           //Triggers:
           if (Array.isArray(data.trigger)) {
-            for (var i in data.trigger) {
+            for (const i in data.trigger) {
               if (data.trigger[i] != '' && data.trigger[i] != null) {
                 jeeP.addTrigger(data.trigger[i])
               }
@@ -402,7 +402,7 @@ if (!jeeFrontEnd.scenario) {
           }
 
           if (Array.isArray(data.schedule)) {
-            for (var i in data.schedule) {
+            for (const i in data.schedule) {
               if (data.schedule[i] != '' && data.schedule[i] != null) {
                 jeeP.addSchedule(data.schedule[i])
               }
@@ -422,10 +422,10 @@ if (!jeeFrontEnd.scenario) {
           //Links:
           document.querySelector('#generaltab div.scenario_link_getUsedBy').empty()
           document.querySelector('#generaltab div.scenario_link_getUse').empty()
-          var html_getUsedBy = ''
-          var html_getUse = ''
+          let html_getUsedBy = ''
+          let html_getUse = ''
           if (data.scenario_link.scenario) {
-            for (var i in data.scenario_link.scenario) {
+            for (const i in data.scenario_link.scenario) {
               if (data.scenario_link.scenario[i].link == 'getUsedBy') {
                 if (data.scenario_link.scenario[i].isActive == 1) {
                   html_getUsedBy += '<span class="label label-success cursor scenario_link" data-scenario_id="' + i + '">' + data.scenario_link.scenario[i].name + '</span><br/>'
@@ -453,8 +453,8 @@ if (!jeeFrontEnd.scenario) {
           jeeP.actionOptions = []
 
 
-          var elements = ''
-          for (var i in data.elements) {
+          const elements = ''
+          for (const i in data.elements) {
             elements += jeeP.addElement(data.elements[i])
           }
           document.getElementById('div_scenarioElement').insertAdjacentHTML('beforeend', elements)
@@ -467,9 +467,9 @@ if (!jeeFrontEnd.scenario) {
           jeeP.updateElementCollapse()
           jeeP.updateElseToggle()
           jeedomUtils.taAutosize()
-          var title = ''
+          let title = ''
           if (data.name) title = data.name + ' - ' + JEEDOM_PRODUCT_NAME
-          var hash = window.location.hash
+          const hash = window.location.hash
           jeedomUtils.addOrUpdateUrl('id', data.id, title)
           if (hash == '') {
             document.querySelector('.nav-tabs a[data-target="#generaltab"]').click()
@@ -497,12 +497,12 @@ if (!jeeFrontEnd.scenario) {
     saveScenario: function(_callback) {
       jeedomUtils.hideAlert()
       //Get scenarios settings:
-      var scenario = this.dom_divScenario.getJeeValues('.scenarioAttr')[0]
+      const scenario = this.dom_divScenario.getJeeValues('.scenarioAttr')[0]
       if (typeof scenario.trigger == 'undefined') scenario.trigger = ''
       if (typeof scenario.schedule == 'undefined') scenario.schedule = ''
 
       //Get scenario elements:
-      var elements = []
+      const elements = []
       document.getElementById('root').querySelectorAll(':scope > .expression').forEach(_exp => {
         elements.push(jeeP.getElement(_exp.querySelector('div.element')))
       })
@@ -519,7 +519,7 @@ if (!jeeFrontEnd.scenario) {
         success: function(data) {
           jeeFrontEnd.modifyWithoutSave = false
           jeeP.resetUndo()
-          var url = 'index.php?v=d&p=scenario&id=' + data.id + '&saveSuccessFull=1'
+          const url = 'index.php?v=d&p=scenario&id=' + data.id + '&saveSuccessFull=1'
           if (window.location.hash != '') {
             url += window.location.hash
           }
@@ -532,7 +532,7 @@ if (!jeeFrontEnd.scenario) {
     },
     //Adding:
     addTrigger: function(_trigger) {
-      var div = '<div class="form-group trigger">'
+      let div = '<div class="form-group trigger">'
       div += '<label class="col-xs-3 control-label">{{Evénement}}</label>'
       div += '<div class="col-xs-9">'
       div += '<div class="input-group">'
@@ -549,7 +549,7 @@ if (!jeeFrontEnd.scenario) {
       document.querySelector('.provokeMode').insertAdjacentHTML('beforeend', div)
     },
     addSchedule: function(_schedule) {
-      var div = '<div class="form-group schedule">'
+      let div = '<div class="form-group schedule">'
       div += '<label class="col-xs-3 control-label">{{Programmation}}</label>'
       div += '<div class="col-xs-9">'
       div += '<div class="input-group">'
@@ -565,12 +565,12 @@ if (!jeeFrontEnd.scenario) {
     },
     addExpression: function(_expression) {
       if (!isset(_expression) || !isset(_expression.type) || _expression.type == '') return ''
-      var sortable = 'sortable'
+      let sortable = 'sortable'
       if (_expression.type == 'condition' || _expression.type == 'code') {
         sortable = 'noSortable'
       }
 
-      var retour = '<div class="expression ' + sortable + ' col-xs-12" >'
+      let retour = '<div class="expression ' + sortable + ' col-xs-12" >'
       if (_expression.type == 'action') {
         retour = '<div class="expression expressionACTION ' + sortable + ' col-xs-12" >'
       }
@@ -600,7 +600,7 @@ if (!jeeFrontEnd.scenario) {
           if (isset(_expression.element) && isset(_expression.element.html)) {
             retour += _expression.element.html
           } else {
-            var element = jeeP.addElement(_expression.element, true)
+            const element = jeeP.addElement(_expression.element, true)
             if (element.trim() == '') {
               return ''
             }
@@ -621,7 +621,7 @@ if (!jeeFrontEnd.scenario) {
           } else {
             retour += '<input type="checkbox" class="expressionAttr" data-l1key="options" data-l2key="background" checked  title="{{Cocher pour que la commande s\'exécute en parallèle des autres actions}}"/>'
           }
-          var expression_txt = init(_expression.expression)
+          let expression_txt = init(_expression.expression)
           if (typeof expression_txt != 'string') {
             expression_txt = JSON.stringify(expression_txt)
           }
@@ -636,7 +636,7 @@ if (!jeeFrontEnd.scenario) {
           retour += '<button class="btn btn-default bt_selectCmdExpression roundedRight" type="button" title="{{Sélectionner la commande}}"><i class="fas fa-list-alt"></i></button>'
           retour += '</span>'
           retour += '</div></div>'
-          var actionOption_id = jeedomUtils.uniqId()
+          const actionOption_id = jeedomUtils.uniqId()
           retour += '<div class="col-xs-7 expressionOptions"  id="' + actionOption_id + '">'
           retour += '</div>'
           this.actionOptions.push({
@@ -660,12 +660,12 @@ if (!jeeFrontEnd.scenario) {
     addSubElement: function(_subElement) {
       if (!isset(_subElement.type) || _subElement.type == '') return ''
       if (!isset(_subElement.options)) _subElement.options = {}
-      var noSortable = ''
+      let noSortable = ''
       if (_subElement.type == 'if' || _subElement.type == 'for' || _subElement.type == 'while' || _subElement.type == 'code') {
         noSortable = 'noSortable'
       }
 
-      var blocClass = ''
+      let blocClass = ''
       switch (_subElement.type) {
         case 'if':
           blocClass = 'subElementIF'
@@ -701,7 +701,7 @@ if (!jeeFrontEnd.scenario) {
           blocClass = 'subElementACTION'
           break
       }
-      var retour = '<div class="subElement ' + blocClass + ' ' + noSortable + '">'
+      let retour = '<div class="subElement ' + blocClass + ' ' + noSortable + '">'
       retour += '<input class="subElementAttr" data-l1key="id" style="display : none;" value="' + init(_subElement.id) + '"/>'
       retour += '<input class="subElementAttr" data-l1key="scenarioElement_id" style="display : none;" value="' + init(_subElement.scenarioElement_id) + '"/>'
       retour += '<input class="subElementAttr" data-l1key="type" style="display : none;" value="' + init(_subElement.type) + '"/>'
@@ -733,7 +733,7 @@ if (!jeeFrontEnd.scenario) {
           retour += '</div>'
 
           retour += '<div class="expressions" >'
-          var expression = {
+          const expression = {
             type: 'condition'
           }
           if (isset(_subElement.expressions) && isset(_subElement.expressions[0])) {
@@ -752,7 +752,7 @@ if (!jeeFrontEnd.scenario) {
           retour += '</div>'
           retour += '<div class="expressions">'
           if (isset(_subElement.expressions)) {
-            for (var k in _subElement.expressions) {
+            for (const k in _subElement.expressions) {
               retour += this.addExpression(_subElement.expressions[k])
             }
           }
@@ -767,7 +767,7 @@ if (!jeeFrontEnd.scenario) {
           retour += '</div>'
           retour += '<div class="expressions">'
           if (isset(_subElement.expressions)) {
-            for (var k in _subElement.expressions) {
+            for (const k in _subElement.expressions) {
               retour += this.addExpression(_subElement.expressions[k])
             }
           }
@@ -793,7 +793,7 @@ if (!jeeFrontEnd.scenario) {
           retour += '<legend >{{DE 1 A}}</legend>'
           retour += '</div>'
           retour += '<div class="expressions" >'
-          var expression = {
+          const expression = {
             type: 'condition'
           }
           if (isset(_subElement.expressions) && isset(_subElement.expressions[0])) {
@@ -853,7 +853,7 @@ if (!jeeFrontEnd.scenario) {
           retour += '<legend title="{{Action DANS x minutes}}">{{DANS}}</legend>'
           retour += '</div>'
           retour += '<div class="expressions" >'
-          var expression = {
+          const expression = {
             type: 'condition'
           }
           if (isset(_subElement.expressions) && isset(_subElement.expressions[0])) {
@@ -883,7 +883,7 @@ if (!jeeFrontEnd.scenario) {
           retour += '<legend >{{A}}</legend><span>(Hmm)</span>'
           retour += '</div>'
           retour += '<div class="expressions" >'
-          var expression = {
+          const expression = {
             type: 'condition'
           }
           if (isset(_subElement.expressions) && isset(_subElement.expressions[0])) {
@@ -902,7 +902,7 @@ if (!jeeFrontEnd.scenario) {
           retour += '</div>'
           retour += '<div class="expressions">'
           if (isset(_subElement.expressions)) {
-            for (var k in _subElement.expressions) {
+            for (const k in _subElement.expressions) {
               retour += this.addExpression(_subElement.expressions[k])
             }
           }
@@ -926,7 +926,7 @@ if (!jeeFrontEnd.scenario) {
           retour += '</div>'
           retour += '<div>'
           retour += '<legend >{{CODE}}</legend>'
-          var expression = {
+          const expression = {
             type: 'code'
           }
           if (isset(_subElement.expressions) && isset(_subElement.expressions[0]) && typeof _subElement.expressions[0].expression == "string") {
@@ -954,7 +954,7 @@ if (!jeeFrontEnd.scenario) {
           retour += '</div>'
           retour += '<div>'
           retour += '<legend >{{COMMENTAIRE}}</legend>'
-          var expression = {
+          const expression = {
             type: 'comment'
           }
           if (isset(_subElement.expressions) && isset(_subElement.expressions[0])) {
@@ -962,7 +962,7 @@ if (!jeeFrontEnd.scenario) {
             if (typeof expression.expression === 'object') {
               expression.expression = JSON.stringify(expression.expression, null, 2)
             }
-            var txt = expression.expression.substring(0, 200).HTMLFormat()
+            let txt = expression.expression.substring(0, 200).HTMLFormat()
             txt = '<b>' + txt.split('\n')[0] + '</b>' + txt.replace(txt.split('\n')[0], '')
             retour += '<div class="blocPreview">' + txt + '</div>'
           } else {
@@ -1007,7 +1007,7 @@ if (!jeeFrontEnd.scenario) {
           retour += '</div>'
           retour += '<div class="expressions">'
           if (isset(_subElement.expressions)) {
-            for (var k in _subElement.expressions) {
+            for (const k in _subElement.expressions) {
               retour += this.addExpression(_subElement.expressions[k])
             }
           }
@@ -1028,7 +1028,7 @@ if (!jeeFrontEnd.scenario) {
       if (!isset(_element)) return
       if (!isset(_element.type) || _element.type == '') return ''
 
-      var elementClass = ''
+      let elementClass = ''
       switch (_element.type) {
         case 'if':
           elementClass = 'elementIF'
@@ -1055,14 +1055,14 @@ if (!jeeFrontEnd.scenario) {
           elementClass = 'elementACTION'
       }
 
-      var div = '<div class="element ' + elementClass + '">'
+      let div = '<div class="element ' + elementClass + '">'
 
       div += '<input class="elementAttr" data-l1key="id" style="display : none;" value="' + init(_element.id) + '"/>'
       div += '<input class="elementAttr" data-l1key="type" style="display : none;" value="' + init(_element.type) + '"/>'
       switch (_element.type) {
         case 'if':
           if (isset(_element.subElements) && isset(_element.subElements)) {
-            for (var j in _element.subElements) {
+            for (const j in _element.subElements) {
               div += this.addSubElement(_element.subElements[j])
             }
           } else {
@@ -1079,7 +1079,7 @@ if (!jeeFrontEnd.scenario) {
           break
         case 'for':
           if (isset(_element.subElements) && isset(_element.subElements)) {
-            for (var j in _element.subElements) {
+            for (const j in _element.subElements) {
               div += this.addSubElement(_element.subElements[j])
             }
           } else {
@@ -1107,7 +1107,7 @@ if (!jeeFrontEnd.scenario) {
           break
         case 'in':
           if (isset(_element.subElements) && isset(_element.subElements)) {
-            for (var j in _element.subElements) {
+            for (const j in _element.subElements) {
               div += this.addSubElement(_element.subElements[j])
             }
           } else {
@@ -1121,7 +1121,7 @@ if (!jeeFrontEnd.scenario) {
           break
         case 'at':
           if (isset(_element.subElements) && isset(_element.subElements)) {
-            for (var j in _element.subElements) {
+            for (const j in _element.subElements) {
               div += this.addSubElement(_element.subElements[j])
             }
           } else {
@@ -1135,7 +1135,7 @@ if (!jeeFrontEnd.scenario) {
           break
         case 'code':
           if (isset(_element.subElements) && isset(_element.subElements)) {
-            for (var j in _element.subElements) {
+            for (const j in _element.subElements) {
               div += this.addSubElement(_element.subElements[j])
             }
           } else {
@@ -1146,7 +1146,7 @@ if (!jeeFrontEnd.scenario) {
           break
         case 'comment':
           if (isset(_element.subElements) && isset(_element.subElements)) {
-            for (var j in _element.subElements) {
+            for (const j in _element.subElements) {
               div += this.addSubElement(_element.subElements[j])
             }
           } else {
@@ -1157,7 +1157,7 @@ if (!jeeFrontEnd.scenario) {
           break
         case 'action':
           if (isset(_element.subElements) && isset(_element.subElements)) {
-            for (var j in _element.subElements) {
+            for (const j in _element.subElements) {
               div += this.addSubElement(_element.subElements[j])
             }
           } else {
@@ -1171,7 +1171,7 @@ if (!jeeFrontEnd.scenario) {
       return div
     },
     getElement: function(dom_element) {
-      var element = dom_element.getJeeValues('.elementAttr', 1)
+      const element = dom_element.getJeeValues('.elementAttr', 1)
       if (element.length == 0) return
       element = element[0]
       element.subElements = []
@@ -1181,7 +1181,7 @@ if (!jeeFrontEnd.scenario) {
         dom_element = [dom_element]
       }
 
-      var subElement, expression_dom, expression, id
+      const subElement, expression_dom, expression, id
       dom_element.forEach(function(dom_el) {
         dom_el.findAtDepth('.subElement', 2).forEach(function(_el) {
           subElement = _el.getJeeValues('.subElementAttr', 2)[0]
@@ -1213,7 +1213,7 @@ if (!jeeFrontEnd.scenario) {
     },
     getAddButton: function(_type, _caret) {
       if (!isset(_caret)) _caret = false
-      var retour = ''
+      let retour = ''
       if (_caret) {
         retour += '<div class="input-group">'
         retour += '<button class="bt_showElse btn btn-xs btn-default roundedLeft" type="button" data-toggle="dropdown" title="{{Afficher/masquer le bloc Sinon}}" aria-haspopup="true" aria-expanded="true">'
@@ -1254,9 +1254,9 @@ if (!jeeFrontEnd.scenario) {
     },
     updateAccordionName: function() {
       document.querySelectorAll('a.accordion-toggle').forEach(function(_acc) {
-        var name = _acc.getAttribute('data-groupname')
-        var num = _acc.closest('div.panel').querySelectorAll('div.scenarioDisplayCard').length
-        var newName = name + ' - ' + num + ' ' + (num > 1 ? '{{scénarios}}' : '{{scénario}}')
+        const name = _acc.getAttribute('data-groupname')
+        const num = _acc.closest('div.panel').querySelectorAll('div.scenarioDisplayCard').length
+        const newName = name + ' - ' + num + ' ' + (num > 1 ? '{{scénarios}}' : '{{scénario}}')
         _acc.textContent = newName
       })
     },
@@ -1264,7 +1264,7 @@ if (!jeeFrontEnd.scenario) {
     getSelectCmdExpressionMessage: function(subType, cmdHumanName) {
       if (!['numeric', 'string', 'binary'].includes(subType)) return '{{Aucun choix possible}}'
 
-      var message = '<div class="row">'
+      const message = '<div class="row">'
       message += '<div class="col-md-12">'
       message += '<form class="form-horizontal" onsubmit="return false;">'
       message += '<div class="form-group">'
@@ -1338,7 +1338,7 @@ if (!jeeFrontEnd.scenario) {
       return message
     },
     selectCmdFromModal: function(event) { //Condition chaining modals outside page_container, called from bt_selectCmdFromModal onclick()
-      var modal = event.target.closest('.jeeDialogPrompt')
+      const modal = event.target.closest('.jeeDialogPrompt')
       modal.style.display = 'none'
       jeedom.cmd.getSelectModal({
         cmd: {
@@ -1354,8 +1354,8 @@ if (!jeeFrontEnd.scenario) {
     reloadStack: function(loadStack) {
       document.getElementById('div_scenarioElement').empty()
       this.actionOptions = []
-      var elements = ''
-      for (var i in loadStack) {
+      const elements = ''
+      for (const i in loadStack) {
         elements += this.addElement(loadStack[i])
       }
       document.getElementById('div_scenarioElement').empty().html(elements, true)
@@ -1368,7 +1368,7 @@ if (!jeeFrontEnd.scenario) {
       this.bt_undo.removeClass('disabled')
       this.bt_redo.addClass('disabled')
 
-      var newStack = []
+      const newStack = []
       document.getElementById('root').querySelectorAll(':scope > .expression').forEach(_exp => {
         newStack.push(jeeP.getElement(_exp.querySelector('div.element')))
       })
@@ -1390,7 +1390,7 @@ if (!jeeFrontEnd.scenario) {
         return
       }
       try {
-        var loadState = this.undoState
+        const loadState = this.undoState
         if (this.reDo == 0) this.setUndoStack(this.undoState + 1)
         this.reloadStack(this.undoStack[loadState])
         this.undoState -= 1
@@ -1414,7 +1414,7 @@ if (!jeeFrontEnd.scenario) {
       }
       this.bt_undo.removeClass('disabled')
       try {
-        var loadState = this.undoState + 2
+        const loadState = this.undoState + 2
         this.reloadStack(this.undoStack[loadState])
         this.undoState += 1
 
@@ -1439,14 +1439,14 @@ if (!jeeFrontEnd.scenario) {
     },
     //Code Editors:
     setEditors: function() {
-      var expression, code
+      const expression, code
       document.querySelectorAll('.expressionAttr[data-l1key="type"][value="code"]').forEach(function(elCode) {
         expression = elCode.closest('.expression')
         code = expression.querySelector('.expressionAttr[data-l1key="expression"]')
         elCode.querySelector('.blocPreview')?.html(code.value)
         if (code.getAttribute('id') == undefined && code.isVisible()) {
           code.uniqueId()
-          var id = code.getAttribute('id')
+          const id = code.getAttribute('id')
           setTimeout(function() {
             jeeP.editors[id] = CodeMirror.fromTextArea(document.getElementById(id), {
               lineNumbers: true,
@@ -1467,7 +1467,7 @@ if (!jeeFrontEnd.scenario) {
     },
     resetEditors: function() {
       this.editors = []
-      var expression, code
+      const expression, code
       document.querySelectorAll('.expressionAttr[data-l1key="type"][value="code"]').forEach(elCode => {
         expression = elCode.closest('.expression')
         code = expression.querySelector('.expressionAttr[data-l1key="expression"]')
@@ -1478,7 +1478,7 @@ if (!jeeFrontEnd.scenario) {
       this.setEditors()
     },
     syncEditors: function() {
-      var expression, code, id
+      const expression, code, id
       document.querySelectorAll('.expressionAttr[data-l1key="type"][value="code"]').forEach(function(elCode) {
         expression = elCode.closest('.expression')
         code = expression.querySelector('.expressionAttr[data-l1key="expression"]')
@@ -1544,9 +1544,9 @@ document.getElementById('bt_addScenario').addEventListener('click', function(eve
           })
         },
         success: function(data) {
-          var vars = getUrlVars()
-          var url = 'index.php?'
-          for (var i in vars) {
+          const vars = getUrlVars()
+          const url = 'index.php?'
+          for (const i in vars) {
             if (i != 'id' && i != 'saveSuccessFull' && i != 'removeSuccessFull') {
               url += i + '=' + vars[i].replace('#', '') + '&'
             }
@@ -1562,11 +1562,11 @@ document.getElementById('bt_addScenario').addEventListener('click', function(eve
 })
 
 document.getElementById('bt_changeAllScenarioState').addEventListener('click', function(event) {
-  var _target = event.target.closest('#bt_changeAllScenarioState')
+  const _target = event.target.closest('#bt_changeAllScenarioState')
   if (_target.getAttribute('data-state') == '0') {
-    var msg = '{{Êtes-vous sûr de vouloir désactiver les scénarios ?}}'
+    let msg = '{{Êtes-vous sûr de vouloir désactiver les scénarios ?}}'
   } else {
-    var msg = '{{Êtes-vous sûr de vouloir activer les scénarios ?}}'
+    let msg = '{{Êtes-vous sûr de vouloir activer les scénarios ?}}'
   }
 
   jeeDialog.confirm(msg, function(result) {
@@ -1673,9 +1673,9 @@ document.querySelector('.scenarioAttr[data-l2key="timeline::enable"]').addEventL
   }
 })
 
-var select = document.getElementById('in_addElementType')
-var input = document.getElementById('in_addElementTypeFilter')
-var allOptions = Array.from(select.options)
+const select = document.getElementById('in_addElementType')
+const input = document.getElementById('in_addElementTypeFilter')
+const allOptions = Array.from(select.options)
 
 function filterOptions() {
   const text = input.value.trim().toLowerCase().stripAccents()
@@ -1700,7 +1700,7 @@ select.addEventListener('change', function(event) {
 })
 
 document.getElementById('in_searchInsideScenario').addEventListener('keyup', function(event) {
-  var search = this.value
+  let search = this.value
   document.querySelectorAll('#div_scenarioElement .insideSearch').removeClass('insideSearch')
   document.querySelectorAll('#div_scenarioElement div.CodeMirror.CodeMirror-wrap').forEach(_code => {
     _code.CodeMirror.setCursor(0)
@@ -1714,7 +1714,7 @@ document.getElementById('in_searchInsideScenario').addEventListener('keyup', fun
   search = jeedomUtils.normTextLower(search)
 
   //search code blocks:
-  var cmEditor, code, cursor
+  let cmEditor, code, cursor
   document.querySelectorAll('#div_scenarioElement div.elementCODE').forEach(_code => {
     try {
       cmEditor = _code.querySelector('div.CodeMirror.CodeMirror-wrap').CodeMirror
@@ -1735,7 +1735,7 @@ document.getElementById('in_searchInsideScenario').addEventListener('keyup', fun
     } catch { }
   })
   //search in expressions:
-  var text
+  const text
   document.querySelectorAll('#div_scenarioElement div.element:not(.elementCODE) .expressionAttr').forEach(_expr => {
     text = jeedomUtils.normTextLower(_expr.value)
     if (text.includes(search)) {
@@ -1753,20 +1753,20 @@ document.getElementById('in_searchInsideScenario').addEventListener('keyup', fun
 
 //_________________Root page events:
 document.getElementById('in_searchScenario').addEventListener('keyup', function() {
-  var search = this.value
+  let search = this.value
   if (search == '') {
     document.querySelectorAll('#accordionScenario .accordion-toggle:not(.collapsed)').forEach(_panel => { _panel.click() })
     document.querySelectorAll('.scenarioDisplayCard').seen()
     return
   }
   search = jeedomUtils.normTextLower(search)
-  var not = search.startsWith(":not(")
+  const not = search.startsWith(":not(")
   if (not) {
     search = search.replace(':not(', '')
   }
   document.querySelectorAll('#accordionScenario .accordion-toggle').forEach(_panel => { _panel.setAttribute('data-show', 0) })
   document.querySelectorAll('.scenarioDisplayCard').unseen()
-  var match, text
+  let match, text
 
   document.querySelectorAll('.scenarioDisplayCard .name').forEach(scName => {
     match = false
@@ -1787,7 +1787,7 @@ document.getElementById('in_searchScenario').addEventListener('keyup', function(
 })
 
 document.getElementById('scenarioThumbnailDisplay').addEventListener('click', function(event) {
-  var _target = null
+  const _target = null
   if (!event.target.matches('a.accordion-toggle')) {
     event.preventDefault()
     event.stopImmediatePropagation()
@@ -1810,7 +1810,7 @@ document.getElementById('scenarioThumbnailDisplay').addEventListener('click', fu
   }
 
   if (_target = event.target.closest('#accordionScenario .bt_ViewLog')) {
-    var id = _target.closest('.scenarioDisplayCard').getAttribute('data-scenario_id')
+    const id = _target.closest('.scenarioDisplayCard').getAttribute('data-scenario_id')
     jeeDialog.dialog({
       id: 'jee_modal2',
       title: "{{Log d'exécution du scénario}}",
@@ -1820,9 +1820,9 @@ document.getElementById('scenarioThumbnailDisplay').addEventListener('click', fu
   }
 
   if (_target = event.target.closest('.scenarioDisplayCard')) {
-    var id = _target.getAttribute('data-scenario_id')
+    const id = _target.getAttribute('data-scenario_id')
     if ((isset(event.detail) && event.detail.ctrlKey) || event.ctrlKey || event.metaKey) {
-      var url = '/index.php?v=d&p=scenario&id=' + id
+      const url = '/index.php?v=d&p=scenario&id=' + id
       window.open(url).focus()
     } else {
       document.getElementById('scenarioThumbnailDisplay').unseen()
@@ -1833,11 +1833,11 @@ document.getElementById('scenarioThumbnailDisplay').addEventListener('click', fu
 })
 
 document.getElementById('scenarioThumbnailDisplay').addEventListener('mouseup', function(event) {
-  var _target = null
+  const _target = null
   if (_target = event.target.closest('.scenarioDisplayCard')) {
     if (event.which == 2) {
       event.preventDefault()
-      var id = _target.getAttribute('data-scenario_id')
+      const id = _target.getAttribute('data-scenario_id')
       document.querySelector('.scenarioDisplayCard[data-scenario_id="' + id + '"]').triggerEvent('click', { detail: { ctrlKey: true } })
     }
     return
@@ -1847,7 +1847,7 @@ document.getElementById('scenarioThumbnailDisplay').addEventListener('mouseup', 
 
 //_________________Floating bar events:
 document.getElementById('div_editScenario').querySelector('div.floatingbar').addEventListener('click', function(event) {
-  var _target = null
+  const _target = null
   if (_target = event.target.closest('#bt_logScenario')) {
     jeeDialog.dialog({
       id: 'jee_modal',
@@ -1919,8 +1919,8 @@ document.getElementById('div_editScenario').querySelector('div.floatingbar').add
 
   if (_target = event.target.closest('#bt_runScenario')) {
     jeedomUtils.hideAlert()
-    var scenario_id = document.querySelector('.scenarioAttr[data-l1key="id"]').jeeValue()
-    var logmode = document.querySelector('select[data-l2key="logmode"]').jeeValue()
+    const scenario_id = document.querySelector('.scenarioAttr[data-l1key="id"]').jeeValue()
+    const logmode = document.querySelector('select[data-l2key="logmode"]').jeeValue()
     if (event.ctrlKey || event.metaKey) {
       jeeP.saveScenario(function() {
         jeedom.scenario.changeState({
@@ -2050,7 +2050,7 @@ document.getElementById('div_editScenario').querySelector('div.floatingbar').add
 
   if (_target = event.target.closest('#bt_resetInsideScenarioSearch')) {
     if (_target.hasClass('disabled')) return
-    var searchField = document.getElementById('in_searchInsideScenario')
+    const searchField = document.getElementById('in_searchInsideScenario')
     if (_target.getAttribute('data-state') == '0') {
       //show search:
       searchField.seen()
@@ -2102,12 +2102,12 @@ document.getElementById('div_editScenario').querySelector('div.floatingbar').add
 
 //_________________General tab events:
 document.getElementById('generaltab').addEventListener('click', function(event) {
-  var _target = null
+  const _target = null
 
   if (_target = event.target.closest('.scenario_link')) {
     jeedomUtils.hideAlert()
     if ((isset(event.detail) && event.detail.ctrlKey) || event.ctrlKey || event.metaKey) {
-      var url = '/index.php?v=d&p=scenario&id=' + event.target.getAttribute('data-scenario_id')
+      const url = '/index.php?v=d&p=scenario&id=' + event.target.getAttribute('data-scenario_id')
       window.open(url).focus()
     } else {
       document.getElementById('scenarioThumbnailDisplay').unseen()
@@ -2117,7 +2117,7 @@ document.getElementById('generaltab').addEventListener('click', function(event) 
 
   if (_target = event.target.closest('.action_link')) {
     jeedomUtils.hideAlert()
-    var cmdId = _target.getAttribute('data-cmd_id')
+    const cmdId = _target.getAttribute('data-cmd_id')
     jeeDialog.dialog({
       id: 'jee_modal2',
       title: '{{Configuration de la commande}}',
@@ -2128,7 +2128,7 @@ document.getElementById('generaltab').addEventListener('click', function(event) 
 
   if (_target = event.target.closest('#bt_chooseIcon')) {
     jeedomUtils.hideAlert()
-    var _icon = false
+    let _icon = false
     if (document.querySelector('div[data-l2key="icon"] > i') != null) {
       _icon = document.querySelector('div[data-l2key="icon"] > i').getAttribute('class')
     }
@@ -2204,7 +2204,7 @@ document.getElementById('generaltab').addEventListener('mouseup', function(event
   if (event.target.matches('.scenario_link')) {
     if (event.which == 2) {
       event.preventDefault()
-      var id = event.target.getAttribute('data-scenario_id')
+      const id = event.target.getAttribute('data-scenario_id')
       document.querySelector('.scenario_link[data-scenario_id="' + id + '"]').triggerEvent('click', { detail: { ctrlKey: true } })
     }
   }
@@ -2221,12 +2221,12 @@ document.getElementById('generaltab').addEventListener('dblclick', function(even
 
 //_________________Scenario tab events:
 document.getElementById('scenariotab').addEventListener('click', function(event) {
-  var _target = null
+  const _target = null
   if (_target = event.target.closest('#bt_addElementSave')) { //Ok button from new block modal
     jeeP.setUndoStack()
     jeeFrontEnd.modifyWithoutSave = true
     if (jeeP.addElementSave.expression) {
-      var newEL = domUtils.parseHTML(jeeP.addExpression({
+      const newEL = domUtils.parseHTML(jeeP.addExpression({
         type: 'element',
         element: {
           type: document.getElementById("in_addElementType").jeeValue()
@@ -2234,7 +2234,7 @@ document.getElementById('scenariotab').addEventListener('click', function(event)
       })
       )
     } else {
-      var newEL = domUtils.parseHTML(jeeP.addElement({
+      const newEL = domUtils.parseHTML(jeeP.addElement({
         type: document.getElementById("in_addElementType").jeeValue()
       })
       )
@@ -2275,7 +2275,7 @@ document.getElementById('scenariotab').addEventListener('click', function(event)
   if (_target = event.target.closest('input:not([type="checkbox"]).expressionAttr, textarea.expressionAttr')) { //ctrl-click input popup
     jeeP.PREV_FOCUS = _target //Place new block next
     if (event.ctrlKey) {
-      var selfInput = _target
+      const selfInput = _target
       jeeDialog.prompt({
         title: '{{Edition}}',
         width: '80%',
@@ -2303,7 +2303,7 @@ document.getElementById('scenariotab').addEventListener('click', function(event)
   }
 
   if (_target = event.target.closest('button.bt_selectJeeDialogCmdExpression')) { //ctrl-click input popup getSelectModal
-    var expression = _target.closest('.jeeDialogPrompt').querySelector('.promptAttr')
+    const expression = _target.closest('.jeeDialogPrompt').querySelector('.promptAttr')
     jeedom.cmd.getSelectModal({}, function(result) {
       expression.insertAtCursor(result.human)
     })
@@ -2369,23 +2369,23 @@ document.getElementById('scenariotab').addEventListener('click', function(event)
   }
 
   if (_target = event.target.closest('.bt_collapse')) {
-    var open = _target.querySelector(':scope > i').hasClass('fa-eye') ? true : false
+    const open = _target.querySelector(':scope > i').hasClass('fa-eye') ? true : false
 
     if (event.ctrlKey || event.metaKey) {
       changeThese = _target.closest('.expressions')?.querySelectorAll('.bt_collapse') || document.querySelectorAll('.bt_collapse')
     } else {
-      var changeThese = [_target]
+      let changeThese = [_target]
     }
 
     for (_target of changeThese) {
-      var icon = _target.querySelector(':scope > i')
+      const icon = _target.querySelector(':scope > i')
       if (open) { // -> Collapse!
         icon.removeClass('fa-eye').addClass('fa-eye-slash')
         _target.closest('.element').addClass('elementCollapse')
         _target.setAttribute('value', 1)
         _target.setAttribute('title', "{{Afficher ce bloc.<br>Ctrl+click: tous.}}")
         //update action, comment and code blocPreview:
-        var txt, _el, id
+        let txt, _el, id
         _target.closest('.element').querySelectorAll('.blocPreview').forEach(function(_blocPreview) {
           txt = '<i>Unfound</i>'
           _el = _blocPreview.closest('.element')
@@ -2426,8 +2426,8 @@ document.getElementById('scenariotab').addEventListener('click', function(event)
   }
 
   if (_target = event.target.closest('.bt_selectCmdExpression')) {
-    var expression = _target.closest('.expression')
-    var type = 'info'
+    const expression = _target.closest('.expression')
+    let type = 'info'
     if (expression.querySelector('.expressionAttr[data-l1key="type"]').jeeValue() == 'action') {
       type = 'action'
     }
@@ -2448,13 +2448,13 @@ document.getElementById('scenariotab').addEventListener('click', function(event)
       }
 
       if (expression.querySelector('.expressionAttr[data-l1key="type"]').jeeValue() == 'condition') {
-        var condType = _target.closest('.subElement')
+        const condType = _target.closest('.subElement')
         if (!condType.hasClass('subElementIF') && !condType.hasClass('subElementFOR') && !condType.hasClass('subElementWHILE')) {
           expression.querySelector('.expressionAttr[data-l1key="expression"]').insertAtCursor(result.human)
           return
         }
 
-        var message = jeeP.getSelectCmdExpressionMessage(result.cmd.subType, result.human)
+        const message = jeeP.getSelectCmdExpressionMessage(result.cmd.subType, result.human)
         jeeDialog.prompt({
           title: "{{Ajout d'une nouvelle condition}}",
           inputType: false,
@@ -2478,7 +2478,7 @@ document.getElementById('scenariotab').addEventListener('click', function(event)
                 click: function(event) {
                   jeeP.setUndoStack()
                   jeeFrontEnd.modifyWithoutSave = true
-                  var condition = result.human
+                  let condition = result.human
                   condition += ' ' + document.querySelector('.conditionAttr[data-l1key="operator"]').jeeValue()
                   if (result.cmd.subType == 'string') {
                     if (document.querySelector('.conditionAttr[data-l1key="operator"]').jeeValue() == 'matches') {
@@ -2507,7 +2507,7 @@ document.getElementById('scenariotab').addEventListener('click', function(event)
   }
 
   if (_target = event.target.closest('.bt_selectOtherActionExpression')) {
-    var expression = _target.closest('.expression')
+    const expression = _target.closest('.expression')
     jeedom.getSelectActionModal({
       scenario: true
     }, function(result) {
@@ -2522,7 +2522,7 @@ document.getElementById('scenariotab').addEventListener('click', function(event)
   }
 
   if (_target = event.target.closest('.bt_selectScenarioExpression')) {
-    var expression = _target.closest('.expression')
+    const expression = _target.closest('.expression')
     jeedom.scenario.getSelectModal({}, function(result) {
       if (expression.querySelector('.expressionAttr[data-l1key="type"]').jeeValue() == 'action') {
         expression.querySelector('.expressionAttr[data-l1key="expression"]').jeeValue(result.human)
@@ -2535,7 +2535,7 @@ document.getElementById('scenariotab').addEventListener('click', function(event)
   }
 
   if (_target = event.target.closest('.bt_selectGenericExpression')) {
-    var expression = _target.closest('.expression')
+    const expression = _target.closest('.expression')
     jeedom.config.getGenericTypeModal({ type: 'info', object: true }, function(result) {
       expression.querySelector('.expressionAttr[data-l1key="expression"]').insertAtCursor(result.human)
     })
@@ -2543,7 +2543,7 @@ document.getElementById('scenariotab').addEventListener('click', function(event)
   }
 
   if (_target = event.target.closest('.bt_selectEqLogicExpression')) {
-    var expression = _target.closest('.expression')
+    const expression = _target.closest('.expression')
     jeedom.eqLogic.getSelectModal({}, function(result) {
       if (expression.querySelector('.expressionAttr[data-l1key="type"]').jeeValue() == 'action') {
         expression.querySelector('.expressionAttr[data-l1key="expression"]').jeeValue(result.human)
@@ -2569,8 +2569,8 @@ document.getElementById('scenariotab').addEventListener('click', function(event)
   if (_target = event.target.closest('.fromSubElement')) {
     jeeP.setUndoStack()
 
-    var elementDiv = _target.closest('.subElement').querySelector('.expressions')
-    var newEL = domUtils.parseHTML(jeeP.addExpression({
+    const elementDiv = _target.closest('.subElement').querySelector('.expressions')
+    const newEL = domUtils.parseHTML(jeeP.addExpression({
       type: 'element',
       element: {
         type: _target.getAttribute('data-type')
@@ -2593,7 +2593,7 @@ document.getElementById('scenariotab').addEventListener('click', function(event)
 
   //COPY - PASTE
   if (_target = event.target.closest('i.bt_copyElement')) {
-    var clickedBloc = _target.closest('.element')
+    const clickedBloc = _target.closest('.element')
     jeeP.clipboard = jeeP.getElement(clickedBloc)
 
     //delete all id in properties to make it unique later:
@@ -2616,12 +2616,12 @@ document.getElementById('scenariotab').addEventListener('click', function(event)
     } else {
       return false
     }
-    var clickedBloc = _target.closest('.element')
+    const clickedBloc = _target.closest('.element')
 
     jeeP.setUndoStack()
     jeeP.actionOptions = []
 
-    var pastedElement = document.createElement('div')
+    let pastedElement = document.createElement('div')
     pastedElement.innerHTML = jeeP.addElement(jeeP.clipboard)
 
     //Are we pasting inside an expresion:
@@ -2669,14 +2669,14 @@ document.getElementById('scenariotab').addEventListener('click', function(event)
 
 document.getElementById('scenariotab').addEventListener('change', function(event) {
   if (event.target.matches('.subElementAttr[data-l1key="options"][data-l2key="enable"]')) {
-    var checkbox = event.target
-    var element = checkbox.closest('.element')
+    const checkbox = event.target
+    const element = checkbox.closest('.element')
     if (checkbox.checked) {
       element.removeClass('disableElement')
     } else {
       element.addClass('disableElement')
     }
-    var subElement = checkbox.closest('.element').querySelector('.subElement:not(.noSortable)')
+    const subElement = checkbox.closest('.element').querySelector('.subElement:not(.noSortable)')
     if (!subElement) return
     if (checkbox.checked) {
       subElement.querySelectorAll('.expressions')?.removeClass('disableSubElement')
@@ -2687,7 +2687,7 @@ document.getElementById('scenariotab').addEventListener('change', function(event
   }
 
   if (event.target.matches('.expressionAttr[data-l1key="options"][data-l2key="enable"]')) {
-    var element = event.target.closest('.expression')
+    const element = event.target.closest('.expression')
     if (event.target.checked) {
       element.removeClass('disableSubElement')
     } else {
@@ -2698,7 +2698,7 @@ document.getElementById('scenariotab').addEventListener('change', function(event
 })
 
 document.getElementById('scenariotab').addEventListener('mouseenter', function(event) {
-  var _target = null
+  const _target = null
   if (_target = event.target.closest('button.dropdown-toggle')) {
     if (event.clientY > window.innerHeight - 220) {
       _target.closest('div.dropdown').addClass('dropup')
@@ -2709,7 +2709,7 @@ document.getElementById('scenariotab').addEventListener('mouseenter', function(e
 }, { capture: true })
 
 document.getElementById('scenariotab').addEventListener('mouseout', function(event) {
-  var _target = null
+  const _target = null
   if (_target = event.target.closest('button.dropdown-toggle')) {
     if (event.clientY > window.innerHeight - 220) {
       event.target.closest('div.dropdown').addClass('dropup')
@@ -2720,11 +2720,11 @@ document.getElementById('scenariotab').addEventListener('mouseout', function(eve
 })
 
 document.getElementById('scenariotab').addEventListener('focusout', function(event) {
-  var _target = null
+  const _target = null
   if (_target = event.target.closest('.expression .expressionAttr[data-l1key="expression"]')) {
     if (_target.getAttribute('prevalue') == _target.value) return
     if (_target.closest('.expression').querySelector('.expressionAttr[data-l1key="type"]').value == 'action') {
-      var expression = _target.closest('.expression').getJeeValues('.expressionAttr')
+      const expression = _target.closest('.expression').getJeeValues('.expressionAttr')
       jeedom.cmd.displayActionOption(_target.value, init(expression[0].options), function(html) {
         _target.closest('.expression').querySelector('.expressionOptions').html(html)
         jeedomUtils.taAutosize()
@@ -2754,12 +2754,12 @@ try {
     success: function(scenarioGroupedList) {
       if (scenarioGroupedList.length == 0) return
 
-      var contextmenuitems = {}
-      var uniqId = 0
-      var items, scName, scId
-      for (var group in scenarioGroupedList) {
+      const contextmenuitems = {}
+      let uniqId = 0
+      let items, scName, scId
+      for (const group in scenarioGroupedList) {
         items = {}
-        for (var i in scenarioGroupedList[group]) {
+        for (const i in scenarioGroupedList[group]) {
           scName = scenarioGroupedList[group][i].humanName.replace('[' + group + ']', '')
           scId = scenarioGroupedList[group][i].id
           items[uniqId] = {
@@ -2783,7 +2783,7 @@ try {
           callback: function(key, options, event) {
             if (!jeedomUtils.checkPageModified()) {
               if (event.ctrlKey || event.metaKey || event.which == 2) {
-                var url = 'index.php?v=d&p=scenario&id=' + options.commands[key].id
+                const url = 'index.php?v=d&p=scenario&id=' + options.commands[key].id
                 if (window.location.hash != '') {
                   url += window.location.hash
                 }
@@ -2808,16 +2808,16 @@ try {
     appendTo: 'div#div_pageContainer',
     className: 'scenario-context-menu',
     build: function(trigger) {
-      var scGroups = []
+      const scGroups = []
       Object.keys(jeephp2js.scenarioListGroup).forEach(function(key) {
         scGroups.push(jeephp2js.scenarioListGroup[key].group)
       })
 
-      var scId = trigger.getAttribute('data-scenario_id')
-      var scName = trigger.querySelector('.name strong').innerHTML
-      var isActive = !trigger.hasClass('inactive')
+      const scId = trigger.getAttribute('data-scenario_id')
+      const scName = trigger.querySelector('.name strong').innerHTML
+      const isActive = !trigger.hasClass('inactive')
 
-      var contextmenuitems = {}
+      const contextmenuitems = {}
       contextmenuitems['scId'] = { 'name': scName + '(id: ' + scId + ')', 'id': 'scId', 'disabled': true }
       if (isActive) {
         contextmenuitems['disable'] = { 'name': '{{Rendre inactif}}', 'id': 'disable', 'icon': 'fas fa-toggle-on' }
@@ -2826,8 +2826,8 @@ try {
       }
 
       //group submenu:
-      var idx = 0
-      var items = {}
+      let idx = 0
+      let items = {}
       items['group_none'] = {
         'name': '{{Aucun}}',
         'id': 'group_none',
@@ -2849,7 +2849,7 @@ try {
       }
 
       //parent submenu
-      var items = {}
+      let items = {}
       items[0] = {
         'name': '<span class="label labelObjectHuman">None</span>',
         'id': 'parent_0',
@@ -2858,8 +2858,8 @@ try {
         'jHumanName': '{{Aucun}}',
         'isHtmlName': true,
       }
-      var idx = 1
-      for (var parent of jeephp2js.objectList) {
+      let idx = 1
+      for (const parent of jeephp2js.objectList) {
         items[idx] = {
           'name': parent.tag,
           'id': 'parent_' + idx,
@@ -2879,7 +2879,7 @@ try {
         callback: function(key, options) {
           if (options.commands[key].jType == 'group') {
             if (key == 'group_none') key = null
-            var scenario = {
+            const scenario = {
               id: scId,
               group: key
             }
@@ -2897,12 +2897,12 @@ try {
           }
 
           if (options.commands[key].jType == 'parent') {
-            var humanName = options.commands[key].jHumanName
-            var objectId = options.commands[key].jId
+            let humanName = options.commands[key].jHumanName
+            const objectId = options.commands[key].jId
             if (key == '0') {
               humanName = '<span class="label labelObjectHuman">None</span>'
             }
-            var scenario = {
+            const scenario = {
               id: scId,
               object_id: objectId
             }
@@ -2922,7 +2922,7 @@ try {
           }
 
           if (key == 'disable') {
-            var scenario = {
+            const scenario = {
               id: scId,
               isActive: "0"
             }
@@ -2939,7 +2939,7 @@ try {
           }
 
           if (key == 'enable') {
-            var scenario = {
+            const scenario = {
               id: scId,
               isActive: "1"
             }

--- a/desktop/js/timeline.js
+++ b/desktop/js/timeline.js
@@ -50,28 +50,30 @@ if (!jeeFrontEnd.timeline) {
           if (data.length == 0) return
           data.sort(jeeP.sortByDateConsistentASC)
           data = data.reverse()
-          var dataLength = data.length
-          var decayFactor = 130
+          const dataLength = data.length
+          const decayFactor = 130
 
           moment.locale(jeeFrontEnd.language.substring(0, 2))
 
-          var lastEvent = document.querySelector('#timelineContainer #events li.event:last-child')
+          const lastEvent = document.querySelector('#timelineContainer #events li.event:last-child')
+          let isFirstOfDay, isLastOfDay, prevDate, prevDateTs, content
+          let nextDate, thisDateTs
           if (lastEvent != null) {
-            var isFirstOfDay = data[0].date.substring(0, 10) != lastEvent.querySelector('div.date').innerHTML.substring(4) ? true : false
-            var isLastOfDay = false
-            var prevDate = moment(lastEvent.querySelector('div.date').innerHTML, 'ddd  YYYY-MM-DD').format("YYYY-MM-DD")
-            var prevDateTs = moment(prevDate + ' ' + lastEvent.querySelector('div.time').innerHTML, "YYYY-MM-DD hh:mm:ss").unix()
-            var content = ''
+            isFirstOfDay = data[0].date.substring(0, 10) != lastEvent.querySelector('div.date').innerHTML.substring(4) ? true : false
+            isLastOfDay = false
+            prevDate = moment(lastEvent.querySelector('div.date').innerHTML, 'ddd  YYYY-MM-DD').format("YYYY-MM-DD")
+            prevDateTs = moment(prevDate + ' ' + lastEvent.querySelector('div.time').innerHTML, "YYYY-MM-DD hh:mm:ss").unix()
+            content = ''
           } else {
-            var isFirstOfDay, isLastOfDay = false
-            var nextDate, thisDateTs = false
-            var prevDate = moment().format("YYYY-MM-DD")
-            var prevDateTs = moment().unix()
-            var content = '<div class="label-warning day">' + moment(data[0].date).format('ddd YYYY-MM-DD') + '</div>'
+            isLastOfDay = false
+            thisDateTs = false
+            prevDate = moment().format("YYYY-MM-DD")
+            prevDateTs = moment().unix()
+            content = '<div class="label-warning day">' + moment(data[0].date).format('ddd YYYY-MM-DD') + '</div>'
           }
 
-          var thisData, date, dateFull, time, lineClass, style, height, li
-          for (var i in data) {
+          let thisData, date, dateFull, time, lineClass, style, height, li
+          for (const i in data) {
             thisData = data[i]
             date = thisData.date.substring(0, 10)
             time = thisData.date.substring(11, 19)
@@ -169,11 +171,11 @@ if (!jeeFrontEnd.timeline) {
 
     },
     sortByDateConsistentASC: function(itemA, itemB) {
-      var valueA = itemA.date
-      var valueB = itemB.date
-      var a = moment(valueA)
-      var b = moment(valueB)
-      var r = 0
+      const valueA = itemA.date
+      const valueB = itemB.date
+      const a = moment(valueA)
+      const b = moment(valueB)
+      let r = 0
       if (a.isValid() && b.isValid()) {
         r = ((a.valueOf() > b.valueOf()) ? 1 : ((a.valueOf() < b.valueOf()) ? -1 : 0))
       }
@@ -190,18 +192,18 @@ jeeFrontEnd.timeline.init()
 
 //searching
 document.getElementById('in_searchTimeline')?.addEventListener('keyup', function(event) {
-  var search = event.target.value
+  let search = event.target.value
   if (search == '') {
     document.querySelectorAll('#events > li.event').seen()
     return
   }
   search = jeedomUtils.normTextLower(search)
-  var not = search.startsWith(":not(")
+  const not = search.startsWith(":not(")
   if (not) {
     search = search.replace(':not(', '')
   }
   document.querySelectorAll('#events > li.event').unseen()
-  var match, text
+  let match, text
   document.querySelectorAll('#events > li.event').forEach(_li => {
     match = false
     text = jeedomUtils.normTextLower(_li.querySelector('.tml-cmd')?.textContent)
@@ -264,7 +266,7 @@ document.getElementById('sel_timelineFolder').addEventListener('change', functio
 //Specials
 document.getElementById('div_mainContainer').registerEvent('scroll', function(event) {
   if (jeeP == undefined || jeeP.isScrolling) return
-  let container = document.getElementById('div_mainContainer')
+  const container = document.getElementById('div_mainContainer')
   if (container.scrollTop >= container.scrollHeight - window.innerHeight) {
     jeeP.isScrolling = true
     jeeP.loadStart = jeeP.loadStart + jeeP.loadOffset + 1
@@ -276,7 +278,7 @@ document.getElementById('div_mainContainer').registerEvent('scroll', function(ev
 /*Events delegations
 */
 document.getElementById('events').addEventListener('click', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('.bt_scenarioLog')) {
     jeeDialog.dialog({
       id: 'jee_modal',
@@ -311,9 +313,9 @@ document.getElementById('events').addEventListener('click', function(event) {
 })
 
 document.getElementById('timelineBottom').addEventListener('click', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('a.bt_loadMore')) {
-    var more = parseInt(_target.getAttribute('data-load'))
+    const more = parseInt(_target.getAttribute('data-load'))
     jeeP.loadStart = jeeP.loadStart + jeeP.loadOffset + 1
     jeeP.loadOffset = more
     jeeP.displayTimelineSegment(jeeP.loadStart, jeeP.loadOffset)


### PR DESCRIPTION
## Summary

Replace `var` with `const`/`let` in the scenario and timeline desktop/js modules.

**Modules:** scenario, timeline

### Changes
- All `var` declarations → `const` (not reassigned) or `let` (reassigned)
- `for (var x in/of ...)` → `for (const x in/of ...)`
- `for (var i = 0; ...)` → `for (let i = 0; ...)`

**No functional changes.** Bug fixes for scenario.js are tracked separately in #3319 (Lot 2).

## Type of change
- [x] Refactor (no functional change)
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Suggested changelog entry
```
- refactor(desktop/js): replace var with const/let in scenario and timeline
```

## Test plan
- Open a scenario, confirm loading, saving (Ctrl+S), undo/redo work
- Test copy/paste of scenario elements
- Test right-click context menus on elements
- Open timeline page, confirm timeline displays correctly

## Known risks
- Minimal: block scoping verified, no hoisting dependencies found in scenario.js