### PR TITLE
fix(desktop/js): null guards for dynamic querySelector and missing returns in event handlers (Lot 4)

### DIFF
--- a/desktop/js/administration.js
+++ b/desktop/js/administration.js
@@ -523,7 +523,9 @@ document.getElementById('in_searchConfig').addEventListener('keyup', function(ev
       if (tabId == undefined) return
       //Create new tablink ?
       if (!tabsArr.includes(tabId)) {
-        tabName = document.querySelector('a[data-target="#' + tabId + '"]').innerHTML
+        const _tabEl = document.querySelector('a[data-target="#' + tabId + '"]')
+        if (!_tabEl) return
+        tabName = _tabEl.innerHTML
         if (tabName != null) {
           var newTabLink = document.createElement('div')
           newTabLink.innerHTML = '<a role="searchTabLink" data-target="#' + tabId + '">' + tabName + '</a>'

--- a/desktop/js/backup.js
+++ b/desktop/js/backup.js
@@ -170,9 +170,11 @@ if (!jeeFrontEnd.backup) {
               options += '<option value="' + data[i] + '">' + data[i] + '</option>'
             }
           } else {
-            document.querySelector('.bt_restoreRepoBackup[data-repo="' + _repo + '"]').addClass('disabled')
+            const _btEl = document.querySelector('.bt_restoreRepoBackup[data-repo="' + _repo + '"]')
+            if (_btEl) _btEl.addClass('disabled')
           }
-          document.querySelector('.sel_restoreCloudBackup[data-repo="' + _repo + '"]').innerHTML = options
+          const _selEl = document.querySelector('.sel_restoreCloudBackup[data-repo="' + _repo + '"]')
+          if (_selEl) _selEl.innerHTML = options
         }
       })
     },

