### PR TITLE
fix(desktop/js): correct logic bugs in scenario undo stack, massedit jValue guard, user event handler (Lot 3)

### DIFF
--- a/desktop/js/massedit.js
+++ b/desktop/js/massedit.js
@@ -124,7 +124,7 @@ if (!jeeFrontEnd.massedit) {
         var key = edit.querySelector('select.selectEditKey').value
         var value = edit.querySelector('.selectEditValue').value
         var jValue = false
-        if (edit.querySelector('.inputEditJValue').disabled != null) {
+        if (!edit.querySelector('.inputEditJValue').disabled) {
           var jValue = edit.querySelector('.inputEditJValue').value
         }
         edits.push({

--- a/desktop/js/scenario.js
+++ b/desktop/js/scenario.js
@@ -1322,7 +1322,7 @@ if (!jeeFrontEnd.scenario) {
         newStack.push(jeeP.getElement(_exp.querySelector('div.element')))
       })
 
-      if (newStack == this.undoStack[state - 1]) return
+      if (JSON.stringify(newStack) === JSON.stringify(this.undoStack[state - 1])) return
       if (state == 0) {
         state = this.undoState = this.undoStack.length
         this.reDo = 0

--- a/desktop/js/user.js
+++ b/desktop/js/user.js
@@ -304,7 +304,8 @@ document.getElementById('div_administration').addEventListener('click', function
     } else {
         handleSupportAccess(enable);
     }
-}
+    return
+  }
 
 
   if (_target = event.target.closest('#table_user .bt_del_user')) {


### PR DESCRIPTION
Re-submission of #3324 targeting `develop` as requested.

## Changes

### scenario.js — undo stack dedup never fires
```js
// Before: array reference comparison always false between two distinct arrays
if (newStack == this.undoStack[state - 1]) return
// After:
if (JSON.stringify(newStack) === JSON.stringify(this.undoStack[state - 1])) return
```
The guard never triggered, causing unbounded undo stack growth on every change.

### massedit.js — jValue always captured regardless of disabled state
```js
// Before: .disabled is a boolean — != null is always true
if (edit.querySelector(".inputEditJValue").disabled != null)
// After:
if (!edit.querySelector(".inputEditJValue").disabled)
```
jValue was sent even when its input was disabled (not applicable).

### user.js — event handler falls through after #bt_supportAccess
Missing `return` caused the delegated click handler to continue evaluating subsequent conditions (e.g. `#table_user .bt_del_user`) after handling the support access button.