### PR TITLE
refactor(desktop/js): replace var with const/let in admin and editing modules

### DIFF
--- a/desktop/js/administration.js
+++ b/desktop/js/administration.js
@@ -67,10 +67,10 @@ if (!jeeFrontEnd.administration) {
             })
             return
           }
-          var tbody = document.getElementById('table_objectSummary').tBodies[0]
+          const tbody = document.getElementById('table_objectSummary').tBodies[0]
           if (Sortable.get(tbody)) Sortable.get(tbody).destroy()
           tbody.empty()
-          for (var i in data.result) {
+          for (const i in data.result) {
             if (isset(data.result[i].key) && data.result[i].key == '') continue
             if (!isset(data.result[i].name)) continue
             if (!isset(data.result[i].key)) {
@@ -151,16 +151,16 @@ if (!jeeFrontEnd.administration) {
       if (!isset(_change) || _change === true) jeeFrontEnd.modifyWithoutSave = true
     },
     saveObjectSummary: function() {
-      var summary = {}
-      var temp = document.getElementById('table_objectSummary').tBodies[0].childNodes.getJeeValues('.objectSummaryAttr')
-      for (var i in temp) {
+      const summary = {}
+      const temp = document.getElementById('table_objectSummary').tBodies[0].childNodes.getJeeValues('.objectSummaryAttr')
+      for (const i in temp) {
         if (temp[i].key == '') {
           temp[i].key = temp[i].name
         }
         temp[i].key = temp[i].key.toLowerCase().stripAccents().replace(/\_/g, '').replace(/\-/g, '').replace(/\&/g, '').replace(/\%/g, '').replace(/\s/g, '').replace(/\./g, '')
         summary[temp[i].key] = temp[i]
       }
-      var value = {
+      const value = {
         'object:summary': summary
       }
       domUtils.ajax({
@@ -204,7 +204,7 @@ if (!jeeFrontEnd.administration) {
           success: function(data) {
             if (data == '' || typeof data != 'object') return
             jeeP.actionOptions = []
-            for (var i in data) {
+            for (const i in data) {
               jeeP.addActionOnMessage(data[i], channel)
             }
             jeedom.cmd.displayActionsOption({
@@ -217,7 +217,7 @@ if (!jeeFrontEnd.administration) {
                 })
               },
               success: function(data) {
-                for (var i in data) {
+                for (const i in data) {
                   document.getElementById(data[i].id).html(data[i].html.html)
                 }
                 jeedomUtils.taAutosize()
@@ -329,7 +329,7 @@ if (!jeeFrontEnd.administration) {
             return
           }
           document.getElementById('table_convertColor').tBodies[0].empty()
-          for (var color in data.result) {
+          for (const color in data.result) {
             jeeP.addConvertColor(color, data.result[color], false)
           }
         }
@@ -351,8 +351,8 @@ if (!jeeFrontEnd.administration) {
       if (!isset(_change) || _change === true) jeeFrontEnd.modifyWithoutSave = true
     },
     saveConvertColor: function() {
-      var value = {}
-      var colors = {}
+      const value = {}
+      const colors = {}
       document.querySelectorAll('#table_convertColor tbody tr').forEach(function(element) {
         colors[element.querySelector('.color').jeeValue()] = element.querySelector('.html').jeeValue()
       })
@@ -410,7 +410,7 @@ if (!jeeFrontEnd.administration) {
       jeedomUtils.hideAlert()
       jeeP.saveConvertColor()
       jeeP.saveObjectSummary()
-      var config = document.querySelectorAll('#config').getJeeValues('.configKey')[0]
+      const config = document.querySelectorAll('#config').getJeeValues('.configKey')[0]
       document.querySelectorAll('.bt_addActionOnMessage').forEach(_bt => {
         let channel = _bt.getAttribute('data-channel')
         config['actionOnMessage' + channel] = JSON.stringify(document.querySelectorAll('#div_actionOnMessage' + channel + ' .actionOnMessage').getJeeValues('.expressionAttr'))
@@ -434,9 +434,9 @@ if (!jeeFrontEnd.administration) {
               })
             },
             success: function(data) {
-              var reloadPage = false
+              let reloadPage = false
               try {
-                for (var key in jeeP.configReload) {
+                for (const key in jeeP.configReload) {
                   if (jeeP.configReload[key] != data[key]) {
                     reloadPage = true
                     break
@@ -447,7 +447,7 @@ if (!jeeFrontEnd.administration) {
               }
               if (reloadPage) {
                 jeeFrontEnd.modifyWithoutSave = false
-                var url = 'index.php?v=d&p=administration&saveSuccessFull=1'
+                let url = 'index.php?v=d&p=administration&saveSuccessFull=1'
                 if (window.location.hash != '') {
                   url += window.location.hash
                 }
@@ -479,8 +479,8 @@ jeeFrontEnd.administration.init()
 
 //searching
 document.getElementById('in_searchConfig').addEventListener('keyup', function(event) {
-  var search = this.value
-  var resultDiv = document.getElementById('searchResult')
+  let search = this.value
+  const resultDiv = document.getElementById('searchResult')
 
   //place back found els with unique span id to place them back to right place. Avoid cloning els to not break saveConfig().
   document.querySelectorAll('span[searchId]').forEach(_span => {
@@ -502,9 +502,9 @@ document.getElementById('in_searchConfig').addEventListener('keyup', function(ev
   document.querySelectorAll('#config .nav-tabs, #config .tab-content').unseen()
 
   search = jeedomUtils.normTextLower(search)
-  var text, tooltip, tabId, tabName, newTabLink, el, searchId
-  var tabsArr = []
-  var thisTabLink
+  let text, tooltip, tabId, tabName, newTabLink, el, searchId
+  const tabsArr = []
+  let thisTabLink
 
   //Search in all labels and their tooltip:
   document.querySelectorAll('.form-group > .control-label').forEach(_label => {
@@ -525,7 +525,7 @@ document.getElementById('in_searchConfig').addEventListener('keyup', function(ev
       if (!tabsArr.includes(tabId)) {
         tabName = document.querySelector('a[data-target="#' + tabId + '"]').innerHTML
         if (tabName != null) {
-          var newTabLink = document.createElement('div')
+          let newTabLink = document.createElement('div')
           newTabLink.innerHTML = '<a role="searchTabLink" data-target="#' + tabId + '">' + tabName + '</a>'
           resultDiv.appendChild(newTabLink)
           tabsArr.push(tabId)
@@ -537,7 +537,7 @@ document.getElementById('in_searchConfig').addEventListener('keyup', function(ev
       if (el.getAttribute('searchId') == null) {
         searchId = domUtils.uniqueId('search-')
         el.setAttribute('searchId', searchId)
-        var newRefSpan = document.createElement('span')
+        const newRefSpan = document.createElement('span')
         newRefSpan.setAttribute('searchId', searchId)
         el.replaceWith(newRefSpan)
         thisTabLink.appendChild(el)
@@ -558,7 +558,7 @@ document.getElementById('bt_resetConfigSearch').addEventListener('click', functi
 /*Events delegations
 */
 document.getElementById('generaltab').addEventListener('click', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('#bt_forceSyncHour')) {
     jeedomUtils.hideAlert()
     jeedom.forceSyncHour({
@@ -653,7 +653,7 @@ document.getElementById('generaltab').addEventListener('click', function(event) 
 /**************************INTERFACE***********************************/
 //Init file upload buttons:
 document.querySelectorAll('input.bt_uploadImage').forEach(_button => {
-  var dataPage = _button.getAttribute('data-page')
+  const dataPage = _button.getAttribute('data-page')
   new jeeFileUploader({
     fileInput: _button,
     url: 'core/ajax/config.ajax.php?action=uploadImage&id=' + dataPage,
@@ -680,7 +680,7 @@ document.querySelectorAll('input.bt_uploadImage').forEach(_button => {
 /*Events delegations
 */
 document.getElementById('interfacetab').addEventListener('click', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('#bt_resetThemeCookie')) {
     setCookie('currentTheme', '', -1)
     jeedomUtils.showAlert({
@@ -691,7 +691,7 @@ document.getElementById('interfacetab').addEventListener('click', function(event
   }
 
   if (_target = event.target.closest('.bt_removeBackgroundImage')) {
-    var dataPage = _target.getAttribute('data-page')
+    const dataPage = _target.getAttribute('data-page')
     jeeDialog.confirm('{{Êtes-vous sûr de vouloir supprimer cette image de fond ?}}', function(result) {
       if (result) {
         jeedom.config.removeImage({
@@ -722,9 +722,9 @@ document.getElementById('interfacetab').addEventListener('click', function(event
 /*Events delegations
 */
 document.getElementById('tablist').addEventListener('click', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('#bt_networkTab')) {
-    var tableBody = document.getElementById('networkInterfacesTable').tBodies[0]
+    const tableBody = document.getElementById('networkInterfacesTable').tBodies[0]
     if (tableBody.children.length == 0) {
       jeedom.network.getInterfacesInfo({
         error: function(error) {
@@ -737,7 +737,7 @@ document.getElementById('tablist').addEventListener('click', function(event) {
           let div = ''
           let options = '<option value="auto">{{Automatique}}</option>'
 
-          for (var i in _interfaces) {
+          for (const i in _interfaces) {
             div += '<tr>'
             div += '<td>' + _interfaces[i].ifname + '</td>'
             div += '<td data-interface="' + _interfaces[i].ifname + '">' + (_interfaces[i].addr_info && _interfaces[i].addr_info[0] ? _interfaces[i].addr_info[0].local : '') + '</td>'
@@ -768,7 +768,7 @@ document.getElementById('tablist').addEventListener('click', function(event) {
 
 
 document.getElementById('networktab').addEventListener('click', function(event) {
-  var _target = null
+  let _target = null
 
   if (_target = event.target.closest('#bt_restartDns')) {
     jeedomUtils.hideAlert()
@@ -828,7 +828,7 @@ document.getElementById('networktab').addEventListener('click', function(event) 
 })
 
 document.getElementById('networktab').addEventListener('change', function(event) {
-  var _target = null
+  let _target = null
   if ((_target = event.target.closest('.configKey[data-l1key="market::allowDNS"]')) || (_target = event.target.closest('.configKey[data-l1key="network::disableMangement"]'))) {
     if (document.querySelector('.configKey[data-l1key="market::allowDNS"]')?.jeeValue() == 1 && document.querySelector('.configKey[data-l1key="network::disableMangement"]').jeeValue() == 0) {
       document.querySelector('.configKey[data-l1key="externalProtocol"]').setAttribute('disabled', true)
@@ -885,7 +885,7 @@ document.getElementById('networktab').addEventListener('change', function(event)
 /*Events delegations
 */
 document.getElementById('logtab').addEventListener('click', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('#bt_removeTimelineEvent')) {
     jeedom.timeline.deleteAll({
       error: function(error) {
@@ -895,7 +895,7 @@ document.getElementById('logtab').addEventListener('click', function(event) {
         })
       },
       success: function(data) {
-        var cmd = (cmd = document.getElementById('timelineEvents')) ? cmd.innerHTML = 0 : null
+        const cmd = (cmd = document.getElementById('timelineEvents')) ? cmd.innerHTML = 0 : null
         jeedomUtils.showAlert({
           message: '{{Evènements de la timeline supprimés avec succès}}',
           level: 'success'
@@ -936,7 +936,7 @@ document.getElementById('logtab').addEventListener('click', function(event) {
   }
 
   if (_target = event.target.closest('.listCmdAction')) {
-    var el = _target.closest('.actionOnMessage').querySelector('.expressionAttr[data-l1key="cmd"]')
+    const el = _target.closest('.actionOnMessage').querySelector('.expressionAttr[data-l1key="cmd"]')
     jeedom.cmd.getSelectModal({
       cmd: {
         type: 'action'
@@ -952,7 +952,7 @@ document.getElementById('logtab').addEventListener('click', function(event) {
   }
 
   if (_target = event.target.closest('.listAction')) {
-    var el = _target.closest('.actionOnMessage').querySelector('.expressionAttr[data-l1key="cmd"]')
+    const el = _target.closest('.actionOnMessage').querySelector('.expressionAttr[data-l1key="cmd"]')
     jeedom.getSelectActionModal({}, function(result) {
       el.jeeValue(result.human)
       jeedom.cmd.displayActionOption(result.human, '', function(html) {
@@ -964,7 +964,7 @@ document.getElementById('logtab').addEventListener('click', function(event) {
   }
 
   if (_target = event.target.closest('.bt_selectAlertCmd')) {
-    var type = _target.getAttribute('data-type')
+    const type = _target.getAttribute('data-type')
     jeedom.cmd.getSelectModal({
       cmd: {
         type: 'action',
@@ -990,7 +990,7 @@ document.getElementById('logtab').addEventListener('click', function(event) {
 })
 
 document.getElementById('logtab').addEventListener('change', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('.configKey[data-l1key="log::engine"]')) {
     if (_target.value == '') return
     let element = document.querySelector('.logEngine.' + _target.value)
@@ -1000,9 +1000,9 @@ document.getElementById('logtab').addEventListener('change', function(event) {
 })
 
 document.getElementById('logtab').addEventListener('focusout', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('.cmdAction.expressionAttr[data-l1key="cmd"]')) {
-    var expression = _target.closest('.actionOnMessage').getJeeValues('.expressionAttr')
+    const expression = _target.closest('.actionOnMessage').getJeeValues('.expressionAttr')
     if (expression[0] && expression[0].options) {
       jeedom.cmd.displayActionOption(_target.value, init(expression[0].options), function(html) {
         _target.closest('.actionOnMessage').querySelector('.actionOptions').html(html)
@@ -1018,15 +1018,15 @@ document.getElementById('logtab').addEventListener('focusout', function(event) {
 /*Events delegations
 */
 document.getElementById('summarytab').addEventListener('click', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('#bt_addObjectSummary')) {
     jeeP.addObjectSummary()
     return
   }
 
   if (_target = event.target.closest('.objectSummaryAction[data-l1key="chooseIcon"]')) {
-    var objectSummary = _target.closest('.objectSummary')
-    var icon = objectSummary.querySelector('span[data-l1key="icon"] > i')
+    const objectSummary = _target.closest('.objectSummary')
+    let icon = objectSummary.querySelector('span[data-l1key="icon"] > i')
     if (icon != null) {
       icon = icon.getAttribute('class')
     } else {
@@ -1040,8 +1040,8 @@ document.getElementById('summarytab').addEventListener('click', function(event) 
   }
 
   if (_target = event.target.closest('.objectSummaryAction[data-l1key="chooseIconNul"]')) {
-    var objectSummary = _target.closest('.objectSummary')
-    var icon = objectSummary.querySelector('span[data-l1key="iconnul"] > i')
+    const objectSummary = _target.closest('.objectSummary')
+    let icon = objectSummary.querySelector('span[data-l1key="iconnul"] > i')
     if (icon != null) {
       icon = icon.getAttribute('class')
     } else {
@@ -1061,7 +1061,7 @@ document.getElementById('summarytab').addEventListener('click', function(event) 
   }
 
   if (_target = event.target.closest('.objectSummaryAction[data-l1key="createVirtual"]')) {
-    var objectSummary = _target.closest('.objectSummary').querySelector('.objectSummaryAttr[data-l1key="key"]').jeeValue()
+    const objectSummary = _target.closest('.objectSummary').querySelector('.objectSummaryAttr[data-l1key="key"]').jeeValue()
     domUtils.ajax({
       type: "POST",
       url: "core/ajax/object.ajax.php",
@@ -1092,7 +1092,7 @@ document.getElementById('summarytab').addEventListener('click', function(event) 
 })
 
 document.getElementById('summarytab').addEventListener('dblclick', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('.summIconContainer')) {
     _target.closest('.objectSummaryAttr').innerHTML = ''
     return
@@ -1100,7 +1100,7 @@ document.getElementById('summarytab').addEventListener('dblclick', function(even
 })
 
 document.getElementById('summarytab').addEventListener('change', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('.objectSummaryAttr')) {
     jeeFrontEnd.modifyWithoutSave = true
     return
@@ -1112,7 +1112,7 @@ document.getElementById('summarytab').addEventListener('change', function(event)
 /*Events delegations
 */
 document.getElementById('eqlogictab').addEventListener('click', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('#bt_influxDelete')) {
     jeeDialog.confirm('{{Êtes-vous sûr de vouloir supprimer la base d\'InfluxDB}}', function(result) {
       if (result) {
@@ -1184,7 +1184,7 @@ document.getElementById('eqlogictab').addEventListener('click', function(event) 
 /*Events delegations
 */
 document.getElementById('interacttab').addEventListener('click', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('#bt_addColorConvert')) {
     jeeP.addConvertColor()
     return
@@ -1196,7 +1196,7 @@ document.getElementById('interacttab').addEventListener('click', function(event)
   }
 
   if (_target = event.target.closest('.bt_resetColor')) {
-    var key = _target.getAttribute('data-l1key')
+    const key = _target.getAttribute('data-l1key')
     jeedom.getConfiguration({
       key: key,
       default: 1,
@@ -1219,7 +1219,7 @@ document.getElementById('interacttab').addEventListener('click', function(event)
 /*Events delegations
 */
 document.getElementById('securitytab').addEventListener('click', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('#bt_testLdapConnection')) {
     jeedom.config.save({
       configuration: document.getElementById('config').getJeeValues('.configKey')[0],
@@ -1277,7 +1277,7 @@ document.getElementById('securitytab').addEventListener('click', function(event)
 })
 
 document.getElementById('securitytab').addEventListener('change', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('.configKey[data-l1key="ldap:enable"]')) {
     if (_target.checked) {
       document.getElementById('div_config_ldap').seen()
@@ -1293,9 +1293,9 @@ document.getElementById('securitytab').addEventListener('change', function(event
 /*Events delegations
 */
 document.getElementById('updatetab').addEventListener('click', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('.testRepoConnection')) {
-    var repo = _target.getAttribute('data-repo')
+    const repo = _target.getAttribute('data-repo')
     jeedom.config.save({
       configuration: document.getElementById('config').getJeeValues('.configKey')[0],
       error: function(error) {
@@ -1355,7 +1355,7 @@ document.getElementById('updatetab').addEventListener('click', function(event) {
 })
 
 document.getElementById('updatetab').addEventListener('change', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('.enableRepository')) {
     if (_target.checked) {
       document.querySelectorAll('.repositoryConfiguration' + _target.getAttribute('data-repo')).seen()
@@ -1371,7 +1371,7 @@ document.getElementById('updatetab').addEventListener('change', function(event) 
 /*Events delegations
 */
 document.getElementById('cachetab').addEventListener('click', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('#bt_cleanCache')) {
     jeedomUtils.hideAlert()
     jeeP.cleanCache()
@@ -1390,7 +1390,7 @@ document.getElementById('cachetab').addEventListener('click', function(event) {
 })
 
 document.getElementById('cachetab').addEventListener('change', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('.configKey[data-l1key="cache::engine"]')) {
     document.querySelectorAll('.cacheEngine').unseen()
     if (_target.value == '') return
@@ -1405,7 +1405,7 @@ document.getElementById('cachetab').addEventListener('change', function(event) {
 /*Events delegations
 */
 document.getElementById('apitab').addEventListener('click', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('.bt_regenerate_api')) {
     jeedomUtils.hideAlert()
     jeeDialog.confirm('{{Êtes-vous sûr de vouloir réinitialiser la clé API de}}' + ' ' + _target.getAttribute('data-plugin') + ' ?', function(result) {
@@ -1448,7 +1448,7 @@ document.getElementById('apitab').addEventListener('click', function(event) {
 /*Events delegations
 */
 document.getElementById('ostab').addEventListener('click', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('#bt_cleanFileSystemRight')) {
     jeedom.cleanFileSystemRight({
       error: function(error) {
@@ -1535,7 +1535,7 @@ document.getElementById('ostab').addEventListener('click', function(event) {
 
 /**************************--GLOBAL--***********************************/
 document.getElementById('div_pageContainer').addEventListener('click', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('#bt_saveGeneraleConfig')) {
     jeeP.saveConfig()
     return
@@ -1543,14 +1543,14 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
 })
 
 document.getElementById('div_pageContainer').addEventListener('change', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('.configKey')) {
     if (_target.isVisible()) jeeFrontEnd.modifyWithoutSave = true
     return
   }
 })
 document.getElementById('div_pageContainer').addEventListener('mousedown', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('.ispin-wrapper')) {
     jeeFrontEnd.modifyWithoutSave = true
     return

--- a/desktop/js/massedit.js
+++ b/desktop/js/massedit.js
@@ -39,12 +39,12 @@ if (!jeeFrontEnd.massedit) {
     },
     addFilter: function() {
       document.getElementById('bt_testFilter').removeClass('disabled')
-      var newFilterHtml = ''
+      let newFilterHtml = ''
       newFilterHtml += '<div class="form-group filter">'
 
       newFilterHtml += '<div class="col-md-2 col-xs-3">'
       newFilterHtml += '<select class="selectFilterKey form-control input-sm">'
-      var keys = Object.keys(jeephp2js.typePossibilities[this._filterType_])
+      const keys = Object.keys(jeephp2js.typePossibilities[this._filterType_])
       keys.forEach((key, index) => {
         newFilterHtml += '<option value="' + key + '">' + key + '</option>'
       })
@@ -66,24 +66,24 @@ if (!jeeFrontEnd.massedit) {
       newFilterHtml += '</div>'
 
       document.getElementById('filter').insertAdjacentHTML('beforeend', newFilterHtml)
-      var newFilter = document.querySelectorAll('#filter > div.filter').last()
+      const newFilter = document.querySelectorAll('#filter > div.filter').last()
       newFilter.querySelector('.selectFilterKey').triggerEvent('change')
       return newFilter
     },
     setEdit: function() {
-      var newEditHtml = ''
+      let newEditHtml = ''
       newEditHtml += '<div class="edit">'
 
       newEditHtml += '<div class="col-md-2 col-xs-3">'
       newEditHtml += '<select class="selectEditKey form-control input-sm">'
-      var keys = Object.keys(jeephp2js.typePossibilities[this._filterType_])
+      const keys = Object.keys(jeephp2js.typePossibilities[this._filterType_])
       keys.forEach((key, index) => {
         newEditHtml += '<option value="' + key + '">' + key + '</option>'
       })
       newEditHtml += '</select>'
       newEditHtml += '</div>'
 
-      var editId = 'j' + Math.random().toString(36).substr(2, 9)
+      const editId = 'j' + Math.random().toString(36).substr(2, 9)
       newEditHtml += '<div class="col-md-3 col-xs-3">'
       newEditHtml += '<input class="selectEditValue form-control input-sm" type="text" value="" list="' + editId + '_EditvaluesList" />'
       newEditHtml += '<datalist id="' + editId + '_EditvaluesList">'
@@ -102,13 +102,13 @@ if (!jeeFrontEnd.massedit) {
       document.getElementById('edit').insertAdjacentHTML('beforeend', newEditHtml)
     },
     getFilters: function() {
-      var filters = []
+      const filters = []
       document.querySelectorAll('#filter > div.filter').forEach(_filterEl => {
-        var key = _filterEl.querySelector('.selectFilterKey').value
-        var value = _filterEl.querySelector('select.selectFilterValue').selectedOptions[0].text
-        var jValue = false
+        const key = _filterEl.querySelector('.selectFilterKey').value
+        const value = _filterEl.querySelector('select.selectFilterValue').selectedOptions[0].text
+        let jValue = false
         if (!(_filterEl.querySelector('.selectFilterJValue').disabled)) {
-          var jValue = _filterEl.querySelector('select.selectFilterJValue').selectedOptions[0].text
+          let jValue = _filterEl.querySelector('select.selectFilterJValue').selectedOptions[0].text
         }
         filters.push({
           'key': key,
@@ -119,13 +119,13 @@ if (!jeeFrontEnd.massedit) {
       return filters
     },
     getEdits: function() {
-      var edits = []
+      const edits = []
       document.querySelectorAll('#edit > .edit').forEach(function(edit) {
-        var key = edit.querySelector('select.selectEditKey').value
-        var value = edit.querySelector('.selectEditValue').value
-        var jValue = false
+        const key = edit.querySelector('select.selectEditKey').value
+        const value = edit.querySelector('.selectEditValue').value
+        let jValue = false
         if (edit.querySelector('.inputEditJValue').disabled != null) {
-          var jValue = edit.querySelector('.inputEditJValue').value
+          let jValue = edit.querySelector('.inputEditJValue').value
         }
         edits.push({
           'key': key,
@@ -136,10 +136,10 @@ if (!jeeFrontEnd.massedit) {
       return edits
     },
     getTestSQLstring: function(_filters) {
-      var sqlTable = this._filterType_
-      var sqlCmd = ''
+      const sqlTable = this._filterType_
+      const sqlCmd = ''
       sqlCmd = 'SELECT id, name FROM `' + sqlTable + '`'
-      for (var i = 0; i < _filters.length; i++) {
+      for (let i = 0; i < _filters.length; i++) {
         if (i == 0) {
           sqlCmd += ' WHERE '
         } else {
@@ -154,13 +154,13 @@ if (!jeeFrontEnd.massedit) {
       return sqlCmd
     },
     getExecSQLstring: function(_filters, _edits) {
-      var sqlTable = this._filterType_
-      var sqlCmd = ''
+      const sqlTable = this._filterType_
+      const sqlCmd = ''
 
-      var condition = 'WHERE' + this.getTestSQLstring(_filters).split('WHERE')[1]
+      const condition = 'WHERE' + this.getTestSQLstring(_filters).split('WHERE')[1]
 
       //only support one edit at that time:
-      var edit = _edits[0]
+      const edit = _edits[0]
       if (edit.jValue) {
         sqlCmd = 'UPDATE `' + sqlTable + '`'
         sqlCmd += ' SET `' + edit.key + '` = JSON_REPLACE(`' + edit.key + '`, "' + "$." + edit.value + '", "' + edit.jValue + '")'
@@ -175,12 +175,12 @@ if (!jeeFrontEnd.massedit) {
       return sqlCmd
     },
     getCleaningSpaceSQLstring: function(_edits) {
-      var sqlTable = this._filterType_
-      var sqlCmd = ''
+      const sqlTable = this._filterType_
+      const sqlCmd = ''
 
-      var condition = 'WHERE id in (' + this._editIds_.join(', ') + ')'
+      const condition = 'WHERE id in (' + this._editIds_.join(', ') + ')'
 
-      var edit = _edits[0]
+      const edit = _edits[0]
       if (edit.jValue) {
         sqlCmd = 'UPDATE `' + sqlTable + '`'
         sqlCmd += ' SET `' + edit.key + '` = REPLACE(`' + edit.key + '`, ": ", ":")'
@@ -205,9 +205,9 @@ if (!jeeFrontEnd.massedit) {
         },
         success: function(result) {
           document.getElementById('testResult').empty().seen()
-          var testResEl = document.getElementById('testResult')
+          const testResEl = document.getElementById('testResult')
           if (_mode == 0) {
-            for (var i in result.sql) {
+            for (const i in result.sql) {
               testResEl.insertAdjacentHTML('beforeend', '<div class="btn btn-xs btn-primary testSqlDiv" data-id="' + result.sql[i].id + '" style="margin:3px;">' + result.sql[i].name + ' (' + result.sql[i].id + ')' + '</div>')
             }
           }
@@ -220,8 +220,8 @@ if (!jeeFrontEnd.massedit) {
       })
     },
     downloadObjectAsJson: function(exportObj, exportName) {
-      var dataStr = "data:text/json;charset=utf-8," + encodeURIComponent(JSON.stringify(exportObj))
-      var downloadAnchorNode = document.createElement('a')
+      const dataStr = "data:text/json;charset=utf-8," + encodeURIComponent(JSON.stringify(exportObj))
+      const downloadAnchorNode = document.createElement('a')
       downloadAnchorNode.setAttribute("href", dataStr)
       downloadAnchorNode.setAttribute("target", "_blank")
       downloadAnchorNode.setAttribute("download", exportName + ".json")
@@ -238,26 +238,26 @@ if (!jeeFrontEnd.massedit) {
         return false
       }
       if (_fileHdl) {
-        var readFile = new FileReader()
+        const readFile = new FileReader()
         readFile.readAsText(_fileHdl)
         readFile.onload = function(e) {
-          var massEditData = JSON.parse(e.target.result)
-          var newFilter
+          let massEditData = JSON.parse(e.target.result)
+          const newFilter
           try {
             //type:
             document.getElementById('sel_FilterByType').value = massEditData.type
             document.getElementById('sel_FilterByType').triggerEvent('change')
 
             //filters:
-            for (var idx in massEditData.filters) {
+            for (const idx in massEditData.filters) {
               newFilter = jeeP.addFilter()
               //key:
               newFilter.querySelector('.selectFilterKey').value = massEditData.filters[idx].key
               newFilter.querySelector('.selectFilterKey').triggerEvent('change')
 
               //value:
-              var select = newFilter.querySelector('.selectFilterValue')
-              var option = Array.from(select.options).filter(op => op.textContent == massEditData.filters[idx].value)[0]
+              let select = newFilter.querySelector('.selectFilterValue')
+              let option = Array.from(select.options).filter(op => op.textContent == massEditData.filters[idx].value)[0]
               select.value = option.value
               select.triggerEvent('change')
 
@@ -271,7 +271,7 @@ if (!jeeFrontEnd.massedit) {
             }
 
             //edits:
-            for (var idx in massEditData.edits) {
+            for (const idx in massEditData.edits) {
               document.querySelector('.selectEditKey').value = massEditData.edits[idx].key
               document.querySelector('.selectEditKey').triggerEvent('change')
               document.querySelector('.selectEditValue').value = massEditData.edits[idx].value
@@ -294,11 +294,11 @@ if (!jeeFrontEnd.massedit) {
       }
     },
     execMassEdit: function() {
-      var filters = jeeP.getFilters()
-      var edits = jeeP.getEdits()
+      const filters = jeeP.getFilters()
+      const edits = jeeP.getEdits()
 
       //get ids of modifying items to clean spaces in json string later.
-      var sqlCmd = jeeP.getTestSQLstring(filters)
+      const sqlCmd = jeeP.getTestSQLstring(filters)
       jeeP.dbExecuteCommand(sqlCmd, 2)
 
       //exec user edition:
@@ -326,7 +326,7 @@ jeeFrontEnd.massedit.postInit()
 /*Events delegations
 */
 document.getElementById('div_pageContainer').addEventListener('click', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('#bt_addFilter')) {
     jeeP.addFilter()
     document.getElementById('testResult').empty().unseen()
@@ -335,8 +335,8 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
   }
 
   if (_target = event.target.closest('#bt_testFilter')) {
-    var filters = jeeP.getFilters()
-    var sqlCmd = jeeP.getTestSQLstring(filters)
+    const filters = jeeP.getFilters()
+    const sqlCmd = jeeP.getTestSQLstring(filters)
     document.getElementById('testSQL').empty().append(sqlCmd)
     jeeP.dbExecuteCommand(sqlCmd, 0)
     return
@@ -355,7 +355,7 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
     event.preventDefault()
     event.stopPropagation()
     event.stopImmediatePropagation()
-    var thisId = _target.getAttribute('data-id')
+    const thisId = _target.getAttribute('data-id')
     jeedom[jeeP._filterType_]['byId']({
       id: thisId,
       error: function(error) {
@@ -368,7 +368,7 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
         if (isset(_item.result)) _item = _item.result
 
         if (jeeP._filterType_ == 'eqLogic') {
-          var url = 'index.php?v=d&p=' + _item.eqType_name + '&m=' + _item.eqType_name + '&id=' + _item.id
+          const url = 'index.php?v=d&p=' + _item.eqType_name + '&m=' + _item.eqType_name + '&id=' + _item.id
           window.open(url)
           return true
         }
@@ -381,12 +381,12 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
           return true
         }
         if (jeeP._filterType_ == 'object') {
-          var url = 'index.php?v=d&p=object&id=' + _item.id
+          const url = 'index.php?v=d&p=object&id=' + _item.id
           window.open(url)
           return true
         }
         if (jeeP._filterType_ == 'scenario') {
-          var url = 'index.php?v=d&p=scenario&id=' + _item.id
+          const url = 'index.php?v=d&p=scenario&id=' + _item.id
           window.open(url)
           return true
         }
@@ -396,9 +396,9 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
   }
 
   if (_target = event.target.closest('#bt_exportFilter')) {
-    var filters = jeeP.getFilters()
-    var edits = jeeP.getEdits()
-    var jsonData = {
+    const filters = jeeP.getFilters()
+    const edits = jeeP.getEdits()
+    const jsonData = {
       'type': jeeP._filterType_,
       'filters': filters,
       'edits': edits
@@ -414,7 +414,7 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
 })
 
 document.getElementById('div_pageContainer').addEventListener('change', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('#sel_FilterByType')) {
     jeeP.resetUI()
     jeeP._filterType_ = _target.value
@@ -424,14 +424,14 @@ document.getElementById('div_pageContainer').addEventListener('change', function
   }
 
   if (_target = event.target.closest('select.selectFilterKey')) {
-    var key = _target.value
-    var selectValues = _target.closest('div.form-group').querySelector('select.selectFilterValue')
-    var selectJValues = _target.closest('div.form-group').querySelector('select.selectFilterJValue')
+    const key = _target.value
+    const selectValues = _target.closest('div.form-group').querySelector('select.selectFilterValue')
+    const selectJValues = _target.closest('div.form-group').querySelector('select.selectFilterJValue')
     selectValues.empty()
     selectJValues.empty()
 
     //set possible values for key
-    var newOption
+    let newOption
     if (typeof jeephp2js.typePossibilities[jeeP._filterType_][key][0] != 'undefined') {
       selectJValues.disabled = true
       jeephp2js.typePossibilities[jeeP._filterType_][key].forEach(function(item, index) {
@@ -442,7 +442,7 @@ document.getElementById('div_pageContainer').addEventListener('change', function
       })
     } else {
       selectJValues.removeAttribute('disabled')
-      var values = Object.keys(jeephp2js.typePossibilities[jeeP._filterType_][key])
+      const values = Object.keys(jeephp2js.typePossibilities[jeeP._filterType_][key])
       values.forEach((value, index) => {
         newOption = document.createElement('option')
         newOption.text = value
@@ -458,18 +458,18 @@ document.getElementById('div_pageContainer').addEventListener('change', function
     document.getElementById('testSQL').empty()
     document.getElementById('testResult').empty().unseen()
 
-    var selectKey = _target.closest('div.form-group').querySelector('select.selectFilterKey')
-    var key = selectKey.value
-    var value = _target.selectedOptions[0] ? _target.selectedOptions[0].text : ''
-    var selectJValues = _target.closest('div.form-group').querySelector('select.selectFilterJValue')
+    const selectKey = _target.closest('div.form-group').querySelector('select.selectFilterKey')
+    const key = selectKey.value
+    const value = _target.selectedOptions[0] ? _target.selectedOptions[0].text : ''
+    const selectJValues = _target.closest('div.form-group').querySelector('select.selectFilterJValue')
     selectJValues.empty()
 
     //does have json value ?
     if (selectJValues.disabled) return false
 
     //set json values for filter:
-    var newOption
-    var jValues = value in jeephp2js.typePossibilities[jeeP._filterType_][key] ? Object.keys(jeephp2js.typePossibilities[jeeP._filterType_][key][value]) : []
+    let newOption
+    const jValues = value in jeephp2js.typePossibilities[jeeP._filterType_][key] ? Object.keys(jeephp2js.typePossibilities[jeeP._filterType_][key][value]) : []
     jValues.forEach((jValue, index) => {
       newOption = document.createElement('option')
       newOption.text = jeephp2js.typePossibilities[jeeP._filterType_][key][value][index]
@@ -480,22 +480,22 @@ document.getElementById('div_pageContainer').addEventListener('change', function
   }
 
   if (_target = event.target.closest('select.selectEditKey')) {
-    var value = _target.value
+    const value = _target.value
     _target.closest('div.form-group').querySelector('input.selectEditValue').value = ''
-    var editValueId = _target.closest('div.form-group').querySelector('input.selectEditValue').getAttribute('list')
-    var inputJValue = _target.closest('div.form-group').querySelector('input.inputEditJValue')
+    const editValueId = _target.closest('div.form-group').querySelector('input.selectEditValue').getAttribute('list')
+    const inputJValue = _target.closest('div.form-group').querySelector('input.inputEditJValue')
     inputJValue.value = ''
 
     //set possible values for key if necessary
-    var inputValues = _target.closest('div.form-group').querySelector('#' + editValueId)
+    const inputValues = _target.closest('div.form-group').querySelector('#' + editValueId)
     inputValues.empty()
-    var key = _target.value
-    var newOption
+    const key = _target.value
+    let newOption
     if (typeof jeephp2js.typePossibilities[jeeP._filterType_][key][0] != 'undefined') {
       inputJValue.disabled = true
     } else {
       inputJValue.removeAttribute('disabled')
-      var values = Object.keys(jeephp2js.typePossibilities[jeeP._filterType_][key])
+      const values = Object.keys(jeephp2js.typePossibilities[jeeP._filterType_][key])
       values.forEach((value, index) => {
         newOption = document.createElement('option')
         newOption.text = value
@@ -508,22 +508,22 @@ document.getElementById('div_pageContainer').addEventListener('change', function
   }
 
   if (_target = event.target.closest('select.selectEditValue')) {
-    var key = _target.closest('div.form-group').querySelector('select.selectEditKey').value
-    var value = _target.closest('div.form-group').querySelector('input.selectEditValue').value
+    const key = _target.closest('div.form-group').querySelector('select.selectEditKey').value
+    const value = _target.closest('div.form-group').querySelector('input.selectEditValue').value
     if (!isset(jeephp2js.typePossibilities[jeeP._filterType_][key][value])) {
       return false
     }
 
-    var inputJValue = _target.closest('div.form-group').querySelector('input.inputEditJValue')
+    const inputJValue = _target.closest('div.form-group').querySelector('input.inputEditJValue')
     inputJValue.value = ''
     //set possible json values for value:
-    var editJValueId = inputJValue.getAttribute('list')
-    var inputJValues = _target.closest('div.form-group').querySelector('#' + editJValueId)
+    const editJValueId = inputJValue.getAttribute('list')
+    const inputJValues = _target.closest('div.form-group').querySelector('#' + editJValueId)
     inputJValues.empty()
 
-    var jValues = jeephp2js.typePossibilities[jeeP._filterType_][key][value]
+    const jValues = jeephp2js.typePossibilities[jeeP._filterType_][key][value]
     if (!jValues || typeof jValues == 'string') return false
-    var newOption
+    let newOption
     jValues.forEach((jValue, index) => {
       newOption = document.createElement('option')
       newOption.text = jValue

--- a/desktop/js/replace.js
+++ b/desktop/js/replace.js
@@ -30,7 +30,7 @@ if (!jeeFrontEnd.replace) {
     //Filtering:
     applyFilter: function() {
       jeeP.filteredObjects = new Array()
-      var key = null
+      let key = null
       document.querySelectorAll('#objectFilter .objectFilterKey').forEach(_filter => {
         if (_filter.checked) {
           key = parseInt(_filter.getAttribute('data-key'))
@@ -38,7 +38,7 @@ if (!jeeFrontEnd.replace) {
           jeeP.filteredObjects.push(key)
         }
       })
-      var byPlugins = new Array()
+      const byPlugins = new Array()
       document.querySelectorAll('#pluginFilter .pluginFilterKey').forEach(_filter => {
         if (_filter.checked) {
           byPlugins.push(_filter.getAttribute('data-key'))
@@ -53,10 +53,10 @@ if (!jeeFrontEnd.replace) {
       })
 
       jeeP.sourcesEqContainer.empty()
-      var eqDiv = ''
-      var parentName
-      var selectReplaceEqlogics = jeeP.getEqlogicSelect(true)
-      var selectReplaceCmds
+      let eqDiv = ''
+      const parentName
+      const selectReplaceEqlogics = jeeP.getEqlogicSelect(true)
+      let selectReplaceCmds
       jeeP.filteredEqlogics.forEach(function(eqlogic) {
         parentName = jeephp2js.listObjects.filter(o => o.id == eqlogic.object_id)[0].name
         eqDiv = '<ul class="eqLogic cursor" data-id="' + eqlogic.id + '" data-name="' + eqlogic.name + '" data-parent="' + parentName + '">'
@@ -103,18 +103,18 @@ if (!jeeFrontEnd.replace) {
       jeeP.sourcesEqContainer.empty()
     },
     getHumanName: function(_eqLogicId) {
-      var parentId = jeephp2js.listEqlogics.filter(e => e.id == _eqLogicId)[0].object_id
-      var parentName = jeephp2js.listObjects.filter(o => o.id == parentId)[0].name
-      var humanName = '[' + parentName + '][' + jeephp2js.listEqlogics.filter(e => e.id == _eqLogicId)[0].name + ']'
+      const parentId = jeephp2js.listEqlogics.filter(e => e.id == _eqLogicId)[0].object_id
+      const parentName = jeephp2js.listObjects.filter(o => o.id == parentId)[0].name
+      const humanName = '[' + parentName + '][' + jeephp2js.listEqlogics.filter(e => e.id == _eqLogicId)[0].name + ']'
       return humanName
     },
     //Replacer syncyhing:
     getEqlogicSelect: function(reset=false) {
       if (!this.filteredEqlogics) return ''
 
-      var select = '<select class="selectEqReplace">'
+      let select = '<select class="selectEqReplace">'
       select += '<option value=""></option>'
-      var parentName
+      const parentName
       this.filteredObjects.forEach(function(_id) {
         select += '<optgroup label="' + jeephp2js.listObjects.filter(o => o.id == _id)[0].name + '">'
         jeeP.filteredEqlogics.filter(o => o.object_id == _id).forEach(function(eqlogic) {
@@ -138,14 +138,14 @@ if (!jeeFrontEnd.replace) {
     },
     synchEqlogicsReplacers: function() {
       //Get all selected target eqlogics:
-      var eqReplacers = document.querySelectorAll('#eqSource select.selectEqReplace')
+      const eqReplacers = document.querySelectorAll('#eqSource select.selectEqReplace')
       jeeP.replacerEqList = new Array()
       eqReplacers.forEach(_select => {
         if (_select.value != '') jeeP.replacerEqList.push(_select.value)
       })
 
       //Check each eqlogic to synch state and select:
-      var thisId
+      let thisId
       document.querySelectorAll('#eqSource ul.eqLogic').forEach( _ul => {
         thisId = _ul.getAttribute('data-id')
         if (jeeP.replacerEqList.includes(thisId)) { //Already selected as target replacement
@@ -165,11 +165,11 @@ if (!jeeFrontEnd.replace) {
     //Selection:
     selectReplacerEqlogic: function(_selectEl) {
       //get source and target eqLogics Ids:
-      var thisEq = _selectEl.closest('ul.eqLogic')
-      var sourceEqId = thisEq.getAttribute('data-id')
-      var sourceEqName = thisEq.getAttribute('data-name')
-      var targetEqId = _selectEl.value
-      var targetEqName = _selectEl.querySelector('option[value="' + targetEqId + '"]').getAttribute('data-name')
+      const thisEq = _selectEl.closest('ul.eqLogic')
+      const sourceEqId = thisEq.getAttribute('data-id')
+      const sourceEqName = thisEq.getAttribute('data-name')
+      const targetEqId = _selectEl.value
+      const targetEqName = _selectEl.querySelector('option[value="' + targetEqId + '"]').getAttribute('data-name')
 
       //open cmds ul:
       if (_selectEl.value != '' && !thisEq.querySelector('ul').isVisible()) {
@@ -206,23 +206,23 @@ if (!jeeFrontEnd.replace) {
       jeeP.synchEqlogicsReplacers()
 
       //Get over each command to set its select option with target commands list:
-      var replacerCmdsInfo = jeephp2js.listCommands.filter(o => o.eqLogic_id == targetEqId && o.type == 'info')
-      var replacerCmdsAction = jeephp2js.listCommands.filter(o => o.eqLogic_id == targetEqId && o.type == 'action')
-      var cmdsObject = jeephp2js.listCommands.filter(o => o.eqLogic_id == sourceEqId)
-      var cmds = thisEq.querySelectorAll('.cmd')
-      var cmdSelect
+      const replacerCmdsInfo = jeephp2js.listCommands.filter(o => o.eqLogic_id == targetEqId && o.type == 'info')
+      const replacerCmdsAction = jeephp2js.listCommands.filter(o => o.eqLogic_id == targetEqId && o.type == 'action')
+      const cmdsObject = jeephp2js.listCommands.filter(o => o.eqLogic_id == sourceEqId)
+      const cmds = thisEq.querySelectorAll('.cmd')
+      let cmdSelect
       cmds.forEach( _cmd => {
-        var type = _cmd.getAttribute('data-type')
+        const type = _cmd.getAttribute('data-type')
         if (type == 'info') {
-          var optionsCmds = replacerCmdsInfo
+          let optionsCmds = replacerCmdsInfo
         } else {
-          var optionsCmds = replacerCmdsAction
+          let optionsCmds = replacerCmdsAction
         }
 
         cmdSelect = _cmd.querySelector('select')
         cmdSelect.empty()
-        var options = '<option value=""></option>'
-        var _cmd = jeephp2js.listCommands.filter(o => o.id == _cmd.getAttribute('data-id'))[0]
+        let options = '<option value=""></option>'
+        let _cmd = jeephp2js.listCommands.filter(o => o.id == _cmd.getAttribute('data-id'))[0]
         optionsCmds.forEach(function(optionsCmd) {
           if (_cmd.name.toLowerCase().trim() == optionsCmd.name.toLowerCase().trim() && _cmd.type == optionsCmd.type) {
             options += '<option selected value="' + optionsCmd.id + '">' + optionsCmd.name + '</option>'
@@ -235,24 +235,24 @@ if (!jeeFrontEnd.replace) {
     },
     //Get job done!
     doReplace: async function() {
-      var opt_mode = document.getElementById('opt_mode').value
-      var opt_copyEqProperties = document.getElementById('opt_copyEqProperties').checked
-      var opt_hideEqs = document.getElementById('opt_hideEqs').checked
-      var opt_disableEqs = document.getElementById('opt_disableEqs').checked
-      var opt_copyCmdProperties = document.getElementById('opt_copyCmdProperties').checked
-      var opt_removeHistory = document.getElementById('opt_removeHistory').checked
-      var opt_copyHistory = document.getElementById('opt_copyHistory').checked
+      const opt_mode = document.getElementById('opt_mode').value
+      const opt_copyEqProperties = document.getElementById('opt_copyEqProperties').checked
+      const opt_hideEqs = document.getElementById('opt_hideEqs').checked
+      const opt_disableEqs = document.getElementById('opt_disableEqs').checked
+      const opt_copyCmdProperties = document.getElementById('opt_copyCmdProperties').checked
+      const opt_removeHistory = document.getElementById('opt_removeHistory').checked
+      const opt_copyHistory = document.getElementById('opt_copyHistory').checked
 
       //Used for check and later parts sent:
-      var replaceEqs = {}
-      var replaceCmds = {}
+      let replaceEqs = {}
+      let replaceCmds = {}
       //Get all eqs and their cmds to send eq one by one:
-      var replace = {}
+      const replace = {}
 
       document.querySelectorAll('#eqSource ul.eqLogic').forEach(_eglogic => {
         if (_eglogic.querySelector('input.cb_selEqLogic').checked) {
-          var sourceEqId = _eglogic.getAttribute('data-id')
-          var targetEqId = _eglogic.querySelector(':scope > div.replacer select').value
+          const sourceEqId = _eglogic.getAttribute('data-id')
+          const targetEqId = _eglogic.querySelector(':scope > div.replacer select').value
 
           if (targetEqId != '') {
             replaceEqs[sourceEqId] = targetEqId
@@ -263,8 +263,8 @@ if (!jeeFrontEnd.replace) {
             }
 
             _eglogic.querySelectorAll('li.cmd').forEach(_cmd => {
-              var cmdId = _cmd.getAttribute('data-id')
-              var replaceId = _cmd.querySelector('select').value
+              const cmdId = _cmd.getAttribute('data-id')
+              const replaceId = _cmd.querySelector('select').value
               if (replaceId != '') {
                 replaceCmds[cmdId] = replaceId
 
@@ -294,8 +294,8 @@ if (!jeeFrontEnd.replace) {
         return true
       }
 
-      var requestLength = Object.keys(replaceEqs).length
-      var requestDone = 0
+      const requestLength = Object.keys(replaceEqs).length
+      let requestDone = 0
       document.getElementById('progressbar').style.width = '0.5%'
       document.getElementById('progresscontainer').removeClass('hidden').scrollIntoView(false)
 
@@ -304,10 +304,10 @@ if (!jeeFrontEnd.replace) {
         replaceCmds = replace[sourceEqId].cmds
 
         //UI:
-        var text = '  ' + jeeP.getHumanName(sourceEqId) + ' -> ' + jeeP.getHumanName(replace[sourceEqId].target) + '...';
+        const text = '  ' + jeeP.getHumanName(sourceEqId) + ' -> ' + jeeP.getHumanName(replace[sourceEqId].target) + '...';
         document.getElementById('progresslog').textContent = text
 
-        var promise = new Promise((resolve, reject) => {
+        const promise = new Promise((resolve, reject) => {
           jeedom.massReplace({
             global: false,
             options: {
@@ -333,7 +333,7 @@ if (!jeeFrontEnd.replace) {
             }
           })
         })
-        var result = await promise
+        const result = await promise
       }
 
       jeedomUtils.showAlert({
@@ -353,8 +353,8 @@ jeeFrontEnd.replace.init()
 //searching:
 document.getElementById('in_searchByName')?.addEventListener('keyup', function(event) {
   try {
-    var search = event.target.value
-    var searchID = search
+    let search = event.target.value
+    let searchID = search
     if (isNaN(search)) searchID = false
 
     if (search == '') {
@@ -363,7 +363,7 @@ document.getElementById('in_searchByName')?.addEventListener('keyup', function(e
     }
 
     search = jeedomUtils.normTextLower(search)
-    var eqLogic, eqName, eqParent, eqId
+    let eqLogic, eqName, eqParent, eqId
     jeeP.sourcesEqContainer.querySelectorAll('ul.eqLogic').forEach(eqLogic => {
       eqParent = jeedomUtils.normTextLower(eqLogic.getAttribute('data-parent'))
       if (searchID) {
@@ -408,7 +408,7 @@ document.getElementById('bt_replace').addEventListener('click', function(event) 
 */
 //Filters
 document.getElementById('accordionFilter').addEventListener('click', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('#bt_applyFilters')) {
     jeeP.applyFilter()
     return
@@ -458,7 +458,7 @@ document.getElementById('accordionFilter').addEventListener('click', function(ev
 })
 
 document.getElementById('accordionFilter').addEventListener('mouseup', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('input.objectFilterKey')) {
     event.preventDefault()
     event.stopPropagation()
@@ -485,7 +485,7 @@ document.getElementById('accordionFilter').addEventListener('mouseup', function(
 })
 
 document.getElementById('accordionFilter').addEventListener('mousedown', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('#objectFilter li a')) {
     event.preventDefault()
     let checkbox = _target.querySelector('input.objectFilterKey')
@@ -523,9 +523,9 @@ document.getElementById('accordionFilter').addEventListener('mousedown', functio
 
 //Replacement:
 document.getElementById('eqSource').addEventListener('click', function(event) {
-  var _target = null
+  let _target = null
   if ((_target = event.target.matches('ul.eqLogic')) || (_target = event.target.matches('.eqName'))) {
-    var el = event.target.closest('ul.eqLogic').querySelector('ul')
+    const el = event.target.closest('ul.eqLogic').querySelector('ul')
     if (el.isVisible()) {
       el.unseen()
     } else {
@@ -536,7 +536,7 @@ document.getElementById('eqSource').addEventListener('click', function(event) {
 })
 
 document.getElementById('eqSource').addEventListener('change', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('select.selectEqReplace')) {
     if(_target.closest('select.selectEqReplace').value == ''){
      	return; 

--- a/desktop/js/update.js
+++ b/desktop/js/update.js
@@ -72,9 +72,9 @@ if (!jeeFrontEnd.update) {
             }, 1000)
             return
           }
-          var log = ''
+          let log = ''
           if (Array.isArray(data.result)) {
-            for (var i in data.result.reverse()) {
+            for (const i in data.result.reverse()) {
               log += data.result[i] + "\n"
               //Update end success:
               if (data.result[i].indexOf('[END ' + _log.toUpperCase() + ' SUCCESS]') != -1) {
@@ -130,14 +130,14 @@ if (!jeeFrontEnd.update) {
           tbody.empty()
           if (isset(jeeFrontEnd.update.updtDataTable)) jeeFrontEnd.update.updtDataTable.refresh()
 
-          var tr_updates = []
-          for (var i in data) {
+          const tr_updates = []
+          for (const i in data) {
             if (!isset(data[i].status)) continue
             if (data[i].type == 'core' || data[i].type == 'plugin') {
               tr_updates.push(jeeP.addUpdate(data[i]))
             }
           }
-          for (var tr of tr_updates) {
+          for (const tr of tr_updates) {
             tbody.appendChild(tr)
           }
           jeedomUtils.initTooltips(tbody)
@@ -193,7 +193,7 @@ if (!jeeFrontEnd.update) {
         _update.status = 'OK'
       }
       _update.status = _update.status.toUpperCase()
-      var labelClass = 'label-success'
+      let labelClass = 'label-success'
       if (_update.status == 'UPDATE') {
         labelClass = 'label-warning'
         if (_update.type == 'core' || _update.type == 'plugin') {
@@ -201,14 +201,14 @@ if (!jeeFrontEnd.update) {
         }
       }
 
-      var tr = '<tr>'
+      let tr = '<tr>'
       tr += '<td style="width:40px"><span class="updateAttr label ' + labelClass + '" data-l1key="status"></span></td>'
       tr += '<td>'
       tr += '<span class="hidden-1280"><span class="updateAttr" data-l1key="source"></span> / <span class="updateAttr" data-l1key="type"></span> : </span>'
       if (_update.name == 'jeedom') {
         tr += '<span class="updateAttr label label-info text-capitalize" data-l1key="name"></span>'
         if (_update.branch) {
-          var updClass
+          let updClass
           switch (_update.branch.toLowerCase()) {
             case 'alpha':
               updClass = 'label-danger'
@@ -225,7 +225,7 @@ if (!jeeFrontEnd.update) {
       else {
         tr += '<span class="label label-info"><span class="updateAttr text-capitalize" data-l1key="plugin" data-l2key="name"></span> (<span class="updateAttr" data-l1key="name"></span>)</span>'
         if (_update.configuration && _update.configuration.version) {
-          var updClass
+          let updClass
           switch (_update.configuration.version.toLowerCase()) {
             case 'stable':
             case 'master':
@@ -379,20 +379,20 @@ if (!jeeFrontEnd.update) {
         subtree: true
       }
 
-      var targetNode = document.getElementById('pre_updateInfo')
+      const targetNode = document.getElementById('pre_updateInfo')
       if (targetNode) this._UpdateObserver_.observe(targetNode, this.observerConfig)
     },
     cleanUpdateLog: function() {
-      var currentUpdateText = document.getElementById('pre_updateInfo').innerHTML
+      const currentUpdateText = document.getElementById('pre_updateInfo').innerHTML
       if (currentUpdateText == '') return false
       if (this.prevUpdateText == currentUpdateText) return false
-      var lines = currentUpdateText.split("\n")
-      var l = lines.length
+      const lines = currentUpdateText.split("\n")
+      const l = lines.length
 
       //update progress bar and clean text!
-      var linesRev = lines.slice().reverse()
-      for (var i = 0; i < l; i++) {
-        var regExpResult = this.regExLogProgress.exec(linesRev[i])
+      const linesRev = lines.slice().reverse()
+      for (let i = 0; i < l; i++) {
+        const regExpResult = this.regExLogProgress.exec(linesRev[i])
         if (regExpResult !== null) {
           jeeP.progress = regExpResult[1]
           jeeP.updateProgressBar()
@@ -400,15 +400,15 @@ if (!jeeFrontEnd.update) {
         }
       }
 
-      var newLogText = ''
-      for (var i = 0; i < l; i++) {
-        var line = lines[i]
+      let newLogText = ''
+      for (let i = 0; i < l; i++) {
+        let line = lines[i]
         if (line == '') continue
         if (line.startsWith('[PROGRESS]')) line = ''
 
         //check ok at end of line:
         if (line.endsWith('OK')) {
-          var matches = line.match(/[. ]{1,}OK/g)
+          let matches = line.match(/[. ]{1,}OK/g)
           if (matches) {
             line = line.replace(matches[0], '')
             line += ' | OK'
@@ -427,12 +427,12 @@ if (!jeeFrontEnd.update) {
         line = line.trim()
 
         //check ok on next line, escaping progress inbetween:
-        var offset = 1
+        let offset = 1
         if (lines[i + 1].startsWith('[PROGRESS]')) {
-          var offset = 2
+          let offset = 2
         }
-        var nextLine = lines[i + offset]
-        var letters = /^[0-9a-zA-Z]+$/
+        let nextLine = lines[i + offset]
+        const letters = /^[0-9a-zA-Z]+$/
         if (!nextLine.replace('OK', '').match(letters)) {
           matches = nextLine.match(/[.]{2,}/g)
           if (matches) {
@@ -477,22 +477,22 @@ if (!jeeFrontEnd.update) {
         success: function(data) {
           document.querySelectorAll('#os .bt_OsPackageUpdate').addClass('disabled')
 
-          var osTable = document.getElementById('table_osUpdate')
+          const osTable = document.getElementById('table_osUpdate')
           osTable.tBodies[0].empty()
 
-          var tr_updates = []
-          for (var type of Object.keys(data)) { //apt pip2 pip3
-            var OSPackages = Object.keys(data[type])
+          const tr_updates = []
+          for (const type of Object.keys(data)) { //apt pip2 pip3
+            const OSPackages = Object.keys(data[type])
             if (OSPackages.length > 0) {
               document.querySelector('#os .bt_OsPackageUpdate[data-type="' + type + '"]').removeClass('disabled')
-              for (var OSPackage of OSPackages) {
+              for (const OSPackage of OSPackages) {
                 tr_updates.push(jeeFrontEnd.update.addOsUpdate(data[type][OSPackage]))
               }
             }
 
           }
 
-          for (var tr of tr_updates) {
+          for (const tr of tr_updates) {
             osTable.tBodies[0].appendChild(tr)
           }
 
@@ -511,7 +511,7 @@ if (!jeeFrontEnd.update) {
       })
     },
     addOsUpdate: function(_update) {
-      var tr = '<tr>'
+      let tr = '<tr>'
       tr += '<td>'
       tr += '<span class="osUpdateAttr" data-l1key="type"></span>'
       tr += '</td>'
@@ -537,9 +537,9 @@ if (!jeeFrontEnd.update) {
         height: window.innerHeight > 500 ? 440 : window.innerHeight - 80,
         top: window.innerHeight > 500 ? 120 : 0,
         callback: function() {
-          var contentEl = jeeDialog.get('#md_update', 'content')
+          const contentEl = jeeDialog.get('#md_update', 'content')
           if (contentEl.querySelector('#md_specifyUpdate') == null) {
-            var newContent = document.getElementById('md_specifyUpdate-template').cloneNode(true)
+            const newContent = document.getElementById('md_specifyUpdate-template').cloneNode(true)
             newContent.setAttribute('id', 'md_specifyUpdate')
             contentEl.appendChild(newContent)
             newContent.querySelectorAll('[data-title]').forEach(_tooltip => {
@@ -571,7 +571,7 @@ if (!jeeFrontEnd.update) {
             className: 'success',
             callback: {
               click: function(event) {
-                var options = document.getElementById('md_specifyUpdate').getJeeValues('.updateOption')[0]
+                const options = document.getElementById('md_specifyUpdate').getJeeValues('.updateOption')[0]
                 jeedomUtils.hideAlert()
                 jeeDialog.get('#md_update').hide()
                 jeeP.progress = 0
@@ -616,7 +616,7 @@ if (jeephp2js.isUpdating == '1') {
 /*Events delegations
 */
 document.getElementById('div_pageContainer').addEventListener('click', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('#bt_checkAllUpdate')) {
     if (!document.querySelector('a[data-target="#coreplugin"]').hasClass('active')) document.querySelector('a[data-target="#coreplugin"]').click()
     jeeP.checkAllUpdate()
@@ -641,8 +641,8 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
 
   if (_target = event.target.closest('#table_update .update')) {
     if (_target.hasClass('disabled')) return;
-    var id = _target.closest('tr').getAttribute('data-id');
-    var logicalId = _target.closest('tr').getAttribute('data-logicalid');
+    const id = _target.closest('tr').getAttribute('data-id');
+    const logicalId = _target.closest('tr').getAttribute('data-logicalid');
 
     jeedom.plugin.get({
         id: logicalId,
@@ -653,8 +653,8 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
             });
         },
         success: function(data) {
-            var isActivated = (data.activate !== undefined && data.activate !== null) ? data.activate : 1;
-            var confirmationMessage = '{{Êtes-vous sûr de vouloir mettre à jour le plugin :}} ' + logicalId + ' ?';
+            const isActivated = (data.activate !== undefined && data.activate !== null) ? data.activate : 1;
+            let confirmationMessage = '{{Êtes-vous sûr de vouloir mettre à jour le plugin :}} ' + logicalId + ' ?';
             if (isActivated != 1) {
                 confirmationMessage = '{{Attention : Le plugin ' + logicalId + ' n\'est pas activé. Êtes-vous sûr de vouloir le mettre à jour ?}}';
             }
@@ -686,8 +686,8 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
 }
 
   if (_target = event.target.closest('#table_update .remove')) {
-    var id = _target.closest('tr').getAttribute('data-id')
-    var logicalId = _target.closest('tr').getAttribute('data-logicalid')
+    const id = _target.closest('tr').getAttribute('data-id')
+    const logicalId = _target.closest('tr').getAttribute('data-logicalid')
     jeeDialog.confirm('{{Êtes-vous sûr de vouloir supprimer :}}' + ' ' + logicalId + ' ?', function(result) {
       if (result) {
         jeedomUtils.hideAlert()
@@ -709,7 +709,7 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
   }
 
   if (_target = event.target.closest('#table_update .checkUpdate')) {
-    var id = _target.closest('tr').getAttribute('data-id')
+    const id = _target.closest('tr').getAttribute('data-id')
     jeedomUtils.hideAlert()
     jeedom.update.check({
       id: id,

--- a/desktop/js/user.js
+++ b/desktop/js/user.js
@@ -63,10 +63,10 @@ if (!jeeFrontEnd.user) {
           })
         },
         success: function(data) {
-          var table = document.getElementById('table_user')
+          const table = document.getElementById('table_user')
           table.tBodies[0].empty()
-          var disable, userTR, node
-          for (var i in data) {
+          let disable, userTR, node
+          for (const i in data) {
             let newRow = table.tBodies[0].insertRow(i)
             disable = ''
             if (data[i].login == 'internal_report' || data[i].login == 'jeedom_support') {
@@ -176,7 +176,7 @@ if (!jeeFrontEnd.user) {
       })
     },
     saveUsers: function() {
-      var users = document.getElementById('table_user').querySelectorAll('tbody tr').getJeeValues('.userAttr')
+      const users = document.getElementById('table_user').querySelectorAll('tbody tr').getJeeValues('.userAttr')
       if (!jeeP.checkUsersLogins(users)) return
       jeedom.user.save({
         users: users,
@@ -233,7 +233,7 @@ function handleSupportAccess(enable) {
 */
 //div_administration
 document.getElementById('div_administration').addEventListener('click', function(event) {
-  var _target = null
+  let _target = null
   if (event.target.matches('.userAttr')) {
     jeeFrontEnd.modifyWithoutSave = true
   }
@@ -248,7 +248,7 @@ document.getElementById('div_administration').addEventListener('click', function
       inputType: false,
       callback: function(result) {
         if (result) {
-          var user = [{
+          const user = [{
             login: result.newUserLogin,
             password: result.newUserMdp
           }]
@@ -281,7 +281,7 @@ document.getElementById('div_administration').addEventListener('click', function
   }
 
   if (_target = event.target.closest('#bt_supportAccess')) {
-    var enable = _target.getAttribute('data-enable');
+    const enable = _target.getAttribute('data-enable');
     if (enable == '1') {
         bootbox.confirm({
             message: "{{En activant l\'accès support, vous autorisez un technicien du support Jeedom à accéder à votre installation. Continuez ?}}",
@@ -309,10 +309,10 @@ document.getElementById('div_administration').addEventListener('click', function
 
   if (_target = event.target.closest('#table_user .bt_del_user')) {
     jeedomUtils.hideAlert();
-    var user = {
+    const user = {
       id: _target.closest('tr').querySelector('.userAttr[data-l1key="id"]').innerHTML
     }
-    var userName = _target.closest('tr').querySelector('input[data-l1key="login"]').value
+    const userName = _target.closest('tr').querySelector('input[data-l1key="login"]').value
     jeeDialog.confirm('{{Vous allez supprimer l\'utilisateur :}}' + ' ' + userName, function(result) {
       if (result) {
         jeedom.user.remove({
@@ -338,7 +338,7 @@ document.getElementById('div_administration').addEventListener('click', function
 
   if (_target = event.target.closest('#table_user .bt_change_mdp_user')) {
     jeedomUtils.hideAlert()
-    var user = {
+    const user = {
       id: _target.closest('tr').querySelector('.userAttr[data-l1key="id"]').innerHTML,
       login: _target.closest('tr').querySelector('input[data-l1key="login"]').value
     }
@@ -369,7 +369,7 @@ document.getElementById('div_administration').addEventListener('click', function
 
   if (_target = event.target.closest('#table_user .bt_changeHash')) {
     jeedomUtils.hideAlert()
-    var user = {
+    const user = {
       id: _target.closest('tr').querySelector('.userAttr[data-l1key="id"]').innerHTML
     }
     jeeDialog.confirm("{{Êtes-vous sûr de vouloir changer la clef API de l\'utilisateur ?}}", function(result) {
@@ -487,7 +487,7 @@ document.getElementById('div_administration').addEventListener('click', function
 })
 
 document.getElementById('div_administration').addEventListener('change', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('select[data-l1key="profils"]')) {
     if (_target.value != 'restrict') {
       _target.closest('tr').querySelector('a.bt_manage_restrict_rights')?.addClass('disabled')
@@ -510,9 +510,9 @@ document.getElementById('div_administration').addEventListener('change', functio
 
 //tableSessions
 document.getElementById('tableSessions').addEventListener('click', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('.bt_deleteSession')) {
-    var id = _target.closest('tr').getAttribute('data-id')
+    const id = _target.closest('tr').getAttribute('data-id')
     jeeFrontEnd.user.deleteSession(_target.closest('tr').getAttribute('data-id'))
     return
   }
@@ -520,7 +520,7 @@ document.getElementById('tableSessions').addEventListener('click', function(even
 
 //div_Devices
 document.getElementById('div_Devices').addEventListener('click', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('#bt_removeAllRegisterDevice')) {
     jeedom.user.removeRegisterDevice({
       error: function(error) {
@@ -538,8 +538,8 @@ document.getElementById('div_Devices').addEventListener('click', function(event)
   }
 
   if (_target = event.target.closest('.bt_removeRegisterDevice')) {
-    var key = event.target.closest('tr').getAttribute('data-key')
-    var user_id = event.target.closest('tr').getAttribute('data-user_id')
+    const key = event.target.closest('tr').getAttribute('data-key')
+    const user_id = event.target.closest('tr').getAttribute('data-user_id')
     jeeFrontEnd.user.removeRegisterDevice(key, user_id)
     return
   }


### PR DESCRIPTION
## Summary

Replace `var` with `const`/`let` in administration and editing desktop/js modules.

**Modules:** administration, update, user, massedit, replace

### Changes
- All `var` declarations → `const` (not reassigned) or `let` (reassigned)
- `for (var x in/of ...)` → `for (const x in/of ...)`
- `for (var i = 0; ...)` → `for (let i = 0; ...)`

**No functional changes.** Bug fixes for these files are tracked separately in #3318 (Lot 1) and #3319 (Lot 2).

## Type of change
- [x] Refactor (no functional change)
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Suggested changelog entry
```
- refactor(desktop/js): replace var with const/let in admin and editing modules (administration, update, user, massedit, replace)
```

## Test plan
- Open Administration page, confirm config search works
- Open Update page, confirm update list loads and log refresh works
- Open User management page, confirm user list and edit work
- Open Mass Edit page, confirm filter/edit actions work
- Open Replace page, confirm equipment search (by name and id) works correctly

## Known risks
- Minimal: block scoping verified, no hoisting dependencies found