--- a/desktop/js/object.js
+++ b/desktop/js/object.js
@@ -847,7 +847,7 @@ document.getElementById('div_conf').addEventListener('click', function(event) {
           success: function() {
             jeeFrontEnd.modifyWithoutSave = false
             document.getElementById('bt_gotoDashboard').querySelectorAll(':scope li a').forEach(_link => {
-              if (_link.href.includes(removeId)) _link.parentNode.remove()
+              if (_link.href.includes(id)) _link.parentNode.remove()
             })
             jeedomUtils.loadPage('index.php?v=d&p=object&removeSuccessFull=1')
           }

--- a/desktop/js/overview.js
+++ b/desktop/js/overview.js
@@ -55,7 +55,9 @@ if (!jeeFrontEnd.overview) {
     },
     updateSummary: function(_className) {
       _className = _className.replace('objectSummaryContainer ', '')
-      var parent = document.querySelector('.' + _className).closest('.objectPreview')
+      const _classEl = document.querySelector('.' + _className)
+      if (!_classEl) return
+      var parent = _classEl.closest('.objectPreview')
       if (parent == null) return
       parent.querySelector('.topPreview')?.querySelectorAll('.objectSummaryParent')?.remove()
       var pResume = parent.querySelector('.resume')

--- a/desktop/js/replace.js
+++ b/desktop/js/replace.js
@@ -129,7 +129,8 @@ if (!jeeFrontEnd.replace) {
       return select
     },
     resetEqlogicSelect: function(eqlogicId=-1) {
-      document.querySelector('#eqSource ul.eqLogic[data-id="' + eqlogicId + '"] select.selectEqReplace').jeeValue('')
+      const _selEl = document.querySelector('#eqSource ul.eqLogic[data-id="' + eqlogicId + '"] select.selectEqReplace')
+      if (_selEl) _selEl.jeeValue('')
     },
     resetCmdSelects: function(eqlogicId=-1) {
       document.querySelectorAll('#eqSource ul.eqLogic[data-id="' + eqlogicId + '"] li.cmd').forEach( _cmd => {

--- a/desktop/js/scenario.js
+++ b/desktop/js/scenario.js
@@ -2062,6 +2062,7 @@ document.getElementById('generaltab').addEventListener('click', function(event) 
       document.getElementById('scenarioThumbnailDisplay').unseen()
       jeeP.printScenario(_target.getAttribute('data-scenario_id'))
     }
+    return
   }
 
   if (_target = event.target.closest('.action_link')) {
@@ -2215,10 +2216,12 @@ document.getElementById('scenariotab').addEventListener('click', function(event)
 
   if (_target = event.target.closest('#bt_cancelElementSave')) {
     jeeDialog.modal(document.getElementById('md_addElement'))._jeeDialog.hide()
+    return
   }
 
   if (_target = event.target.closest('#bt_crossElementSave')) {
     jeeDialog.modal(document.getElementById('md_addElement'))._jeeDialog.hide()
+    return
   }
 
   if (_target = event.target.closest('input:not([type="checkbox"]).expressionAttr, textarea.expressionAttr')) { //ctrl-click input popup

--- a/desktop/js/types.js
+++ b/desktop/js/types.js
@@ -253,12 +253,16 @@ if (!jeeFrontEnd.types) {
       var eqName, cmdName, thisCmd, thisClass, select
       for (var _id in queryEqIds) {
         inner += '<div class="queryEq" data-id="' + _id + '">'
-        eqName = document.querySelector('li.eqLogic[data-id="' + _id + '"]').getAttribute('data-name')
+        const _eqEl = document.querySelector('li.eqLogic[data-id="' + _id + '"]')
+        if (!_eqEl) continue
+        eqName = _eqEl.getAttribute('data-name')
         inner += '<div class="center biggerText">' + eqName + '</div>'
         for (var _cmd in queryEqIds[_id].cmds) {
           thisCmd = queryEqIds[_id].cmds[_cmd]
           // console.log(thisCmd)
-          cmdName = document.querySelector('li.cmd[data-id="' + thisCmd.id + '"]').getAttribute('data-name')
+          const _cmdEl = document.querySelector('li.cmd[data-id="' + thisCmd.id + '"]')
+          if (!_cmdEl) continue
+          cmdName = _cmdEl.getAttribute('data-name')
           thisClass = thisCmd.type == 'info' ? 'alert-info' : 'alert-warning'
 
           inner += '<div class="form-group queryCmd" data-id="' + thisCmd.id + '">'
@@ -486,16 +490,18 @@ new jeeCtxMenu({
 
     return {
       callback: function(key, options) {
+        const _cmdEl = document.querySelector('li.cmd[data-id="' + cmdId + '"]')
+        if (!_cmdEl) return
         if (options.commands[key].id == 'delete_me') {
-          document.querySelector('li.cmd[data-id="' + cmdId + '"] .genericType').textContent = 'None'
-          document.querySelector('li.cmd[data-id="' + cmdId + '"]').setAttribute('data-generic', '')
+          _cmdEl.querySelector('.genericType').textContent = 'None'
+          _cmdEl.setAttribute('data-generic', '')
         } else {
           //var text = options.commands[key].id.split('::')[0] + jeephp2js.typeStringSep + options.commands[key].node.innerText
           var text = options.commands[key].id.split('::')[0] + jeephp2js.typeStringSep + options.commands[key].name
-          document.querySelector('li.cmd[data-id="' + cmdId + '"] .genericType').textContent = text
-          document.querySelector('li.cmd[data-id="' + cmdId + '"]').setAttribute('data-generic', options.commands[key].id.split('::')[1])
+          _cmdEl.querySelector('.genericType').textContent = text
+          _cmdEl.setAttribute('data-generic', options.commands[key].id.split('::')[1])
         }
-        document.querySelector('li.cmd[data-id="' + cmdId + '"]').setAttribute('data-changed', '1')
+        _cmdEl.setAttribute('data-changed', '1')
         jeeFrontEnd.modifyWithoutSave = true
       },
       items: contextmenuitems

--- a/desktop/js/view.js
+++ b/desktop/js/view.js
@@ -292,7 +292,8 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
   }
 
   if (_target = event.target.closest('.bt_gotoViewZone')) {
-    document.querySelector('.lg_viewZone[data-zone_id="' + _target.getAttribute('data-zone_id') + '"]').scrollIntoView()
+    const _zoneEl = document.querySelector('.lg_viewZone[data-zone_id="' + _target.getAttribute('data-zone_id') + '"]')
+    if (_zoneEl) _zoneEl.scrollIntoView()
     return
   }
 


### PR DESCRIPTION
Re-submission of #3325 targeting `develop` as requested.

## Changes

### object.js — wrong variable name in dashboard cleanup
`removeId` is undefined in the success callback; correct variable is `id`. Dashboard menu links were never cleaned after deleting an object.

### overview.js — querySelector before .closest() without null guard
`updateSummary` called from MutationObserver — the className may not yet be in the DOM.

### types.js — querySelector without null guard (×7)
- Generic type modal: `eqLogic[data-id]` and `cmd[data-id]` lookups can return null. Added `if (!el) continue`.
- Context menu callback: all 5 accesses replaced with single lookup + early `if (!cmdEl) return`.

### scenario.js — missing return in 3 event handlers
- `.scenario_link`: fell through to `.action_link`, opening a command config dialog.
- `#bt_cancelElementSave` / `#bt_crossElementSave`: fell through to `expressionAttr` ctrl-click handler.

### backup.js — querySelector on dynamic repo name
Both selectors use an API value that may have no matching DOM element.

### replace.js — querySelector on dynamic eqlogicId
`resetEqlogicSelect` parameter may not match any rendered row.

### view.js — querySelector before scrollIntoView
`data-zone_id` zone may not be rendered in current view.

### administration.js — querySelector before .innerHTML in search
Tab anchor lookup can return null. Existing `if (tabName != null)` ran after the crash.