### PR TITLE
fix(jeedom.class.js): guard catch blocks against undefined jeedom.private

### DIFF
--- a/core/js/jeedom.class.js
+++ b/core/js/jeedom.class.js
@@ -118,7 +118,7 @@ jeedom.changes = function() {
   try {
     jeedom.private.checkParamsRequired(paramsRequired)
   } catch (e) {
-    (paramsSpecifics.error || jeedom.private.default_params.error)(e)
+    (paramsSpecifics.error || jeedom.private?.default_params?.error || console.error)(e)
     return
   }
   const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics)
@@ -382,7 +382,7 @@ jeedom.getStringUsedBy = function(_params) {
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
-    (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
+    (_params?.error || paramsSpecifics.error || jeedom.private?.default_params?.error || console.error)(e)
     return
   }
   const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
@@ -401,7 +401,7 @@ jeedom.getIdUsedBy = function(_params) {
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
-    (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
+    (_params?.error || paramsSpecifics.error || jeedom.private?.default_params?.error || console.error)(e)
     return
   }
   const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
@@ -432,7 +432,7 @@ jeedom.getConfiguration = function(_params) {
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
-    (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
+    (_params?.error || paramsSpecifics.error || jeedom.private?.default_params?.error || console.error)(e)
     return
   }
   const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
@@ -462,7 +462,7 @@ jeedom.getInfoApplication = function(_params) {
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
-    (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
+    (_params?.error || paramsSpecifics.error || jeedom.private?.default_params?.error || console.error)(e)
     return
   }
   const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
@@ -480,7 +480,7 @@ jeedom.haltSystem = function(_params) {
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
-    (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
+    (_params?.error || paramsSpecifics.error || jeedom.private?.default_params?.error || console.error)(e)
     return
   }
   const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
@@ -504,7 +504,7 @@ jeedom.ssh = function(_params) {
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
-    (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
+    (_params?.error || paramsSpecifics.error || jeedom.private?.default_params?.error || console.error)(e)
     return
   }
   const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
@@ -530,7 +530,7 @@ jeedom.db = function(_params) {
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
-    (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
+    (_params?.error || paramsSpecifics.error || jeedom.private?.default_params?.error || console.error)(e)
     return
   }
   const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
@@ -550,7 +550,7 @@ jeedom.dbcorrectTable = function(_params) {
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
-    (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
+    (_params?.error || paramsSpecifics.error || jeedom.private?.default_params?.error || console.error)(e)
     return
   }
   const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
@@ -569,7 +569,7 @@ jeedom.rebootSystem = function(_params) {
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
-    (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
+    (_params?.error || paramsSpecifics.error || jeedom.private?.default_params?.error || console.error)(e)
     return
   }
   const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
@@ -587,7 +587,7 @@ jeedom.systemCorrectPackage = function(_params) {
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
-    (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
+    (_params?.error || paramsSpecifics.error || jeedom.private?.default_params?.error || console.error)(e)
     return
   }
   const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
@@ -606,7 +606,7 @@ jeedom.health = function(_params) {
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
-    (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
+    (_params?.error || paramsSpecifics.error || jeedom.private?.default_params?.error || console.error)(e)
     return
   }
   const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
@@ -624,7 +624,7 @@ jeedom.forceSyncHour = function(_params) {
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
-    (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
+    (_params?.error || paramsSpecifics.error || jeedom.private?.default_params?.error || console.error)(e)
     return
   }
   const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
@@ -724,7 +724,7 @@ jeedom.getGraphData = function(_params) {
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
-    (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
+    (_params?.error || paramsSpecifics.error || jeedom.private?.default_params?.error || console.error)(e)
     return
   }
   const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
@@ -744,7 +744,7 @@ jeedom.getDocumentationUrl = function(_params) {
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
-    (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
+    (_params?.error || paramsSpecifics.error || jeedom.private?.default_params?.error || console.error)(e)
     return
   }
   const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
@@ -765,7 +765,7 @@ jeedom.addWarnme = function(_params) {
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
-    (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
+    (_params?.error || paramsSpecifics.error || jeedom.private?.default_params?.error || console.error)(e)
     return
   }
   const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
@@ -785,7 +785,7 @@ jeedom.getFileFolder = function(_params) {
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
-    (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
+    (_params?.error || paramsSpecifics.error || jeedom.private?.default_params?.error || console.error)(e)
     return
   }
   const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
@@ -805,7 +805,7 @@ jeedom.getFileContent = function(_params) {
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
-    (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
+    (_params?.error || paramsSpecifics.error || jeedom.private?.default_params?.error || console.error)(e)
     return
   }
   const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
@@ -824,7 +824,7 @@ jeedom.setFileContent = function(_params) {
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
-    (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
+    (_params?.error || paramsSpecifics.error || jeedom.private?.default_params?.error || console.error)(e)
     return
   }
   const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
@@ -844,7 +844,7 @@ jeedom.deleteFile = function(_params) {
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
-    (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
+    (_params?.error || paramsSpecifics.error || jeedom.private?.default_params?.error || console.error)(e)
     return
   }
   const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
@@ -863,7 +863,7 @@ jeedom.createFolder = function(_params) {
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
-    (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
+    (_params?.error || paramsSpecifics.error || jeedom.private?.default_params?.error || console.error)(e)
     return
   }
   const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
@@ -883,7 +883,7 @@ jeedom.renameFolder = function(_params) {
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
-    (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
+    (_params?.error || paramsSpecifics.error || jeedom.private?.default_params?.error || console.error)(e)
     return
   }
   const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
@@ -903,7 +903,7 @@ jeedom.deleteFolder = function(_params) {
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
-    (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
+    (_params?.error || paramsSpecifics.error || jeedom.private?.default_params?.error || console.error)(e)
     return
   }
   const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
@@ -922,7 +922,7 @@ jeedom.createFile = function(_params) {
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
-    (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
+    (_params?.error || paramsSpecifics.error || jeedom.private?.default_params?.error || console.error)(e)
     return
   }
   const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
@@ -942,7 +942,7 @@ jeedom.emptyRemoveHistory = function(_params) {
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
-    (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
+    (_params?.error || paramsSpecifics.error || jeedom.private?.default_params?.error || console.error)(e)
     return
   }
   const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
@@ -960,7 +960,7 @@ jeedom.version = function(_params) {
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
-    (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
+    (_params?.error || paramsSpecifics.error || jeedom.private?.default_params?.error || console.error)(e)
     return
   }
   const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
@@ -978,7 +978,7 @@ jeedom.removeImageIcon = function(_params) {
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
-    (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
+    (_params?.error || paramsSpecifics.error || jeedom.private?.default_params?.error || console.error)(e)
     return
   }
   const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
@@ -997,7 +997,7 @@ jeedom.cleanFileSystemRight = function(_params) {
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
-    (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
+    (_params?.error || paramsSpecifics.error || jeedom.private?.default_params?.error || console.error)(e)
     return
   }
   const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
@@ -1015,7 +1015,7 @@ jeedom.consistency = function(_params) {
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
-    (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
+    (_params?.error || paramsSpecifics.error || jeedom.private?.default_params?.error || console.error)(e)
     return
   }
   const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
@@ -1033,7 +1033,7 @@ jeedom.cleanDatabase = function(_params) {
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
-    (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
+    (_params?.error || paramsSpecifics.error || jeedom.private?.default_params?.error || console.error)(e)
     return
   }
   const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
@@ -1051,7 +1051,7 @@ jeedom.massEditSave = function(_params) {
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
-    (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
+    (_params?.error || paramsSpecifics.error || jeedom.private?.default_params?.error || console.error)(e)
     return
   }
   const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
@@ -1071,7 +1071,7 @@ jeedom.massReplace = function(_params) {
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
-    (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
+    (_params?.error || paramsSpecifics.error || jeedom.private?.default_params?.error || console.error)(e)
     return
   }
   const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
@@ -1092,7 +1092,7 @@ jeedom.systemGetUpgradablePackage = function(_params) {
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
-    (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
+    (_params?.error || paramsSpecifics.error || jeedom.private?.default_params?.error || console.error)(e)
     return
   }
   const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
@@ -1112,7 +1112,7 @@ jeedom.systemUpgradablePackage = function(_params) {
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
-    (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
+    (_params?.error || paramsSpecifics.error || jeedom.private?.default_params?.error || console.error)(e)
     return
   }
   const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})

--- a/desktop/js/cron.js
+++ b/desktop/js/cron.js
@@ -63,9 +63,9 @@ if (!jeeFrontEnd.cron) {
             jeeFrontEnd.cron.cronDataTable.destroy()
             delete jeeFrontEnd.cron.cronDataTable
           }
-          var table = document.getElementById('table_cron').querySelector('tbody')
+          const table = document.getElementById('table_cron').querySelector('tbody')
           table.empty()
-          for (var i in data) {
+          for (const i in data) {
             let newRow = document.createElement("tr")
             newRow.innerHTML = jeeP.addCron(data[i])
             newRow.setJeeValues(data[i], '.cronAttr')
@@ -82,11 +82,11 @@ if (!jeeFrontEnd.cron) {
     },
     addCron: function(_cron) {
       jeedomUtils.hideAlert()
-      var disabled = ''
+      const disabled = ''
       if (init(_cron.deamon) == 1) {
         disabled = 'disabled'
       }
-      var tr = '<tr>'
+      const tr = '<tr>'
       tr += '<td><span class="cronAttr label label-info" data-l1key="id"></span></td>'
       tr += '<td class="center">'
       tr += '<input type="checkbox"class="cronAttr" data-l1key="enable" checked ' + disabled + '/>'
@@ -118,8 +118,8 @@ if (!jeeFrontEnd.cron) {
       tr += init(_cron.runtime, '0') + 's'
       tr += '</td>'
       tr += '<td>'
-      var label = 'label label-info'
-      var state = init(_cron.state)
+      let label = 'label label-info'
+      let state = init(_cron.state)
       if (init(_cron.state) == 'run') {
         label = 'label label-success'
         state = '{{En cours}}'
@@ -175,9 +175,9 @@ if (!jeeFrontEnd.cron) {
       jeedom.listener.all({
         success: function(data) {
           domUtils.showLoading()
-          var table = document.getElementById('table_listener').querySelector('tbody')
+          const table = document.getElementById('table_listener').querySelector('tbody')
           table.empty()
-          for (var i in data) {
+          for (const i in data) {
             let newRow = document.createElement("tr")
             newRow.innerHTML = jeeP.addListener(data[i])
             newRow.setJeeValues(data[i], '.listenerAttr')
@@ -190,8 +190,8 @@ if (!jeeFrontEnd.cron) {
     },
     addListener: function(_listener) {
       jeedomUtils.hideAlert()
-      var disabled = ''
-      var tr = '<tr>'
+      const disabled = ''
+      const tr = '<tr>'
       tr += '<td class="option"><span class="listenerAttr" data-l1key="id"></span></td>'
       tr += '<td>'
       if (init(_listener.id) != '') {
@@ -217,7 +217,7 @@ if (!jeeFrontEnd.cron) {
           })
         },
         success: function(plugins) {
-          for (var i in plugins) {
+          for (const i in plugins) {
             if (plugins[i].hasOwnDeamon == 0) continue
 
             jeedom.plugin.getDeamonInfo({
@@ -230,7 +230,7 @@ if (!jeeFrontEnd.cron) {
                 })
               },
               success: function(deamonInfo) {
-                var html = '<tr>'
+                let html = '<tr>'
                 html += '<td>'
                 html += deamonInfo.plugin.name
                 html += '</td>'
@@ -284,9 +284,9 @@ if (!jeeFrontEnd.cron) {
             jeeFrontEnd.cron.queueDataTable.destroy()
             delete jeeFrontEnd.cron.queueDataTable
           }
-          var table = document.getElementById('table_queue').querySelector('tbody')
+          const table = document.getElementById('table_queue').querySelector('tbody')
           table.empty()
-          for (var i in data) {
+          for (const i in data) {
             let newRow = document.createElement("tr")
             newRow.innerHTML = jeeP.addQueue(data[i])
             newRow.setJeeValues(data[i], '.queueAttr')
@@ -303,7 +303,7 @@ if (!jeeFrontEnd.cron) {
     },
     addQueue: function(_queue) {
       jeedomUtils.hideAlert()
-      var tr = '<tr>'
+      const tr = '<tr>'
       tr += '<td><span class="queueAttr label label-info" data-l1key="id"></span></td>'
       tr += '<td>'
       tr += init(_queue.pid)
@@ -318,8 +318,8 @@ if (!jeeFrontEnd.cron) {
       tr += init(_queue.createTime)
       tr += '</td>'
       tr += '<td>'
-      var label = 'label label-info'
-      var state = init(_queue.state)
+      let label = 'label label-info'
+      let state = init(_queue.state)
       if (init(_queue.state) == 'run') {
         label = 'label label-success'
         state = '{{En cours}}'
@@ -388,7 +388,7 @@ document.getElementById('bt_save')?.addEventListener('click', function(event) {
 })
 
 document.getElementById('bt_changeCronState')?.addEventListener('click', function(event) {
-  var _target = event.target
+  const _target = event.target
   jeedom.config.save({
     configuration: {
       enableCron: _target.getAttribute('data-state')
@@ -421,7 +421,7 @@ document.registerEvent('keydown', function(event) {
 /*Events delegations
 */
 document.getElementById('div_pageContainer').addEventListener('click', function(event) {
-  var _target = null
+  const _target = null
   if (_target = event.target.closest('ul.nav.nav-tabs')) {
     if (document.getElementById('tab_tableCron').hasClass('active')) {
       document.querySelector('div.floatingbar').seen()
@@ -433,7 +433,7 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
 })
 
 document.getElementById('div_pageContainer').addEventListener('change', function(event) {
-  var _target = null
+  const _target = null
   if (_target = event.target.closest('.cronAttr')) {
     jeeFrontEnd.modifyWithoutSave = true
   }
@@ -443,7 +443,7 @@ document.getElementById('div_pageContainer').addEventListener('change', function
 //Table cron
 document.getElementById('table_cron')?.tBodies[0].addEventListener('click', function(event) {
   // console.log('click:', event.target)
-  var _target = null
+  const _target = null
   if (_target = event.target.closest('.remove')) {
     _target.closest('tr').remove()
     if (jeeFrontEnd.cron.cronDataTable) jeeFrontEnd.cron.cronDataTable.refresh()
@@ -495,7 +495,7 @@ document.getElementById('table_cron')?.tBodies[0].addEventListener('click', func
 })
 
 document.getElementById('table_cron')?.tBodies[0].addEventListener('change', function(event) {
-  var _target = null
+  const _target = null
   if (_target = event.target.closest('.cronAttr[data-l1key="deamon"]')) {
     if (_target.jeeValue() == 1) {
       _target.closest('tr').querySelector('.cronAttr[data-l1key="deamonSleepTime"]').seen()
@@ -510,7 +510,7 @@ document.getElementById('table_cron')?.tBodies[0].addEventListener('change', fun
 
 document.getElementById('table_queue')?.tBodies[0].addEventListener('click', function(event) {
   // console.log('click:', event.target)
-  var _target = null
+  const _target = null
   if (_target = event.target.closest('.displayQueue')) {
     jeeDialog.dialog({
       id: 'jee_modal',
@@ -526,7 +526,7 @@ document.getElementById('table_queue')?.tBodies[0].addEventListener('click', fun
 
 //Table listeners
 document.getElementById('table_listener')?.tBodies[0].addEventListener('click', function(event) {
-  var _target = null
+  const _target = null
   if (_target = event.target.closest('.display')) {
     jeeDialog.dialog({
       id: 'jee_modal',
@@ -537,7 +537,7 @@ document.getElementById('table_listener')?.tBodies[0].addEventListener('click', 
   }
 
   if (_target = event.target.closest('.removeListener')) {
-    var tr = _target.closest('tr')
+    const tr = _target.closest('tr')
     jeedom.listener.remove({
       id: tr.querySelector('span[data-l1key="id"]').innerHTML,
       success: function() {
@@ -550,10 +550,10 @@ document.getElementById('table_listener')?.tBodies[0].addEventListener('click', 
 
 //Table daemons
 document.getElementById('table_deamon')?.tBodies[0].addEventListener('click', function(event) {
-  var _target = null
+  const _target = null
   if (_target = event.target.closest('.bt_deamonAction')) {
-    var plugin = _target.getAttribute('data-plugin')
-    var action = _target.getAttribute('data-action')
+    const plugin = _target.getAttribute('data-plugin')
+    const action = _target.getAttribute('data-action')
     if (action == 'start') {
       jeedom.plugin.deamonStart({
         id: plugin,

--- a/desktop/js/editor.js
+++ b/desktop/js/editor.js
@@ -48,7 +48,7 @@ if (!jeeFrontEnd.editor) {
                 className: 'success',
                 callback: {
                   click: function(event) {
-                    var SubType = document.querySelector('.selectWidgetSubType[data-type="' + document.getElementById('sel_widgetType')?.value + '"]')?.value
+                    const SubType = document.querySelector('.selectWidgetSubType[data-type="' + document.getElementById('sel_widgetType')?.value + '"]')?.value
                     if (!SubType || SubType.value == '') {
                       jeedomUtils.showAlert({message: '{{Le sous-type ne peut être vide}}', level: 'danger'})
                       return
@@ -57,8 +57,8 @@ if (!jeeFrontEnd.editor) {
                       jeedomUtils.showAlert({message: '{{Le nom ne peut être vide}}', level: 'danger'})
                       return
                     }
-                    var name = 'cmd.'+document.getElementById('sel_widgetType').value+'.'+SubType+'.'+document.getElementById('in_widgetName').value+'.html'
-                    var filePath = 'data/customTemplates/' + document.getElementById('sel_widgetVersion').value + '/'
+                    const name = 'cmd.'+document.getElementById('sel_widgetType').value+'.'+SubType+'.'+document.getElementById('in_widgetName').value+'.html'
+                    const filePath = 'data/customTemplates/' + document.getElementById('sel_widgetVersion').value + '/'
                     jeedom.createFile({
                       path: filePath,
                       name: name,
@@ -68,11 +68,11 @@ if (!jeeFrontEnd.editor) {
                       success: function() {
                         document.getElementById('md_widgetCreation')._jeeDialog.destroy()
                         jeedomUtils.showAlert({message: '{{Fichier enregistré avec succès}}', level: 'success'})
-                        var hash = jeeP.getHashFromPath(filePath.replace('data/customTemplates/', '').replace('/', ''))
+                        let hash = jeeP.getHashFromPath(filePath.replace('data/customTemplates/', '').replace('/', ''))
                         jeeFrontEnd.editor._elfInstance.exec('open', hash)
                         //jeeFrontEnd.editor._elfInstance.exec('reload')
 
-                        var path = filePath.replace('data/customTemplates/', '') + name
+                        const path = filePath.replace('data/customTemplates/', '') + name
                         hash = jeeP.getHashFromPath(path)
                         setTimeout(function() {
                           jeeFrontEnd.editor._elfInstance.exec('edit', hash)
@@ -146,9 +146,9 @@ if (!jeeFrontEnd.editor) {
           return $.Deferred().done()
         }
         this.getActive = function() {
-          var myClass = ''
-          var myIcon = ''
-          var $button = $('#elfinder .elfinder-button-icon-jee_onoffcustom + .elfinder-button-text')
+          let myClass = ''
+          let myIcon = ''
+          const $button = $('#elfinder .elfinder-button-icon-jee_onoffcustom + .elfinder-button-text')
           if (this.config == 1) {
             myClass = 'btn-warning'
             myIcon = ' <i class="fas fa-toggle-on"></i>'
@@ -185,7 +185,7 @@ jeeFrontEnd.editor.init()
 
 CodeMirror.modeURL = "3rdparty/codemirror/mode/%N/%N.js"
 
-var options = {
+let options = {
   url: 'core/php/editor.connector.php?root='+root,
   baseUrl: '3rdparty/elfinder/',
   cssAutoLoad: false,
@@ -255,10 +255,10 @@ var options = {
           },
           load : function(textarea) {
             let self = this
-            var elfinderInstance = $('#elfinder').elfinder(options).elfinder('instance')
-            var fileUrl = elfinderInstance.url(self.file.hash)
+            const elfinderInstance = $('#elfinder').elfinder(options).elfinder('instance')
+            let fileUrl = elfinderInstance.url(self.file.hash)
             fileUrl = fileUrl.replace('/core/php/../../', '')
-            var modal = textarea.closest('.ui-front')
+            const modal = textarea.closest('.ui-front')
             modal.querySelector('.elfinder-dialog-title').innerHTML = fileUrl
 
             this.myCodeMirror = CodeMirror.fromTextArea(textarea, {
@@ -270,10 +270,10 @@ var options = {
               foldGutter: true,
               gutters: ["CodeMirror-linenumbers", "CodeMirror-foldgutter"]
             })
-            var editor = this.myCodeMirror
+            const editor = this.myCodeMirror
 
             //Auto mode set:
-            var info, m, mode, spec;
+            let info, m, mode, spec;
             if (!info) {
               info = CodeMirror.findModeByMIME(self.file.mime);
             }

--- a/desktop/js/history.js
+++ b/desktop/js/history.js
@@ -44,7 +44,7 @@ if (!jeeFrontEnd.history) {
         this.loadIds = this.loadIds.split('-')
         if (is_numeric(this.loadIds[0])) {
           this.loadIds.forEach(function(cmd_id) {
-            var li = document.querySelector('.li_history[data-cmd_id="' + cmd_id + '"]')
+            const li = document.querySelector('.li_history[data-cmd_id="' + cmd_id + '"]')
             if (li) {
               li.addClass('active')
               jeeFrontEnd.history.addChart(cmd_id, 1)
@@ -68,12 +68,12 @@ if (!jeeFrontEnd.history) {
     //grouping/type/variation/step Compare mode available only if one curve in chart
     setChartOptions: function() {
       if (!isset(jeedom.history.chart[this.__el__])) return
-      var _disabled = true
-      var currentSeries = jeedom.history.chart[this.__el__].chart.series.filter(key => !key.name.includes('Navigator '))
+      let _disabled = true
+      const currentSeries = jeedom.history.chart[this.__el__].chart.series.filter(key => !key.name.includes('Navigator '))
 
       if (currentSeries.length == 1) { //only one series in chart:
-        var serieId = currentSeries[0].userOptions.id
-        var isCalcul = document.querySelector('li.li_history[data-cmd_id="' + serieId + '"] a.history')?.getAttribute('data-calcul') === null ? false : true
+        const serieId = currentSeries[0].userOptions.id
+        const isCalcul = document.querySelector('li.li_history[data-cmd_id="' + serieId + '"] a.history')?.getAttribute('data-calcul') === null ? false : true
         if (isCalcul) {
           this.__lastId__ = null
           document.getElementById('cb_derive').checked = false
@@ -84,16 +84,16 @@ if (!jeeFrontEnd.history) {
           this.__lastId__ = currentSeries[currentSeries.length - 1].userOptions.id
           _disabled = false
           if (isset(currentSeries[0].userOptions.dataGrouping)) {
-            var grouping = currentSeries[0].userOptions.dataGrouping.enabled
+            const grouping = currentSeries[0].userOptions.dataGrouping.enabled
             if (grouping) {
-              var groupingType = currentSeries[0].userOptions.dataGrouping.approximation + '::' + currentSeries[0].userOptions.dataGrouping.units[0][0]
+              const groupingType = currentSeries[0].userOptions.dataGrouping.approximation + '::' + currentSeries[0].userOptions.dataGrouping.units[0][0]
               document.getElementById('sel_groupingType').value = groupingType
             } else {
               document.getElementById('sel_groupingType').selectedIndex = 0
             }
           }
 
-          var type = currentSeries[0].userOptions.type
+          const type = currentSeries[0].userOptions.type
           if (type == 'areaspline') type = 'area'
           document.getElementById('sel_chartType').value = type
           document.getElementById('cb_derive').checked = currentSeries[0].userOptions.derive
@@ -131,8 +131,8 @@ if (!jeeFrontEnd.history) {
       }
 
       //Add series:
-      var dateStart = document.getElementById('in_startDate').value
-      var dateEnd = document.getElementById('in_endDate').value
+      const dateStart = document.getElementById('in_startDate').value
+      const dateEnd = document.getElementById('in_endDate').value
       jeedom.history.drawChart({
         cmd_id: _cmd_id,
         el: this.__el__,
@@ -199,10 +199,10 @@ if (!jeeFrontEnd.history) {
         width: 720,
         height: 260,
         callback: function() {
-          var contentEl = jeeDialog.get('#md_historyCompare', 'content')
+          const contentEl = jeeDialog.get('#md_historyCompare', 'content')
 
           if (contentEl.querySelector('#md_getCompareRange') == null) {
-            var newContent = document.getElementById('md_getCompareRange-template').cloneNode(true)
+            const newContent = document.getElementById('md_getCompareRange-template').cloneNode(true)
             newContent.setAttribute('id', 'md_getCompareRange')
             newContent.removeClass('hidden')
             contentEl.appendChild(newContent)
@@ -210,17 +210,17 @@ if (!jeeFrontEnd.history) {
 
           //Set modal events:
           document.getElementById('md_getCompareRange').addEventListener('change', function(event) {
-            var _target = null
-            var _md = document.getElementById('md_getCompareRange')
+            let _target = null
+            const _md = document.getElementById('md_getCompareRange')
             if (_target = event.target.closest('#md_getCompareRange input.in_datepicker')) {
-              var fromStart = moment(_md.querySelector('#in_compareStart1').value + ' 00:00:00', 'YYYY-MM-DD HH:mm:ss')
-              var fromEnd = moment(_md.querySelector('#in_compareEnd1').value + ' 23:59:59', 'YYYY-MM-DD HH:mm:ss')
-              var toStart = moment(_md.querySelector('#in_compareStart2').value + ' 00:00:00', 'YYYY-MM-DD HH:mm:ss')
-              var toEnd = moment(_md.querySelector('#in_compareEnd2').value + ' 23:59:59', 'YYYY-MM-DD HH:mm:ss')
+              const fromStart = moment(_md.querySelector('#in_compareStart1').value + ' 00:00:00', 'YYYY-MM-DD HH:mm:ss')
+              const fromEnd = moment(_md.querySelector('#in_compareEnd1').value + ' 23:59:59', 'YYYY-MM-DD HH:mm:ss')
+              const toStart = moment(_md.querySelector('#in_compareStart2').value + ' 00:00:00', 'YYYY-MM-DD HH:mm:ss')
+              const toEnd = moment(_md.querySelector('#in_compareEnd2').value + ' 23:59:59', 'YYYY-MM-DD HH:mm:ss')
 
-              var diffPeriod = fromEnd.diff(fromStart, 'days')
-              var cdiffPeriod = toEnd.diff(toStart, 'days')
-              var text = '{{Comparer}} ' + diffPeriod + ' {{jours avec}} ' + cdiffPeriod + ' {{jours il y a}} ' + document.getElementById('sel_comparePeriod').selectedOptions[0].text
+              const diffPeriod = fromEnd.diff(fromStart, 'days')
+              const cdiffPeriod = toEnd.diff(toStart, 'days')
+              const text = '{{Comparer}} ' + diffPeriod + ' {{jours avec}} ' + cdiffPeriod + ' {{jours il y a}} ' + document.getElementById('sel_comparePeriod').selectedOptions[0].text
               _md.querySelector('.spanCompareDiffResult').textContent = text
               if (diffPeriod != cdiffPeriod) {
                 _md.querySelector('.spanCompareDiff').seen()
@@ -231,12 +231,12 @@ if (!jeeFrontEnd.history) {
             }
 
             if (_target = event.target.closest('#md_getCompareRange #sel_setPeriod')) {
-              var startDate = _md.querySelector('#in_compareEnd1').value
-              var num = event.target.value.split('.')[0]
-              var type = event.target.value.split('.')[1]
+              let startDate = _md.querySelector('#in_compareEnd1').value
+              const num = event.target.value.split('.')[0]
+              const type = event.target.value.split('.')[1]
 
-              var m_startDate = moment(startDate, 'YYYY-MM-DD HH:mm:ss')
-              var endDate = m_startDate.subtract(num, type).format("YYYY-MM-DD")
+              let m_startDate = moment(startDate, 'YYYY-MM-DD HH:mm:ss')
+              let endDate = m_startDate.subtract(num, type).format("YYYY-MM-DD")
               _md.querySelector('#in_compareStart1').value = endDate
 
               //range to compare with:
@@ -252,12 +252,12 @@ if (!jeeFrontEnd.history) {
             }
 
             if (_target = event.target.closest('#md_getCompareRange #sel_comparePeriod')) {
-              var startDate = _md.querySelector('#in_compareEnd1').value
-              var num = event.target.value.split('.')[0]
-              var type = event.target.value.split('.')[1]
+              let startDate = _md.querySelector('#in_compareEnd1').value
+              const num = event.target.value.split('.')[0]
+              const type = event.target.value.split('.')[1]
 
-              var m_startDate = moment(startDate, 'YYYY-MM-DD HH:mm:ss')
-              var endDate = m_startDate.subtract(num, type).format("YYYY-MM-DD")
+              let m_startDate = moment(startDate, 'YYYY-MM-DD HH:mm:ss')
+              let endDate = m_startDate.subtract(num, type).format("YYYY-MM-DD")
               _md.querySelector('#in_compareEnd2').value = endDate
 
               startDate = _md.querySelector('#in_compareStart1').value
@@ -269,7 +269,7 @@ if (!jeeFrontEnd.history) {
             }
           })
 
-          var _md = document.getElementById('md_getCompareRange')
+          const _md = document.getElementById('md_getCompareRange')
           _md.querySelector('#in_compareStart1').value = document.querySelector('#in_startDate').value
           _md.querySelector('#sel_setPeriod').triggerEvent('change')
           _md.querySelector('#sel_comparePeriod').triggerEvent('change')
@@ -302,8 +302,8 @@ if (!jeeFrontEnd.history) {
     },
     compareChart: function(_cmd_id) {
       //compare:
-      var fromStart, fromEnd, toStart, toEnd
-      var _md = document.getElementById('md_getCompareRange')
+      const fromStart, fromEnd, toStart, toEnd
+      const _md = document.getElementById('md_getCompareRange')
       fromStart = _md.querySelector('#in_compareStart1').value + ' 00:00:00'
       fromEnd = _md.querySelector('#in_compareEnd1').value + ' 23:59:59'
       toStart = _md.querySelector('#in_compareStart2').value + ' 00:00:00'
@@ -356,8 +356,8 @@ if (!jeeFrontEnd.history) {
       })
     },
     setCalculList: function() {
-      var elCalculList = document.getElementById('historyCalculs')
-      var isOpened = false
+      const elCalculList = document.getElementById('historyCalculs')
+      let isOpened = false
       if (elCalculList != null && elCalculList.querySelector('.displayObject i.fas')?.hasClass('fa-arrow-circle-down')) isOpened = true
       jeedom.config.load({
         configuration: 'calculHistory',
@@ -370,12 +370,12 @@ if (!jeeFrontEnd.history) {
           elCalculList.empty()
           if (data.length == 0) return
 
-          var html = '<span class="label cursor displayObject" data-object_id="jeedom-config-calculs" style="background-color:var(--btn-default-color);color:var(--linkHoverLight-color);">{{Mes Calculs}} <i class="fas fa-arrow-circle-right"></i></span>'
+          let html = '<span class="label cursor displayObject" data-object_id="jeedom-config-calculs" style="background-color:var(--btn-default-color);color:var(--linkHoverLight-color);">{{Mes Calculs}} <i class="fas fa-arrow-circle-right"></i></span>'
           html += '<br/>'
           html += '<div class="cmdList" data-object_id="jeedom-config-calculs" style="display:none;margin-left : 20px;">'
-          for (var i in data) {
+          for (const i in data) {
             if (isset(data[i].calcul) && data[i].calcul != '') {
-              var dataName = data[i].name != '' ? data[i].name : data[i].calcul.substring(0, 40)
+              const dataName = data[i].name != '' ? data[i].name : data[i].calcul.substring(0, 40)
               html += '<li class="cursor li_history" data-cmd_id="' + data[i].calcul + '">';
               html += '<a class="history historycalcul" title="' + data[i].calcul + '" data-calcul="' + data[i].calcul + '" data-graphstep="' + data[i].graphStep + '" data-graphtype="' + data[i].graphType + '" data-groupingtype="' + data[i].groupingType + '">' + dataName + '</a>';
               html += '</li>';
@@ -405,12 +405,12 @@ window.registerEvent("resize", function history(event) {
 */
 //Options
 document.getElementById('div_historyOptions').addEventListener('click', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('#bt_validChangeDate')) {
     if (jeedom.history.chart[jeeP.__el__] === undefined) return
     jeedom.history.chart[jeeP.__el__].chart.series.forEach(_series => {
       if (_series.options && !isNaN(_series.options.id)) {
-        var cmdId = _series.options.id
+        const cmdId = _series.options.id
         jeeP.addChart(cmdId, 0)
         jeeP.addChart(cmdId, 1)
       }
@@ -441,12 +441,12 @@ document.getElementById('div_historyOptions').addEventListener('click', function
 })
 
 document.getElementById('div_historyOptions').addEventListener('change', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('#sel_groupingType')) {
     if (event.isTrigger == 3) return
     if (jeeP.__lastId__ == null) return
-    var currentId = jeeP.__lastId__
-    var groupingType = _target.value
+    const currentId = jeeP.__lastId__
+    const groupingType = _target.value
     jeeP.addChart(currentId, 0)
     jeedom.cmd.save({
       cmd: {
@@ -471,8 +471,8 @@ document.getElementById('div_historyOptions').addEventListener('change', functio
   if (_target = event.target.closest('#sel_chartType')) {
     if (event.isTrigger == 3) return
     if (jeeP.__lastId__ == null) return
-    var currentId = jeeP.__lastId__
-    var graphType = _target.value
+    const currentId = jeeP.__lastId__
+    const graphType = _target.value
     jeeP.addChart(currentId, 0)
     jeedom.cmd.save({
       cmd: {
@@ -497,8 +497,8 @@ document.getElementById('div_historyOptions').addEventListener('change', functio
   if (_target = event.target.closest('#cb_derive')) {
     if (event.isTrigger == 3) return
     if (jeeP.__lastId__ == null) return
-    var currentId = jeeP.__lastId__
-    var graphDerive = _target.checked ? '1' : '0'
+    const currentId = jeeP.__lastId__
+    const graphDerive = _target.checked ? '1' : '0'
     jeeP.addChart(currentId, 0)
     jeedom.cmd.save({
       cmd: {
@@ -523,8 +523,8 @@ document.getElementById('div_historyOptions').addEventListener('change', functio
   if (_target = event.target.closest('#cb_step')) {
     if (event.isTrigger == 3) return
     if (jeeP.__lastId__ == null) return
-    var currentId = jeeP.__lastId__
-    var graphStep = _target.checked ? '1' : '0'
+    const currentId = jeeP.__lastId__
+    const graphStep = _target.checked ? '1' : '0'
     jeeP.addChart(currentId, 0)
     jeedom.cmd.save({
       cmd: {
@@ -548,7 +548,7 @@ document.getElementById('div_historyOptions').addEventListener('change', functio
 })
 //Sidebar:
 document.getElementById('sidebar').addEventListener('click', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('#bt_findCmdCalculHistory')) {
     jeedom.cmd.getSelectModal({
       cmd: {
@@ -563,7 +563,7 @@ document.getElementById('sidebar').addEventListener('click', function(event) {
   }
 
   if (_target = event.target.closest('#bt_displayCalculHistory')) {
-    var calcul = document.getElementById('in_calculHistory').jeeValue()
+    const calcul = document.getElementById('in_calculHistory').jeeValue()
     if (calcul != '') jeeP.addChart(calcul, 1)
     return
   }
@@ -630,9 +630,9 @@ document.getElementById('sidebar').addEventListener('click', function(event) {
     if (_target.hasClass('remove') || _target.hasClass('export')) return
     if (isset(jeedom.history.chart[jeeP.__el__]) && jeedom.history.chart[jeeP.__el__].comparing) return
 
-    var options = null
+    let options = null
     if (_target.hasClass('historycalcul')) {
-      var options = {
+      let options = {
         graphType: _target.getAttribute('data-graphtype'),
         groupingType: _target.getAttribute('data-groupingtype'),
         graphStep: (_target.getAttribute('data-graphstep') == 0) ? false : true,
@@ -652,7 +652,7 @@ document.getElementById('sidebar').addEventListener('click', function(event) {
 })
 
 document.getElementById('sidebar').addEventListener('keyup', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('ul li input.filter')) {
     if (event.target.value == '') {
       document.querySelectorAll('#ul_history .cmdList').unseen()

--- a/desktop/js/interact.js
+++ b/desktop/js/interact.js
@@ -44,45 +44,45 @@ if (!jeeFrontEnd.interact) {
           document.querySelectorAll('.interactAttr[data-l1key="filtres"]').forEach(_filter => {
             _filter.selected = false
           })
-          var option = null
+          let option = null
           if (isset(data.filtres) && isset(data.filtres.type) && isPlainObject(data.filtres.type)) {
-            for (var i in data.filtres.type) {
+            for (const i in data.filtres.type) {
               if (data.filtres.type[i] == '1') (option = document.querySelector('.interactAttr[data-l1key="filtres"][data-l2key="type"][data-l3key="' + i + '"]')) != null ? option.selected = true : null
             }
           }
           if (isset(data.filtres) && isset(data.filtres.subtype) && isPlainObject(data.filtres.subtype)) {
-            for (var i in data.filtres.subtype) {
+            for (const i in data.filtres.subtype) {
               if (data.filtres.subtype[i] == '1') (option = document.querySelector('.interactAttr[data-l1key="filtres"][data-l2key="subtype"][data-l3key="' + i + '"]')) != null ? option.selected = true : null
             }
           }
           if (isset(data.filtres) && isset(data.filtres.unite) && isPlainObject(data.filtres.unite)) {
-            for (var i in data.filtres.unite) {
+            for (const i in data.filtres.unite) {
               if (data.filtres.unite[i] == '1') (option = document.querySelector('.interactAttr[data-l1key="filtres"][data-l2key="unite"][data-l3key="' + i + '"]')) != null ? option.selected = true : null
             }
           }
           if (isset(data.filtres) && isset(data.filtres.object) && isPlainObject(data.filtres.object)) {
-            for (var i in data.filtres.object) {
+            for (const i in data.filtres.object) {
               if (data.filtres.object[i] == '1') (option = document.querySelector('.interactAttr[data-l1key="filtres"][data-l2key="object"][data-l3key="' + i + '"]')) != null ? option.selected = true : null
             }
           }
           if (isset(data.filtres) && isset(data.filtres.plugin) && isPlainObject(data.filtres.plugin)) {
-            for (var i in data.filtres.plugin) {
+            for (const i in data.filtres.plugin) {
               if (data.filtres.plugin[i] == '1') (option = document.querySelector('.interactAttr[data-l1key="filtres"][data-l2key="plugin"][data-l3key="' + i + '"]')) != null ? option.selected = true : null
             }
           }
           if (isset(data.filtres) && isset(data.filtres.category) && isPlainObject(data.filtres.category)) {
-            for (var i in data.filtres.category) {
+            for (const i in data.filtres.category) {
               if (data.filtres.category[i] == '1') (option = document.querySelector('.interactAttr[data-l1key="filtres"][data-l2key="category"][data-l3key="' + i + '"]')) != null ? option.selected = true : null
             }
           }
           if (isset(data.actions) && isset(data.actions.cmd) && Array.isArray(data.actions.cmd) && data.actions.cmd.length != null) {
-            for (var i in data.actions.cmd) {
+            for (const i in data.actions.cmd) {
               jeeP.addAction(data.actions.cmd[i], 'action', '{{Action}}')
             }
           }
           jeedomUtils.taAutosize()
 
-          var hash = window.location.hash
+          const hash = window.location.hash
           jeedomUtils.addOrUpdateUrl('id', data.id)
           if (hash == '') {
             document.querySelector('.nav-tabs a[href="#generaltab"]')?.click()
@@ -100,7 +100,7 @@ if (!jeeFrontEnd.interact) {
               })
             },
             success: function(data) {
-              for (var i in data) {
+              for (const i in data) {
                 if (data[i].html != '') {
                   document.getElementById(data[i].id).html(data[i].html.html)
                 }
@@ -120,7 +120,7 @@ if (!jeeFrontEnd.interact) {
       if (!isset(_action.options)) {
         _action.options = {}
       }
-      var div = '<div class="' + _type + '">'
+      let div = '<div class="' + _type + '">'
       div += '<div class="form-group ">'
       div += '<div class="col-sm-5">'
       div += '<div class="input-group input-group-sm">'
@@ -134,7 +134,7 @@ if (!jeeFrontEnd.interact) {
       div += '</span>'
       div += '</div>'
       div += '</div>'
-      var actionOption_id = jeedomUtils.uniqId()
+      const actionOption_id = jeedomUtils.uniqId()
       div += '<div class="col-sm-7 actionOptions" id="' + actionOption_id + '"></div>'
       document.getElementById('div_' + _type).insertAdjacentHTML('beforeend', div)
       document.querySelectorAll('#div_' + _type + ' .' + _type + '').last().setJeeValues(_action, '.expressionAttr')
@@ -157,7 +157,7 @@ if (!jeeFrontEnd.interact) {
             if (interacts.length == 0) {
               return
             }
-            var interactGroups = []
+            let interactGroups = []
             for (i = 0; i < interacts.length; i++) {
               group = interacts[i].group
               if (group == null) continue
@@ -167,13 +167,13 @@ if (!jeeFrontEnd.interact) {
             }
             interactGroups = Array.from(new Set(interactGroups))
             interactGroups.sort()
-            var interactList = []
-            for (var i = 0; i < interactGroups.length; i++) {
+            const interactList = []
+            for (let i = 0; i < interactGroups.length; i++) {
               group = interactGroups[i]
               interactList[group] = []
-              for (var j = 0; j < interacts.length; j++) {
-                var sc = interacts[j]
-                var scGroup = sc.group
+              for (let j = 0; j < interacts.length; j++) {
+                const sc = interacts[j]
+                let scGroup = sc.group
                 if (scGroup == null) continue
                 if (scGroup == "") scGroup = 'Aucun'
                 if (scGroup.toLowerCase() != group.toLowerCase()) continue
@@ -182,15 +182,15 @@ if (!jeeFrontEnd.interact) {
               }
             }
             //set context menu!
-            var contextmenuitems = {}
-            var uniqId = 0
-            for (var group in interactList) {
-              var groupinteracts = interactList[group]
-              var items = {}
-              for (var index in groupinteracts) {
-                var sc = groupinteracts[index]
-                var scName = sc[0]
-                var scId = sc[1]
+            const contextmenuitems = {}
+            let uniqId = 0
+            for (const group in interactList) {
+              const groupinteracts = interactList[group]
+              const items = {}
+              for (const index in groupinteracts) {
+                const sc = groupinteracts[index]
+                const scName = sc[0]
+                const scId = sc[1]
                 items[uniqId] = {
                   'name': scName,
                   'id': scId
@@ -212,7 +212,7 @@ if (!jeeFrontEnd.interact) {
                 callback: function(key, options, event) {
                   if (!jeedomUtils.checkPageModified()) {
                     if (event.ctrlKey || event.metaKey || event.which == 2) {
-                      var url = 'index.php?v=d&p=interact&id=' + options.commands[key].id
+                      const url = 'index.php?v=d&p=interact&id=' + options.commands[key].id
                       if (window.location.hash != '') {
                         url += window.location.hash
                       }
@@ -261,7 +261,7 @@ if (!jeeFrontEnd.interact) {
     },
     //Get filters for save / duplicate
     getInteractFilters: function() {
-      var filters = {}
+      const filters = {}
       filters.type = {}
       document.querySelectorAll('option[data-l1key="filtres"][data-l2key="type"]').forEach(_option => {
         filters.type[_option.getAttribute('data-l3key')] = (_option.selected) ? '1' : '0'
@@ -321,20 +321,20 @@ document.registerEvent('keydown', function(event) {
 
 //searching
 document.getElementById('in_searchInteract')?.addEventListener('keyup', function(event) {
-  var search = event.target.value
+  let search = event.target.value
   if (search == '') {
     document.querySelectorAll('#accordionInteract .accordion-toggle:not(.collapsed)').forEach(_panel => { _panel.click() })
     document.querySelectorAll('.interactDisplayCard').seen()
     return
   }
   search = jeedomUtils.normTextLower(search)
-  var not = search.startsWith(":not(")
+  const not = search.startsWith(":not(")
   if (not) {
     search = search.replace(':not(', '')
   }
   document.querySelectorAll('#accordionInteract .accordion-toggle').forEach(_panel => { _panel.setAttribute('data-show', 0) })
   document.querySelectorAll('.interactDisplayCard').unseen()
-  var match, text
+  let match, text
   document.querySelectorAll('.interactDisplayCard .name').forEach(_name => {
     match = false
     text = jeedomUtils.normTextLower(_name.textContent)
@@ -355,7 +355,7 @@ document.getElementById('in_searchInteract')?.addEventListener('keyup', function
 /*Events delegations
 */
 document.getElementById('div_pageContainer').addEventListener('change', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('.interactAttr')) {
     if (_target.isVisible()) jeeFrontEnd.modifyWithoutSave = true
     return
@@ -364,7 +364,7 @@ document.getElementById('div_pageContainer').addEventListener('change', function
 
 //ThumbnailDisplay
 document.getElementById('interactThumbnailDisplay').addEventListener('click', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('#bt_openAll')) {
     document.querySelectorAll('#accordionInteract .accordion-toggle.collapsed').forEach(_panel => { _panel.click() })
     return
@@ -382,7 +382,7 @@ document.getElementById('interactThumbnailDisplay').addEventListener('click', fu
 
   if (_target = event.target.closest('.interactDisplayCard')) {
     if ((isset(event.detail) && event.detail.ctrlKey) || event.ctrlKey || event.metaKey) {
-      var url = '/index.php?v=d&p=interact&id=' + _target.getAttribute('data-interact_id')
+      const url = '/index.php?v=d&p=interact&id=' + _target.getAttribute('data-interact_id')
       window.open(url).focus()
     } else {
       jeeP.printInteract(_target.getAttribute('data-interact_id'))
@@ -449,7 +449,7 @@ document.getElementById('interactThumbnailDisplay').addEventListener('click', fu
 })
 
 document.getElementById('interactThumbnailDisplay').addEventListener('mouseup', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('.interactDisplayCard')) {
     if (event.which == 2) {
       event.preventDefault()
@@ -463,7 +463,7 @@ document.getElementById('interactThumbnailDisplay').addEventListener('mouseup', 
 
 //Interaction
 document.getElementById('div_conf').addEventListener('click', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('#bt_interactThumbnailDisplay')) {
     if (jeedomUtils.checkPageModified()) return
     document.getElementById('div_conf').unseen()
@@ -473,7 +473,7 @@ document.getElementById('div_conf').addEventListener('click', function(event) {
   }
 
   if (_target = event.target.closest('#bt_chooseIcon')) {
-    var _icon = document.querySelector('div[data-l2key="icon"] > i')
+    let _icon = document.querySelector('div[data-l2key="icon"] > i')
     if (_icon != null) {
       _icon = _icon.getAttribute('class')
     } else {
@@ -489,7 +489,7 @@ document.getElementById('div_conf').addEventListener('click', function(event) {
   if (_target = event.target.closest('#bt_duplicate')) {
     jeeDialog.prompt("{{Nom}} ?", function(result) {
       if (result !== null) {
-        var interact = document.querySelectorAll('.interact').getJeeValues('.interactAttr')[0]
+        const interact = document.querySelectorAll('.interact').getJeeValues('.interactAttr')[0]
         interact.filtres = jeeFrontEnd.interact.getInteractFilters()
         interact.actions = {}
         interact.actions.cmd = document.querySelectorAll('#div_action .action').getJeeValues('.expressionAttr')
@@ -514,7 +514,7 @@ document.getElementById('div_conf').addEventListener('click', function(event) {
   }
 
   if (_target = event.target.closest('#bt_saveInteract')) {
-    var interact = document.querySelectorAll('.interact').getJeeValues('.interactAttr')[0]
+    const interact = document.querySelectorAll('.interact').getJeeValues('.interactAttr')[0]
     interact.filtres = jeeFrontEnd.interact.getInteractFilters()
     interact.actions = {}
     interact.actions.cmd = document.querySelectorAll('#div_action .action').getJeeValues('.expressionAttr')
@@ -588,8 +588,8 @@ document.getElementById('div_conf').addEventListener('click', function(event) {
   }
 
   if (_target = event.target.closest('.listCmd')) {
-    var type = _target.getAttribute('data-type')
-    var el = _target.closest('.' + type).querySelector('.expressionAttr[data-l1key="cmd"]')
+    const type = _target.getAttribute('data-type')
+    const el = _target.closest('.' + type).querySelector('.expressionAttr[data-l1key="cmd"]')
     jeedom.cmd.getSelectModal({
       cmd: {
         type: 'action'
@@ -606,8 +606,8 @@ document.getElementById('div_conf').addEventListener('click', function(event) {
   }
 
   if (_target = event.target.closest('.listAction')) {
-    var type = _target.getAttribute('data-type')
-    var el = _target.closest('.' + type).querySelector('.expressionAttr[data-l1key="cmd"]')
+    const type = _target.getAttribute('data-type')
+    const el = _target.closest('.' + type).querySelector('.expressionAttr[data-l1key="cmd"]')
     jeedom.getSelectActionModal({}, function(result) {
       el.jeeValue(result.human)
       jeeFrontEnd.modifyWithoutSave = true
@@ -620,7 +620,7 @@ document.getElementById('div_conf').addEventListener('click', function(event) {
   }
 
   if (_target = event.target.closest('.bt_removeAction')) {
-    var type = _target.getAttribute('data-type')
+    const type = _target.getAttribute('data-type')
     _target.closest('.' + type).remove()
     jeeFrontEnd.modifyWithoutSave = true
     return
@@ -628,7 +628,7 @@ document.getElementById('div_conf').addEventListener('click', function(event) {
 })
 
 document.getElementById('div_conf').addEventListener('dblclick', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('.interactAttr[data-l1key="display"][data-l2key="icon"]')) {
     _target.remove()
     return
@@ -636,10 +636,10 @@ document.getElementById('div_conf').addEventListener('dblclick', function(event)
 })
 
 document.getElementById('div_conf').addEventListener('focusout', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('.cmdAction.expressionAttr[data-l1key="cmd"]')) {
-    var type = _target.getAttribute('data-type')
-    var expression = _target.closest('.' + type).getJeeValues('.expressionAttr')
+    const type = _target.getAttribute('data-type')
+    const expression = _target.closest('.' + type).getJeeValues('.expressionAttr')
     jeedom.cmd.displayActionOption(_target.jeeValue(), init(expression[0].options), function(html) {
       _target.closest('.' + type).querySelector('.actionOptions').html(html)
       jeedomUtils.taAutosize()

--- a/desktop/js/object.js
+++ b/desktop/js/object.js
@@ -48,7 +48,7 @@ if (!jeeFrontEnd.object) {
             return
           }
           if (isset(data.result.result.filepath)) {
-            var filePath = data.result.result.filepath
+            let filePath = data.result.result.filepath
             filePath = '/data/object/' + filePath.split('/data/object/')[1]
             document.querySelector('.objectImg').seen().querySelector('img').src = filePath
           } else {
@@ -98,9 +98,9 @@ if (!jeeFrontEnd.object) {
           }
 
           if (!isset(data.configuration.useCustomColor) || data.configuration.useCustomColor == "0") {
-            var bodyStyles = window.getComputedStyle(document.body)
-            var objectBkgdColor = bodyStyles.getPropertyValue('--objectBkgd-color')
-            var objectTxtColor = bodyStyles.getPropertyValue('--objectTxt-color')
+            const bodyStyles = window.getComputedStyle(document.body)
+            let objectBkgdColor = bodyStyles.getPropertyValue('--objectBkgd-color')
+            let objectTxtColor = bodyStyles.getPropertyValue('--objectTxt-color')
 
             if (!objectBkgdColor === undefined) {
               objectBkgdColor = jeedomUtils.rgbToHex(objectBkgdColor)
@@ -129,12 +129,12 @@ if (!jeeFrontEnd.object) {
 
           //set summary tab:
           if (isset(data.configuration) && isset(data.configuration.summary)) {
-            var el
-            var summary = data.configuration.summary
-            for (var i in summary) {
+            const el
+            const summary = data.configuration.summary
+            for (const i in summary) {
               el = document.querySelector('.type' + i)
               if (el != null) {
-                for (var j in summary[i]) {
+                for (const j in summary[i]) {
                   jeeP.addSummaryInfo('.type' + i, summary[i][j])
                 }
                 if (summary[i].length != 0) {
@@ -143,13 +143,13 @@ if (!jeeFrontEnd.object) {
               }
             }
           } else {
-            var summary = {}
+            const summary = {}
           }
 
           //set eqlogics tab:
           jeeP.addEqlogicsInfo(_id, data.name, summary)
 
-          var hash = window.location.hash
+          const hash = window.location.hash
           jeedomUtils.addOrUpdateUrl('id', data.id)
           if (hash == '') {
             document.querySelector('.nav-tabs a[data-target="#objecttab"]')?.click()
@@ -168,7 +168,7 @@ if (!jeeFrontEnd.object) {
       if (!isset(_summary)) {
         _summary = {}
       }
-      var div = '<div class="summary">'
+      let div = '<div class="summary">'
       div += '<div class="form-group">'
       div += '<label class="col-xs-1 col-sm-1 control-label hidden-xs">{{Commande}}</label>'
       div += '<div class="col-xs-12 col-sm-4 has-success">'
@@ -205,7 +205,7 @@ if (!jeeFrontEnd.object) {
           })
         },
         success: function(eqLogics) {
-          var summarySelect = '<button type="button" class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown">'
+          let summarySelect = '<button type="button" class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown">'
           summarySelect += '<i class="fas fa-tags"></i>&nbsp;&nbsp;{{Résumé(s)}}&nbsp;&nbsp;<span class="caret"></span>'
           summarySelect += '</button>'
           summarySelect += '<ul class="dropdown-menu" role="menu" style="top:unset;left:unset;height: 190px;overflow: auto;">'
@@ -216,9 +216,9 @@ if (!jeeFrontEnd.object) {
           }
           summarySelect += '</ul>'
 
-          var nbEqs = eqLogics.length
-          var thisEq, thisId, thisEqName, panel, nbCmds, ndCmdsInfo, humanName
-          for (var i = 0; i < nbEqs; i++) {
+          const nbEqs = eqLogics.length
+          let thisEq, thisId, thisEqName, panel, nbCmds, ndCmdsInfo, humanName
+          for (let i = 0; i < nbEqs; i++) {
             thisEq = eqLogics[i]
             thisId = thisEq.id
             thisEqName = thisEq.name
@@ -235,7 +235,7 @@ if (!jeeFrontEnd.object) {
 
             nbCmds = thisEq.cmds.length
             ndCmdsInfo = 0
-            for (var j = 0; j < nbCmds; j++) {
+            for (let j = 0; j < nbCmds; j++) {
               if (thisEq.cmds[j].type != 'info') continue
 
               ndCmdsInfo += 1
@@ -258,8 +258,8 @@ if (!jeeFrontEnd.object) {
           }
 
           //set select values:
-          for (var i in _summay) {
-            for (var j in _summay[i]) {
+          for (const i in _summay) {
+            for (const j in _summay[i]) {
               jeeP.updateSummaryButton(_summay[i][j].cmd, i, true)
             }
           }
@@ -267,11 +267,11 @@ if (!jeeFrontEnd.object) {
       })
     },
     updateSummaryButton: function(_cmd, _key, _state) {
-      var cmdDiv = document.querySelector('#eqLogicsCmds div[data-cmdname="' + _cmd + '"]')
+      const cmdDiv = document.querySelector('#eqLogicsCmds div[data-cmdname="' + _cmd + '"]')
       if (cmdDiv == null) return //cmd is not from this object!
       cmdDiv.querySelector('ul input[data-value="' + _key + '"]').checked = _state
-      var txtDiv = cmdDiv.querySelector('.buttontext')
-      var summaryName = jeephp2js.configObjSummary[_key].name
+      const txtDiv = cmdDiv.querySelector('.buttontext')
+      const summaryName = jeephp2js.configObjSummary[_key].name
       if (_state) {
         //add new summary:
         cmdDiv.querySelector('i').addClass('warning')
@@ -282,8 +282,8 @@ if (!jeeFrontEnd.object) {
         }
       } else {
         //remove summary:
-        var hasSummary = false
-        var newText = ''
+        let hasSummary = false
+        let newText = ''
         txtDiv.textContent = ''
         cmdDiv.querySelectorAll('ul input').forEach(_check => {
           if (_check.checked) {
@@ -305,8 +305,8 @@ if (!jeeFrontEnd.object) {
       }
     },
     updateSummaryTabNbr: function(type) {
-      var tab = document.querySelector('.summarytabnumber' + type)
-      var nbr = document.querySelector('#summarytab' + type).querySelectorAll('.summary').length
+      const tab = document.querySelector('.summarytabnumber' + type)
+      const nbr = document.querySelector('#summarytab' + type).querySelectorAll('.summary').length
       tab.empty()
       if (nbr > 0) tab.append('(' + nbr + ')')
     },
@@ -314,7 +314,7 @@ if (!jeeFrontEnd.object) {
     reOrderChilds: function(_cardId) {
       document.querySelectorAll('div.objectDisplayCard[data-father_id="' + _cardId + '"]').forEach(_card => {
         _card.parentNode.insertBefore(_card, _card.nextSibling)
-        var recId = _card.getAttribute('data-object_id')
+        const recId = _card.getAttribute('data-object_id')
         if (document.querySelector('div.objectDisplayCard[data-father_id="' + recId + '"]') != null) jeeFrontEnd.object.reOrderChilds(recId)
       })
     },
@@ -327,7 +327,7 @@ if (!jeeFrontEnd.object) {
         },
         success: function(data) {
           jeeFrontEnd.object.objectList = Array()
-          var decay
+          let decay
           data.forEach(function(object) {
             decay = object.configuration.parentNumber
             jeeFrontEnd.object.objectList.push({
@@ -342,7 +342,7 @@ if (!jeeFrontEnd.object) {
           })
 
           if (_reorder) {
-            var objectContainer = document.querySelector('#objectPanel .objectListContainer')
+            const objectContainer = document.querySelector('#objectPanel .objectListContainer')
             data.forEach(_object => {
               decay = parseInt(jeeFrontEnd.object.objectList.filter(x => x.id == _object.id)[0].parentNumber)
               objectContainer.querySelector('.objectDisplayCard[data-object_id="' + _object.id + '"] .name .hiddenAsCard').textContent = '\u00A0\u00A0\u00A0'.repeat(decay)
@@ -352,7 +352,7 @@ if (!jeeFrontEnd.object) {
       })
     },
     saveObject: function() {
-      var object = document.querySelectorAll('.object').getJeeValues('.objectAttr')[0]
+      const object = document.querySelectorAll('.object').getJeeValues('.objectAttr')[0]
       if (!isset(object.configuration)) {
         object.configuration = {}
       }
@@ -360,7 +360,7 @@ if (!jeeFrontEnd.object) {
         object.configuration.summary = {}
       }
 
-      var type, summaries, data
+      const type, summaries, data
       document.querySelectorAll('#summarytab .div_summary').forEach(function(divSummary) {
         type = divSummary.getAttribute('data-type')
         object.configuration.summary[type] = []
@@ -381,7 +381,7 @@ if (!jeeFrontEnd.object) {
         },
         success: function(data) {
           jeeFrontEnd.modifyWithoutSave = false
-          var url = 'index.php?v=d&p=object&id=' + data.id + '&saveSuccessFull=1'
+          const url = 'index.php?v=d&p=object&id=' + data.id + '&saveSuccessFull=1'
           if (window.location.hash != '') {
             url += window.location.hash
           }
@@ -400,10 +400,10 @@ try {
     selector: '.nav.nav-tabs',
     appendTo: 'div#div_pageContainer',
     build: function(trigger) {
-      var thisObjectId = document.querySelector('span.objectAttr[data-l1key="id"]').textContent
-      var contextmenuitems = {}
-      var idx = 0
-      for (var object of jeeP.objectList) {
+      const thisObjectId = document.querySelector('span.objectAttr[data-l1key="id"]').textContent
+      const contextmenuitems = {}
+      let idx = 0
+      for (const object of jeeP.objectList) {
         contextmenuitems[idx] = {
           'name': thisObjectId == object.id ? '\u3009' + object.tag : object.tag,
           'disabled': thisObjectId == object.id ? true : false,
@@ -417,7 +417,7 @@ try {
       return {
         callback: function(key, options, event) {
           if (event.ctrlKey || event.metaKey || event.which == 2) {
-            var url = 'index.php?v=d&p=object&id=' + options.commands[key].id
+            const url = 'index.php?v=d&p=object&id=' + options.commands[key].id
             if (window.location.hash != '') {
               url += window.location.hash
             }
@@ -438,13 +438,13 @@ try {
     selector: "#objectPanel .objectDisplayCard",
     appendTo: 'div#div_pageContainer',
     build: function(trigger) {
-      var thisObjectId = trigger.getAttribute('data-object_id')
-      var thisFatherId = trigger.getAttribute('data-father_id')
-      var thisName = trigger.getAttribute('data-object_name')
-      var isActive = !trigger.hasClass('inactive')
+      const thisObjectId = trigger.getAttribute('data-object_id')
+      const thisFatherId = trigger.getAttribute('data-father_id')
+      const thisName = trigger.getAttribute('data-object_name')
+      const isActive = !trigger.hasClass('inactive')
 
       //id, visible:
-      var contextmenuitems = {}
+      const contextmenuitems = {}
       contextmenuitems['thisObjectId'] = {'name': thisName + ' (id: ' + thisObjectId + ')', 'id': 'thisObjectId', 'disabled': true}
       if (isActive) {
         contextmenuitems['hide'] = {'name': '{{Rendre invisible}}', 'id': 'hide', 'icon': 'fas fa-toggle-on'}
@@ -453,7 +453,7 @@ try {
       }
 
       //configuration hideOnDashboard, hideOnOverview:
-      var thisObjectFromList = jeeP.objectList.filter(x => x.id == thisObjectId)[0]
+      const thisObjectFromList = jeeP.objectList.filter(x => x.id == thisObjectId)[0]
       if (thisObjectFromList.hideOnOverview == '0') {
         contextmenuitems['hideSynthesis'] = {'name': '{{Rendre invisible sur la Synthèse}}', 'id': 'hideSynthesis', 'icon': 'fas fa-toggle-on'}
       } else {
@@ -466,7 +466,7 @@ try {
       }
 
       //parent submenu:
-      var parentItems = {}
+      const parentItems = {}
       parentItems[0] = {
         'name': '<span class="label labelObjectHuman">None</span>',
         'disabled': (thisFatherId == '') ? true : false,
@@ -474,8 +474,8 @@ try {
         'jId': '',
         'isHtmlName': true,
       }
-      var idx = 1
-      for (var object of jeeP.objectList) {
+      let idx = 1
+      for (const object of jeeP.objectList) {
         parentItems[idx] = {
           'name': thisFatherId == object.id ? '\u3009' + object.tag : object.tag,
           'disabled': (thisObjectId == object.id) ? true : false,
@@ -491,8 +491,8 @@ try {
       }
 
       //position after submenu:
-      var afterItems = {}
-      for (var object of jeeP.objectList) {
+      const afterItems = {}
+      for (const object of jeeP.objectList) {
         afterItems[idx] = {
           'name': object.tag,
           'disabled': (thisFatherId != object.father_id || thisObjectId == object.id) ? true : false,
@@ -510,8 +510,8 @@ try {
       return {
         callback: function(key, options) {
           if (options.commands[key].jType == 'parent') {
-            var objectId = options.commands[key].jId
-            var object = {
+            const objectId = options.commands[key].jId
+            const object = {
               id: thisObjectId,
               father_id: objectId
             }
@@ -521,8 +521,8 @@ try {
                 jeedomUtils.showAlert({message: error.message, level: 'danger'})
               },
               success: function(data) {
-                var dispCard = document.querySelector('.objectDisplayCard[data-object_id="' + data.id + '"]')
-                var span = '<span class="hiddenAsCard">' + '&nbsp;&nbsp;&nbsp;'.repeat(data.configuration.parentNumber) + '</span>' + data.name
+                const dispCard = document.querySelector('.objectDisplayCard[data-object_id="' + data.id + '"]')
+                const span = '<span class="hiddenAsCard">' + '&nbsp;&nbsp;&nbsp;'.repeat(data.configuration.parentNumber) + '</span>' + data.name
                 dispCard.querySelector('.name').empty().insertAdjacentHTML('beforeend', span)
                 dispCard.setAttribute('data-father_id', objectId)
                 jeeP.getObjectList(true)
@@ -532,7 +532,7 @@ try {
           }
 
           if (options.commands[key].jType == 'after') {
-            var objectId = options.commands[key].jId
+            const objectId = options.commands[key].jId
 
             //move them so we can store them in right order and setOrder()
             let dispCard = document.querySelector('.objectDisplayCard[data-object_id="' + objectId + '"]')
@@ -541,7 +541,7 @@ try {
             document.querySelector('.objectDisplayCard[data-position="' + afterPosition + '"]').after(document.querySelector('.objectDisplayCard[data-object_id="' + thisObjectId + '"]'))
              jeeP.reOrderChilds(thisObjectId)
 
-            var objects = []
+            const objects = []
             document.querySelectorAll('div.objectDisplayCard').forEach(_card => {
               objects.push(_card.getAttribute('data-object_id'))
             })
@@ -559,7 +559,7 @@ try {
           }
 
           if (key == 'hide') {
-            var object = {
+            const object = {
               id: thisObjectId,
               isVisible: "0"
             }
@@ -576,7 +576,7 @@ try {
           }
 
           if (key == 'show') {
-            var object = {
+            const object = {
               id: thisObjectId,
               isVisible: "1"
             }
@@ -594,7 +594,7 @@ try {
 
           //hide on synthesis / dashboard:
           if (key == 'hideSynthesis') {
-            var object = {
+            const object = {
               id: thisObjectId,
               configuration: {hideOnOverview: "1"}
             }
@@ -602,7 +602,7 @@ try {
           }
 
           if (key == 'showSynthesis') {
-            var object = {
+            const object = {
               id: thisObjectId,
               configuration: {hideOnOverview: "0"}
             }
@@ -610,7 +610,7 @@ try {
           }
 
           if (key == 'hideDashboard') {
-            var object = {
+            const object = {
               id: thisObjectId,
               configuration: {hideOnDashboard: "1"}
             }
@@ -618,7 +618,7 @@ try {
           }
 
           if (key == 'showDashboard') {
-            var object = {
+            const object = {
               id: thisObjectId,
               configuration: {hideOnDashboard: "0"}
             }
@@ -643,19 +643,19 @@ try {
 
 //searching
 document.getElementById('in_searchObject')?.addEventListener('keyup', function(event) {
-  var search = event.target.value
+  let search = event.target.value
   if (search == '') {
     document.querySelectorAll('.objectDisplayCard').seen()
     return
   }
   search = jeedomUtils.normTextLower(search)
-  var not = search.startsWith(":not(")
+  const not = search.startsWith(":not(")
   if (not) {
     search = search.replace(':not(', '')
   }
 
   document.querySelectorAll('.objectDisplayCard').unseen()
-  var match, text
+  let match, text
   document.querySelectorAll('.objectDisplayCard .name').forEach(_name => {
     match = false
     text = jeedomUtils.normTextLower(_name.textContent)
@@ -673,7 +673,7 @@ document.getElementById('bt_resetObjectSearch')?.addEventListener('click', funct
 
 //eqLogics tab searching
 document.getElementById('in_searchCmds')?.addEventListener('keyup', function(event) {
-  var search = event.target.value
+  let search = event.target.value
   if (search == '') {
     document.querySelectorAll('#eqLogicsCmds .panel-collapse.in').removeClass('in')
     document.querySelectorAll('#eqLogicsCmds .form-group[data-cmdname]').seen()
@@ -683,7 +683,7 @@ document.getElementById('in_searchCmds')?.addEventListener('keyup', function(eve
   document.querySelectorAll('#eqLogicsCmds .panel-collapse.in').removeClass('in')
   document.querySelectorAll('#eqLogicsCmds .form-group[data-cmdname]').unseen()
   document.querySelectorAll('#eqLogicsCmds .panel-collapse').forEach(_panel => { _panel.setAttribute('data-show', '0') })
-  var text
+  let text
   document.querySelectorAll('#eqLogicsCmds .form-group[data-cmdname]').forEach(_eqLogic => {
     text = jeedomUtils.normTextLower(_eqLogic.getAttribute('data-cmdname'))
     if (text.indexOf(search) >= 0) {
@@ -718,7 +718,7 @@ document.registerEvent('keydown', function(event) {
 */
 //ThumbnailDisplay
 document.getElementById('div_resumeObjectList').addEventListener('click', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('#bt_addObject')) {
     jeeDialog.prompt("{{Nom du nouvel objet}} ?", function(result) {
       if (result !== null) {
@@ -756,7 +756,7 @@ document.getElementById('div_resumeObjectList').addEventListener('click', functi
   if (_target = event.target.closest('.objectDisplayCard')) {
     if (_target.closest('.objectSummaryParent') != null) return
     if ((isset(event.detail) && event.detail.ctrlKey) || event.ctrlKey || event.metaKey) {
-      var url = '/index.php?v=d&p=object&id=' + _target.getAttribute('data-object_id')
+      const url = '/index.php?v=d&p=object&id=' + _target.getAttribute('data-object_id')
       window.open(url).focus()
     } else {
       jeeP.printObject(_target.getAttribute('data-object_id'))
@@ -770,30 +770,30 @@ document.getElementById('div_resumeObjectList').addEventListener('click', functi
 
   if (_target = event.target.closest('#objectPanel .objectSummaryParent')) {
     event.stopPropagation()
-    var summaryType = _target.closest('.objectSummaryParent').getAttribute('data-summary')
-    var objectId = _target.closest('.objectDisplayCard').getAttribute('data-object_id')
+    const summaryType = _target.closest('.objectSummaryParent').getAttribute('data-summary')
+    const objectId = _target.closest('.objectDisplayCard').getAttribute('data-object_id')
     event.target.closest('.objectDisplayCard').triggerEvent('click', {detail: {summaryType: summaryType}})
     return
   }
 })
 
 document.getElementById('div_resumeObjectList').addEventListener('mousedown', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('#objectPanel .objectSummaryParent')) { //Open object summary config on summmary click
     event.stopPropagation()
-    var summaryType = _target.closest('.objectSummaryParent').getAttribute('data-summary')
-    var objectId = _target.closest('.objectDisplayCard').getAttribute('data-object_id')
+    const summaryType = _target.closest('.objectSummaryParent').getAttribute('data-summary')
+    const objectId = _target.closest('.objectDisplayCard').getAttribute('data-object_id')
     event.target.closest('.objectDisplayCard').triggerEvent('click', {detail: {summaryType: summaryType}})
     return
   }
 })
 
 document.getElementById('div_resumeObjectList').addEventListener('mouseup', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('.objectDisplayCard')) {
     if (event.which == 2) {
       event.preventDefault()
-      var id = _target.getAttribute('data-object_id')
+      const id = _target.getAttribute('data-object_id')
       document.querySelector('.objectDisplayCard[data-object_id="' + id + '"]').triggerEvent('click', {detail: {ctrlKey: true}})
     }
     return
@@ -803,7 +803,7 @@ document.getElementById('div_resumeObjectList').addEventListener('mouseup', func
 
 //Object
 document.getElementById('div_conf').addEventListener('click', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('#bt_returnToThumbnailDisplay')) {
     setTimeout(function() {
       document.querySelector('.nav li.active').removeClass('active')
@@ -858,7 +858,7 @@ document.getElementById('div_conf').addEventListener('click', function(event) {
   }
 
   if (_target = event.target.closest('#bt_chooseIcon')) {
-    var _icon = document.querySelector('div[data-l2key="icon"] > i')
+    let _icon = document.querySelector('div[data-l2key="icon"] > i')
     if (_icon != null) {
       _icon = _icon.getAttribute('class')
     } else {
@@ -974,15 +974,15 @@ document.getElementById('div_conf').addEventListener('click', function(event) {
   }
 
   if (_target = event.target.closest('.addSummary')) {
-    var type = _target.getAttribute('data-type')
+    const type = _target.getAttribute('data-type')
     jeeP.addSummaryInfo('.type' + type)
     jeeFrontEnd.modifyWithoutSave = true
     return
   }
 
   if (_target = event.target.closest('.listCmdInfo')) {
-    var el = _target.closest('.summary').querySelector('.summaryAttr[data-l1key="cmd"]')
-    var type = _target.closest('.div_summary').dataset.type
+    const el = _target.closest('.summary').querySelector('.summaryAttr[data-l1key="cmd"]')
+    const type = _target.closest('.div_summary').dataset.type
     jeedom.cmd.getSelectModal({
       object: {
         id: document.querySelector('.objectAttr[data-l1key="id"]').innerHTML
@@ -1000,8 +1000,8 @@ document.getElementById('div_conf').addEventListener('click', function(event) {
   }
 
   if (_target = event.target.closest('.bt_removeSummary')) {
-    var cmd = _target.closest('.summary').querySelector('input[data-l1key="cmd"]').values
-    var type = _target.closest('.div_summary').dataset.type
+    const cmd = _target.closest('.summary').querySelector('input[data-l1key="cmd"]').values
+    const type = _target.closest('.div_summary').dataset.type
     _target.closest('.summary').remove()
     jeeP.updateSummaryTabNbr(type)
     jeeP.updateSummaryButton(cmd, type, false)
@@ -1011,7 +1011,7 @@ document.getElementById('div_conf').addEventListener('click', function(event) {
 
   if (_target = event.target.closest('ul.dropdown-menu a')) {
     if (event.target.type == 'checkbox') return
-    var checkbox = _target.querySelector('input[type="checkbox"]')
+    const checkbox = _target.querySelector('input[type="checkbox"]')
     checkbox.checked = !checkbox.checked
     checkbox.triggerEvent('change')
     event.stopPropagation()
@@ -1020,7 +1020,7 @@ document.getElementById('div_conf').addEventListener('click', function(event) {
 })
 
 document.getElementById('div_conf').addEventListener('dblclick', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('.objectAttr[data-l1key="display"][data-l2key="icon"]')) {
     _target.closest('.objectAttr[data-l2key="icon"]').innerHTML = ''
     jeeFrontEnd.modifyWithoutSave = true
@@ -1029,7 +1029,7 @@ document.getElementById('div_conf').addEventListener('dblclick', function(event)
 })
 
 document.getElementById('div_conf').addEventListener('change', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('select[data-l2key="synthToAction"]')) {
     document.querySelectorAll('select[data-l2key="synthToView"], select[data-l2key="synthToPlan"], select[data-l2key="synthToPlan3d"]').forEach(_select => {
       _select.parentNode.addClass('hidden')
@@ -1040,14 +1040,14 @@ document.getElementById('div_conf').addEventListener('change', function(event) {
   }
 
   if (_target = event.target.closest('ul.dropdown-menu input[type="checkbox"]')) {
-    var type = _target.getAttribute('data-value')
-    var cmd = _target.closest('.form-group').getAttribute('data-cmdname')
-    var state = _target.checked
+    const type = _target.getAttribute('data-value')
+    const cmd = _target.closest('.form-group').getAttribute('data-cmdname')
+    const state = _target.checked
     jeeP.updateSummaryButton(cmd, type, state)
     jeeFrontEnd.modifyWithoutSave = true
 
-    var el = document.querySelector('.type' + type)
-    var summary = {
+    const el = document.querySelector('.type' + type)
+    const summary = {
       cmd: cmd,
       enable: "1",
       invert: "0"

--- a/desktop/js/overview.js
+++ b/desktop/js/overview.js
@@ -50,15 +50,15 @@ if (!jeeFrontEnd.overview) {
         })
       })
 
-      var targetNode = document.getElementById('objectOverviewContainer')
+      const targetNode = document.getElementById('objectOverviewContainer')
       if (targetNode) this._SummaryObserver_.observe(targetNode, this.observerConfig)
     },
     updateSummary: function(_className) {
       _className = _className.replace('objectSummaryContainer ', '')
-      var parent = document.querySelector('.' + _className).closest('.objectPreview')
+      const parent = document.querySelector('.' + _className).closest('.objectPreview')
       if (parent == null) return
       parent.querySelector('.topPreview')?.querySelectorAll('.objectSummaryParent')?.remove()
-      var pResume = parent.querySelector('.resume')
+      const pResume = parent.querySelector('.resume')
       if (pResume == null) return
       pResume.querySelectorAll('.objectSummaryParent[data-summary="temperature"], .objectSummaryParent[data-summary="motion"], .objectSummaryParent[data-summary="security"], .objectSummaryParent[data-summary="humidity"]').forEach(function(element) {
         parent.querySelector('.topPreview').appendChild(element)
@@ -70,9 +70,9 @@ if (!jeeFrontEnd.overview) {
       this.checkResumeEmpty()
     },
     checkResumeEmpty: function() {
-      var button
+      let button
       document.querySelectorAll('.objectPreview').forEach(function(element) {
-        var visibles = [...element.querySelectorAll('.objectSummaryParent')].filter(el => el.isVisible())
+        const visibles = [...element.querySelectorAll('.objectSummaryParent')].filter(el => el.isVisible())
         if (visibles.length == 0) {
           button = '<span class="bt_config"><i class="fas fa-cogs"></i></span>'
           element.querySelector('.bt_config')?.remove()
@@ -105,8 +105,8 @@ if (!jeeFrontEnd.overview) {
           jeeP.modal.querySelector('div.jeeDialogTitle > span.title').innerHTML = _title
           jeeP.modal._jeeDialog.show()
 
-          var nbEqs = data.length
-          for (var i = 0; i < nbEqs; i++) {
+          let nbEqs = data.length
+          for (let i = 0; i < nbEqs; i++) {
             if (self.summaryObjEqs[_object_id].includes(data[i].id)) {
               nbEqs--
               return
@@ -132,10 +132,10 @@ if (!jeeFrontEnd.overview) {
                 if (nbEqs == 0) {
                   //adapt modal size:
                   let bRect = document.body.getBoundingClientRect()
-                  var fullWidth = 0
-                  var fullHeight = 0
-                  var thisWidth = 0
-                  var thisHeight = 0
+                  let fullWidth = 0
+                  let fullHeight = 0
+                  let thisWidth = 0
+                  let thisHeight = 0
 
                   document.querySelectorAll('#md_overviewSummary div.eqLogic-widget').forEach(function(element) {
                     thisWidth = element.offsetWidth
@@ -165,7 +165,7 @@ if (!jeeFrontEnd.overview) {
                   })
 
                   //check is inside screen:
-                  var modalLeft = self.modal.offsetLeft
+                  const modalLeft = self.modal.offsetLeft
                   if (modalLeft + fullWidth + 26 > bRect.width || modalLeft < 5) {
                     self.modal.style.left = bRect.width - fullWidth - 50 + 'px'
                   }
@@ -195,7 +195,7 @@ jeeFrontEnd.overview.init()
 
 //move to top summary:
 document.querySelectorAll('.objectPreview').forEach(function(element) {
-  var parent = element.querySelector('.topPreview')
+  const parent = element.querySelector('.topPreview')
   element.querySelectorAll('.objectSummaryParent[data-summary="temperature"], .objectSummaryParent[data-summary="motion"], .objectSummaryParent[data-summary="security"], .objectSummaryParent[data-summary="humidity"]').forEach(function(el) {
     parent.appendChild(el)
   })
@@ -227,13 +227,13 @@ jeeP.modalContent.addEventListener('click', function(event) {
     event.stopImmediatePropagation()
     event.stopPropagation()
     if (event.ctrlKey || event.metaKey) {
-      var cmdIds = []
+      let cmdIds = []
       event.target.closest('div.eqLogic-widget').querySelectorAll('.history[data-cmd_id]').forEach(function(cmd) {
         cmdIds.push(cmd.getAttribute('data-cmd_id'))
       })
       cmdIds = cmdIds.join('-')
     } else {
-      var cmdIds = event.target.closest('.history[data-cmd_id]').getAttribute('data-cmd_id')
+      let cmdIds = event.target.closest('.history[data-cmd_id]').getAttribute('data-cmd_id')
     }
     jeeDialog.dialog({
       id: 'md_cmdHistory',
@@ -246,9 +246,9 @@ jeeP.modalContent.addEventListener('click', function(event) {
 
 //div_pageContainer events delegation:
 document.getElementById('div_pageContainer').addEventListener('click', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('.objectPreview .name')) {
-    var url = 'index.php?v=d&p=dashboard&object_id=' + _target.closest('.objectPreview').getAttribute('data-object_id') + '&btover=1'
+    const url = 'index.php?v=d&p=dashboard&object_id=' + _target.closest('.objectPreview').getAttribute('data-object_id') + '&btover=1'
     if ((isset(event.detail) && event.detail.ctrlKey) || event.ctrlKey || event.metaKey) {
       window.open(url).focus()
     } else {
@@ -263,21 +263,21 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
 
     event.stopPropagation()
     event.preventDefault()
-    var objectId = event.target.closest('.objectPreview').getAttribute('data-object_id')
-    var summaryType = _target.getAttribute('data-summary')
+    const objectId = event.target.closest('.objectPreview').getAttribute('data-object_id')
+    const summaryType = _target.getAttribute('data-summary')
 
-    var icon = _target.querySelector('i') //?.outerHTML
+    const icon = _target.querySelector('i') //?.outerHTML
     if (icon) {
-      var title = icon.outerHTML + ' ' +  _target.closest('.objectPreview').querySelector('.topPreview .name').textContent
+      let title = icon.outerHTML + ' ' +  _target.closest('.objectPreview').querySelector('.topPreview .name').textContent
     } else {
-      var title = _target.closest('.objectPreview').querySelector('.name').textContent
+      let title = _target.closest('.objectPreview').querySelector('.name').textContent
     }
     jeeP.getSummaryHtml(objectId, summaryType, title)
     return
   }
 
   if (_target = event.target.closest('.objectPreview')) {
-    var url = _target.getAttribute('data-url')
+    const url = _target.getAttribute('data-url')
     if ((isset(event.detail) && event.detail.ctrlKey) || event.ctrlKey || event.metaKey) {
       window.open(url).focus()
     } else {
@@ -287,19 +287,19 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
   }
 
   if (_target = event.target.closest('.objectPreview .bt_config')) {
-    var objectId = event.target.closest('.objectPreview').getAttribute('data-object_id')
-    var url = 'index.php?v=d&p=object&id=' + objectId + '#summarytab'
+    const objectId = event.target.closest('.objectPreview').getAttribute('data-object_id')
+    const url = 'index.php?v=d&p=object&id=' + objectId + '#summarytab'
     jeedomUtils.loadPage(url)
     return
   }
 })
 
 document.getElementById('div_pageContainer').addEventListener('mouseup', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('.objectPreview .name')) {
     if (event.which == 2) {
       event.preventDefault()
-      var id = event.target.closest('.objectPreview').getAttribute('data-object_id')
+      const id = event.target.closest('.objectPreview').getAttribute('data-object_id')
       document.querySelector('.objectPreview[data-object_id="' + id + '"] .name').triggerEvent('click', {detail: {ctrlKey: true}})
     }
     return
@@ -307,8 +307,8 @@ document.getElementById('div_pageContainer').addEventListener('mouseup', functio
 
   if (_target = event.target.closest('.objectSummaryParent')) {
     if (event.which == 2) {
-      var id = _target.getAttribute('data-object_id')
-      var url = 'index.php?v=d&p=dashboard&summary=' + _target.getAttribute('data-summary') + '&object_id=' + id + '&childs=0'
+      const id = _target.getAttribute('data-object_id')
+      const url = 'index.php?v=d&p=dashboard&summary=' + _target.getAttribute('data-summary') + '&object_id=' + id + '&childs=0'
       window.open(url).focus()
       return
     }
@@ -318,7 +318,7 @@ document.getElementById('div_pageContainer').addEventListener('mouseup', functio
     if (event.which == 2) {
       if (event.target.hasClass('topPreview') || event.target.hasClass('name')) return
       event.preventDefault()
-      var id = event.target.getAttribute('data-object_id') || event.target.closest('.objectPreview').getAttribute('data-object_id')
+      const id = event.target.getAttribute('data-object_id') || event.target.closest('.objectPreview').getAttribute('data-object_id')
       document.querySelector('.objectPreview[data-object_id="' + id + '"]').triggerEvent('click', {detail: {ctrlKey: true}})
     }
     return

--- a/desktop/js/plugin.js
+++ b/desktop/js/plugin.js
@@ -80,7 +80,7 @@ if (!jeeFrontEnd.plugin) {
           self.dom_container.querySelector('#span_plugin_name').innerHTML = data.name
 
           if (isset(data.update) && isset(data.update.localVersion)) {
-            var localVer = data.update.localVersion
+            let localVer = data.update.localVersion
             if (localVer.length > 20) localVer = localVer.substring(0, 20) + '...'
             self.dom_container.querySelector('#span_plugin_install_date').innerHTML = localVer
           } else {
@@ -141,8 +141,8 @@ if (!jeeFrontEnd.plugin) {
           }
 
           //dependencies and daemon divs:
-          var divPluginDependancy = self.dom_container.querySelector('#div_plugin_dependancy')
-          var divPluginDeamon = self.dom_container.querySelector('#div_plugin_deamon')
+          const divPluginDependancy = self.dom_container.querySelector('#div_plugin_dependancy')
+          const divPluginDeamon = self.dom_container.querySelector('#div_plugin_deamon')
           divPluginDependancy.closest('.panel').parentNode.addClass('col-md-6')
           divPluginDeamon.closest('.panel').parentNode.addClass('col-md-6')
           if (data.hasDependency == 0 || data.activate != 1) {
@@ -172,7 +172,7 @@ if (!jeeFrontEnd.plugin) {
           }
 
           //top right buttons:
-          var spanRightButton = self.dom_container.querySelector('#span_right_button')
+          const spanRightButton = self.dom_container.querySelector('#span_right_button')
           let title = '{{Rafraichir la page}}'
           let button = '<a class="btn btn-sm roundedLeft bt_refreshPluginInfo" title="' + title + '"><i class="fas fa-sync"></i><span class="hidden-768"> {{Rafraichir}}</span></a>'
           spanRightButton.empty().insertAdjacentHTML('beforeend', button)
@@ -213,7 +213,7 @@ if (!jeeFrontEnd.plugin) {
           self.dom_container.querySelector('#div_configPanel').unseen()
           self.dom_container.querySelector('#div_plugin_panel').empty()
           if (isset(data.display) && data.display != '') {
-            var config_panel_html = '<div class="form-group">'
+            let config_panel_html = '<div class="form-group">'
             config_panel_html += '<label class="col-lg-4 col-md-4 col-sm-4 col-xs-6 control-label">{{Afficher le panneau desktop}}</label>'
             config_panel_html += '<div class="col-lg-2 col-md-3 col-sm-4 col-xs-6">'
             config_panel_html += '<input type="checkbox" class="configKey tooltips" data-l1key="displayDesktopPanel" />'
@@ -224,7 +224,7 @@ if (!jeeFrontEnd.plugin) {
           }
 
           if (isset(data.mobile) && data.mobile != '') {
-            var config_panel_html = '<div class="form-group">'
+            let config_panel_html = '<div class="form-group">'
             config_panel_html += '<label class="col-lg-4 col-md-4 col-sm-4 col-xs-6 control-label">{{Afficher le panneau mobile}}</label>'
             config_panel_html += '<div class="col-lg-2 col-md-3 col-sm-4 col-xs-6">'
             config_panel_html += '<input type="checkbox" class="configKey tooltips" data-l1key="displayMobilePanel" />'
@@ -236,9 +236,9 @@ if (!jeeFrontEnd.plugin) {
 
           self.dom_container.querySelector('#div_plugin_functionality').empty()
           let count_functionality = 0
-          var config_panel_html = '<div class="row">'
+          let config_panel_html = '<div class="row">'
           config_panel_html += '<div class="col-sm-6">'
-          for (var i in data.functionality) {
+          for (const i in data.functionality) {
             config_panel_html += '<div class="form-group">'
             config_panel_html += '<label class="col-lg-3 col-md-4 col-sm-4 col-xs-6 control-label">' + i + '</label>'
             config_panel_html += '<label class="col-lg-2 col-md-2 col-sm-3 col-xs-6">'
@@ -268,7 +268,7 @@ if (!jeeFrontEnd.plugin) {
 
           self.dom_container.querySelector('#div_plugin_toggleState').empty()
           if (data.checkVersion != -1) {
-            var html = '<form class="form-horizontal"><fieldset>'
+            let html = '<form class="form-horizontal"><fieldset>'
             html += '<div class="form-group">'
             html += '<label class="col-sm-2 col-xs-6 control-label">{{Statut}}</label>'
             html += '<div class="col-sm-4 col-xs-6">'
@@ -295,8 +295,8 @@ if (!jeeFrontEnd.plugin) {
             self.dom_container.querySelector('#div_plugin_toggleState').closest('.panel').removeClass('panel-default', 'panel-success').addClass('panel-danger')
             self.dom_container.querySelector('#div_plugin_toggleState').insertAdjacentHTML('beforeend', '{{Votre version de}} ' + JEEDOM_PRODUCT_NAME + ' {{ne permet pas d\'activer ce plugin}}')
           }
-          var log_conf = ''
-          for (var i in data.logs) {
+          let log_conf = ''
+          for (const i in data.logs) {
             log_conf = '<form class="form-horizontal">'
             log_conf += '<div class="form-group">'
             log_conf += '<label class="col-sm-3 control-label">{{Niveau log}}</label>'
@@ -312,7 +312,7 @@ if (!jeeFrontEnd.plugin) {
             log_conf += '<div class="form-group">'
             log_conf += '<label class="col-sm-3 control-label">{{Logs}}</label>'
             log_conf += '<div class="col-sm-9">'
-            for (var j in data.logs[i].log) {
+            for (const j in data.logs[i].log) {
               log_conf += '<a class="btn btn-info btn-sm bt_plugin_conf_view_log" data-slaveId="' + data.logs[i].id + '" data-log="' + data.logs[i].log[j] + '"><i class="fas fa-paperclip"></i>  ' + data.logs[i].log[j].charAt(0).toUpperCase() + data.logs[i].log[j].slice(1) + '</a> '
             }
             log_conf += '</div>'
@@ -336,7 +336,7 @@ if (!jeeFrontEnd.plugin) {
           log_conf += '</form>'
 
           self.dom_container.querySelector('#div_plugin_log').empty().insertAdjacentHTML('beforeend', log_conf)
-          var dom_divPluginConfiguration = self.dom_container.querySelector('#div_plugin_configuration')
+          const dom_divPluginConfiguration = self.dom_container.querySelector('#div_plugin_configuration')
           dom_divPluginConfiguration.empty()
           if (data.checkVersion != -1) {
             if (data.configurationPath != '' && data.activate == '1') {
@@ -444,7 +444,7 @@ if (!jeeFrontEnd.plugin) {
             level: 'success'
           })
           jeeFrontEnd.modifyWithoutSave = false
-          var postSave = document.getElementById('span_plugin_id').innerHTML + '_postSaveConfiguration'
+          const postSave = document.getElementById('span_plugin_id').innerHTML + '_postSaveConfiguration'
           if (typeof window[postSave] == 'function') {
             window[postSave]()
           }
@@ -472,12 +472,12 @@ if (!jeeFrontEnd.plugin) {
       }
 
       if (_event.target.closest('.pluginDisplayCard') != null) {
-        var pluginId = _event.target.closest('.pluginDisplayCard').getAttribute('data-plugin_id')
+        const pluginId = _event.target.closest('.pluginDisplayCard').getAttribute('data-plugin_id')
       } else {
-        var pluginId = _event.target.getAttribute('data-plugin_id')
+        const pluginId = _event.target.getAttribute('data-plugin_id')
       }
 
-      var url = '/index.php?v=d&m=' + pluginId + '&p=' + pluginId
+      const url = '/index.php?v=d&m=' + pluginId + '&p=' + pluginId
       if (_aux) {
         window.open(url).focus()
       } else {
@@ -491,7 +491,7 @@ jeeFrontEnd.plugin.init()
 
 //searching:
 document.getElementById('in_searchPlugin')?.addEventListener('keyup', function(event) {
-  var search = event.target.value
+  let search = event.target.value
   if (search == '') {
     document.querySelectorAll('.pluginDisplayCard').seen()
     return
@@ -499,7 +499,7 @@ document.getElementById('in_searchPlugin')?.addEventListener('keyup', function(e
   search = jeedomUtils.normTextLower(search)
 
   document.querySelectorAll('.pluginDisplayCard').unseen()
-  var text
+  let text
   document.querySelectorAll('.pluginDisplayCard .name').forEach(_name => {
     text = jeedomUtils.normTextLower(_name.textContent)
     if (text.includes(search)) {
@@ -525,7 +525,7 @@ document.registerEvent('keydown', function(event) {
 */
 //Plugin list page:
 document.getElementById('div_resumePluginList')?.addEventListener('click', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('.pullInstall')) {
     jeedom.repo.pullInstall({
       repo: _target.getAttribute('data-repo'),
@@ -590,12 +590,12 @@ document.getElementById('div_resumePluginList')?.addEventListener('click', funct
 })
 
 document.getElementById('div_resumePluginList')?.addEventListener('mouseup', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('div.pluginDisplayCard')) {
     event.stopPropagation()
     if (event.which == 2) {
       event.preventDefault()
-      var pluginId = _target.getAttribute('data-plugin_id')
+      const pluginId = _target.getAttribute('data-plugin_id')
       document.querySelector('.pluginDisplayCard[data-plugin_id="' + pluginId + '"]').triggerEvent('click', { detail: { ctrlKey: true } })
     }
     return
@@ -614,7 +614,7 @@ document.getElementById('div_resumePluginList')?.addEventListener('mouseup', fun
 
 //Plugin configuration, page or modale:
 document.getElementById('div_confPlugin')?.addEventListener('click', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('#bt_returnToThumbnailDisplay')) {
     setTimeout(function() {
       document.querySelectorAll('.nav li.active').removeClass('active')
@@ -789,7 +789,7 @@ document.getElementById('div_confPlugin')?.addEventListener('click', function(ev
 })
 
 document.getElementById('div_confPlugin')?.addEventListener('mouseup', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('.bt_openPluginPage')) {
     if (event.which == 2) {
       event.stopPropagation()
@@ -801,7 +801,7 @@ document.getElementById('div_confPlugin')?.addEventListener('mouseup', function(
 })
 
 document.getElementById('div_confPlugin')?.addEventListener('change', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('.configKey')) {
     if (_target.isVisible()) jeeFrontEnd.modifyWithoutSave = true
     return

--- a/desktop/js/report.js
+++ b/desktop/js/report.js
@@ -33,8 +33,8 @@ if (!jeeFrontEnd.report) {
         },
         success: function(data) {
           document.querySelectorAll('#ul_report .li_report').remove()
-          var ul = '';
-          for (var i in data) {
+          let ul = '';
+          for (const i in data) {
             ul += '<li class="cursor li_report" data-type=' + _type + ' data-id=' + _id + ' data-report="' + i + '"><a>' + i + '</a></li>'
           }
           document.getElementById('ul_report').insertAdjacentHTML('beforeend', ul)
@@ -55,10 +55,10 @@ if (!jeeFrontEnd.report) {
         success: function(data) {
           document.getElementById('div_reportForm').setJeeValues(data, '.reportAttr').seen()
           document.getElementById('div_imgreport')?.empty()
-          var type = document.querySelector('#div_reportForm .reportAttr[data-l1key="type"]').jeeValue()
-          var id = document.querySelector('#div_reportForm .reportAttr[data-l1key="id"]').jeeValue()
-          var filename = document.querySelector('#div_reportForm .reportAttr[data-l1key="filename"]').jeeValue()
-          var extension =document.querySelector('#div_reportForm .reportAttr[data-l1key="extension"]').jeeValue()
+          const type = document.querySelector('#div_reportForm .reportAttr[data-l1key="type"]').jeeValue()
+          const id = document.querySelector('#div_reportForm .reportAttr[data-l1key="id"]').jeeValue()
+          const filename = document.querySelector('#div_reportForm .reportAttr[data-l1key="filename"]').jeeValue()
+          const extension =document.querySelector('#div_reportForm .reportAttr[data-l1key="extension"]').jeeValue()
           if (extension != 'pdf') {
             let img = '<img class="img-responsive" src="core/php/downloadFile.php?pathfile=data/report/' + type + '/' + id + '/' + filename + '.' + extension + '" />'
             document.getElementById('div_imgreport')?.insertAdjacentHTML('beforeend', img)
@@ -79,17 +79,17 @@ jeeFrontEnd.report.init()
 
 //Manage events outside parents delegations:
 document.getElementById('bt_download')?.addEventListener('click', function(event) {
-  var type = document.querySelector('#div_reportForm .reportAttr[data-l1key="type"]').jeeValue()
-  var id = document.querySelector('#div_reportForm .reportAttr[data-l1key="id"]').jeeValue()
-  var filename = document.querySelector('#div_reportForm .reportAttr[data-l1key="filename"]').jeeValue()
-  var extension = document.querySelector('#div_reportForm .reportAttr[data-l1key="extension"]').jeeValue()
+  const type = document.querySelector('#div_reportForm .reportAttr[data-l1key="type"]').jeeValue()
+  const id = document.querySelector('#div_reportForm .reportAttr[data-l1key="id"]').jeeValue()
+  const filename = document.querySelector('#div_reportForm .reportAttr[data-l1key="filename"]').jeeValue()
+  const extension = document.querySelector('#div_reportForm .reportAttr[data-l1key="extension"]').jeeValue()
   window.open('core/php/downloadFile.php?pathfile=data/report/' + type + '/' + id + '/' + filename + '.' + extension, "_blank", null)
 })
 
 document.getElementById('bt_remove')?.addEventListener('click', function(event) {
-  var filename = document.querySelector('#div_reportForm .reportAttr[data-l1key="filename"]').jeeValue()
-  var extension = document.querySelector('#div_reportForm .reportAttr[data-l1key="extension"]').jeeValue()
-  var report = filename + '.' + extension
+  const filename = document.querySelector('#div_reportForm .reportAttr[data-l1key="filename"]').jeeValue()
+  const extension = document.querySelector('#div_reportForm .reportAttr[data-l1key="extension"]').jeeValue()
+  const report = filename + '.' + extension
   jeedom.report.remove({
     type: document.querySelector('#div_reportForm .reportAttr[data-l1key="type"]').jeeValue(),
     id: document.querySelector('#div_reportForm .reportAttr[data-l1key="id"]').jeeValue(),
@@ -129,10 +129,10 @@ document.getElementById('bt_removeAll')?.addEventListener('click', function(even
 /*Events delegations
 */
 document.getElementById('div_pageContainer').addEventListener('click', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('.li_type')) {
-    var currentType = document.querySelector('.li_type.active').getAttribute('data-type')
-    var newType = _target.getAttribute('data-type')
+    const currentType = document.querySelector('.li_type.active').getAttribute('data-type')
+    const newType = _target.getAttribute('data-type')
     document.querySelectorAll('.li_type').removeClass('active')
     _target.addClass('active')
     document.querySelectorAll('.reportType').unseen()

--- a/desktop/js/types.js
+++ b/desktop/js/types.js
@@ -23,13 +23,13 @@ if (!jeeFrontEnd.types) {
       this.generics = jeephp2js.generics
       this.gen_families = jeephp2js.gen_families
       this.genericsByFamily = {}
-      for (var i in this.gen_families) {
+      for (const i in this.gen_families) {
         this.genericsByFamily[this.gen_families[i]] = {}
       }
       this.setQueryButtons()
     },
     setFamiliesNumber: function() {
-      var ul
+      let ul
       document.querySelectorAll('span.spanNumber').forEach(_span => {
         ul = _span.closest('.eqlogicSortable').querySelector('ul.eqLogicSortable')
         _span.textContent = ' (' + ul.querySelectorAll('li.eqLogic').length + ')'
@@ -46,11 +46,11 @@ if (!jeeFrontEnd.types) {
       })
     },
     getSelectCmd: function(_family = '', _type, _subtype, _none = true) {
-      var htmlSelect = '<select class="modalCmdGenericSelect input-xs">'
+      let htmlSelect = '<select class="modalCmdGenericSelect input-xs">'
       if (_none) htmlSelect += '<option value="">{{Aucun}}</option>'
-      for (var group in this.genericsByFamily) {
+      for (const group in this.genericsByFamily) {
         if (_family != '' && group != _family) continue
-        for (var i in this.genericsByFamily[group]) {
+        for (const i in this.genericsByFamily[group]) {
           if (this.genericsByFamily[group][i].type.toLowerCase() == _type.toLowerCase() && (this.genericsByFamily[group][i].subtype.includes(_subtype) || this.genericsByFamily[group][i].subtype.length == 0)) {
             htmlSelect += '<option value="' + this.genericsByFamily[group][i].genkey + '">' + this.genericsByFamily[group][i].name + '</option>'
           }
@@ -98,12 +98,12 @@ if (!jeeFrontEnd.types) {
         },
       })
 
-      var container = document.querySelector('#md_applyCmdsTypes .jeeDialogContent')
-      var inner = '<table class="table table-condensed">'
+      const container = document.querySelector('#md_applyCmdsTypes .jeeDialogContent')
+      let inner = '<table class="table table-condensed">'
       inner += '<td>{{Générique}}</td><td>{{Nom}}</td><td>{{Type}}</td><td>{{Sous type}}</td>'
 
-      var family, familyName, generics, generic, infos, actions
-      for (var familyId in jeeP.gen_families) {
+      let family, familyName, generics, generic, infos, actions
+      for (const familyId in jeeP.gen_families) {
         infos = []
         actions = []
         family = jeeP.gen_families[familyId]
@@ -124,13 +124,13 @@ if (!jeeFrontEnd.types) {
         infos.sort(jeeP.compareGenericName)
         actions.sort(jeeP.compareGenericName)
 
-        for (var idx in infos) {
+        for (const idx in infos) {
           generic = infos[idx]
           inner += '<tr>'
           inner += '<td>' + generic.genkey + '</td><td>' + generic.name + '</td><td class="label-info">' + generic.type + '</td><td class="label">' + generic.subtype + '</td>'//<td>' + generic.comment + '</td>'
           inner += '</tr>'
         }
-        for (var idx in actions) {
+        for (const idx in actions) {
           generic = actions[idx]
           inner += '<tr>'
           inner += '<td>' + generic.genkey + '</td><td>' + generic.name + '</td><td class="label-warning">' + generic.type + '</td><td class="label">' + generic.subtype + '</td>'//<td>' + generic.comment + '</td>'
@@ -142,19 +142,19 @@ if (!jeeFrontEnd.types) {
     },
     //Modal apply:
     queryCmdsTypes: function(_butAuto) {
-      var genFamilyId = _butAuto.closest('div.eqlogicSortable').getAttribute('data-id')
-      var genFamily = jeeP.gen_families[genFamilyId]
+      const genFamilyId = _butAuto.closest('div.eqlogicSortable').getAttribute('data-id')
+      const genFamily = jeeP.gen_families[genFamilyId]
 
       //Get selected eqLogics and all their cmd data:
-      var queryEqIds = {}
+      const queryEqIds = {}
       queryEqIds[(_butAuto.closest('li.eqLogic').getAttribute('data-id'))] = { 'cmds': [] }
       _butAuto.closest('ul.eqLogicSortable').querySelectorAll('li.eqLogic.dragSelected').forEach(_handle => {
         if (_handle.querySelector('ul.eqLogicCmds')) {
           queryEqIds[_handle.getAttribute('data-id')] = { 'cmds': [] }
         }
       })
-      var cmd
-      for (var _id in queryEqIds) {
+      let cmd
+      for (const _id in queryEqIds) {
         document.querySelectorAll('li.eqLogic[data-id="' + _id + '"] li.cmd').forEach(_cmd => {
           cmd = {}
           cmd['id'] = _cmd.getAttribute('data-id')
@@ -171,11 +171,11 @@ if (!jeeFrontEnd.types) {
       }
 
       //Iterate for each generic in this family, each eqLogic selected, each eqLogic commands:
-      var thisGen, thisCmd
+      let thisGen, thisCmd
       Object.keys(jeeP.genericsByFamily[genFamily]).forEach(key => {
         thisGen = jeeP.genericsByFamily[genFamily][key]
-        for (var _id in queryEqIds) {
-          for (var _cmd in queryEqIds[_id].cmds) {
+        for (const _id in queryEqIds) {
+          for (const _cmd in queryEqIds[_id].cmds) {
             thisCmd = queryEqIds[_id].cmds[_cmd]
             if (thisGen.type.toLowerCase() != thisCmd.type.toLowerCase()) continue
             if (thisGen.subtype.length > 0 && !thisGen.subtype.includes(thisCmd.subtype)) continue
@@ -185,9 +185,9 @@ if (!jeeFrontEnd.types) {
       })
 
       //Find something in possibilities ...
-      var thisPoss, match
-      for (var _id in queryEqIds) {
-        for (var _cmd in queryEqIds[_id].cmds) {
+      let thisPoss, match
+      for (const _id in queryEqIds) {
+        for (const _cmd in queryEqIds[_id].cmds) {
           thisCmd = queryEqIds[_id].cmds[_cmd]
           if (thisCmd.possibilities.length == 0) continue
           if (thisCmd.possibilities.length == 1) {
@@ -195,7 +195,7 @@ if (!jeeFrontEnd.types) {
             thisCmd.queryGenericName = thisCmd.possibilities[0].name
             continue
           }
-          for (var poss in thisCmd.possibilities) {
+          for (const poss in thisCmd.possibilities) {
             thisPoss = thisCmd.possibilities[poss]
             match = false
 
@@ -247,15 +247,15 @@ if (!jeeFrontEnd.types) {
         },
       })
 
-      var container = document.querySelector('#md_applyCmdsTypes .jeeDialogContent')
+      const container = document.querySelector('#md_applyCmdsTypes .jeeDialogContent')
       container.setAttribute('data-generic', genFamilyId)
-      var inner = '<br/>'
-      var eqName, cmdName, thisCmd, thisClass, select
-      for (var _id in queryEqIds) {
+      let inner = '<br/>'
+      let eqName, cmdName, thisCmd, thisClass, select
+      for (const _id in queryEqIds) {
         inner += '<div class="queryEq" data-id="' + _id + '">'
         eqName = document.querySelector('li.eqLogic[data-id="' + _id + '"]').getAttribute('data-name')
         inner += '<div class="center biggerText">' + eqName + '</div>'
-        for (var _cmd in queryEqIds[_id].cmds) {
+        for (const _cmd in queryEqIds[_id].cmds) {
           thisCmd = queryEqIds[_id].cmds[_cmd]
           // console.log(thisCmd)
           cmdName = document.querySelector('li.cmd[data-id="' + thisCmd.id + '"]').getAttribute('data-name')
@@ -281,9 +281,9 @@ if (!jeeFrontEnd.types) {
 
     },
     applyModalGeneric: function() {
-      var container = document.querySelector('#md_applyCmdsTypes .jeeDialogContent')
-      var genFamilyId = container.getAttribute('data-generic')
-      var cmd, select, genericName
+      const container = document.querySelector('#md_applyCmdsTypes .jeeDialogContent')
+      const genFamilyId = container.getAttribute('data-generic')
+      let cmd, select, genericName
       container.querySelectorAll('.queryCmd').forEach(_queryCmd => {
         if (_queryCmd.querySelector('.cb_selCmd').checked) {
           select = _queryCmd.querySelector('.modalCmdGenericSelect')
@@ -302,8 +302,8 @@ if (!jeeFrontEnd.types) {
     },
     //Save:
     saveGenericTypes: function() {
-      var eqLogics = []
-      var eqGeneric
+      const eqLogics = []
+      const eqGeneric
       document.querySelectorAll('.eqlogicSortable').forEach(_listEqlogic => {
         eqGeneric = _listEqlogic.getAttribute('data-id')
         if (eqGeneric == 'none') {
@@ -332,7 +332,7 @@ if (!jeeFrontEnd.types) {
       }
 
       //save cmds:
-      var cmds = []
+      const cmds = []
       document.querySelectorAll('li.cmd').forEach(_cmd => {
         if (_cmd.getAttribute('data-changed') == '0') return true
         cmds.push({
@@ -385,7 +385,7 @@ if (!jeeFrontEnd.types) {
 jeeFrontEnd.types.init()
 
 //Sortable:
-var sortLists = document.getElementById('genericsContainer').querySelectorAll('.eqLogicSortable')
+const sortLists = document.getElementById('genericsContainer').querySelectorAll('.eqLogicSortable')
 sortLists.forEach(_group => {
   new Sortable(_group, {
     group: {
@@ -446,22 +446,22 @@ new jeeCtxMenu({
   appendTo: 'div#div_pageContainer',
   build: function(trigger) {
     trigger.addClass('hover')
-    var eqGeneric = trigger.closest('.eqlogicSortable').getAttribute('data-id')
-    var cmdId = trigger.getAttribute('data-id')
-    var cmdType = trigger.getAttribute('data-type')
-    var cmdSubType = trigger.getAttribute('data-subType')
+    const eqGeneric = trigger.closest('.eqlogicSortable').getAttribute('data-id')
+    const cmdId = trigger.getAttribute('data-id')
+    const cmdType = trigger.getAttribute('data-type')
+    const cmdSubType = trigger.getAttribute('data-subType')
 
-    var contextmenuitems = {}
+    const contextmenuitems = {}
     if (trigger.getAttribute('data-generic')) {
       contextmenuitems['deleteme'] = { 'name': '{{Supprimer}}', 'id': 'delete_me' }
       contextmenuitems['sep1'] = "---------"
     }
 
-    var items
-    var uniqId = 0
-    for (var group in jeeP.genericsByFamily) {
+    let items
+    let uniqId = 0
+    for (const group in jeeP.genericsByFamily) {
       items = {}
-      for (var i in jeeP.genericsByFamily[group]) {
+      for (const i in jeeP.genericsByFamily[group]) {
         if (jeeP.genericsByFamily[group][i].type.toLowerCase() == cmdType.toLowerCase() && (jeeP.genericsByFamily[group][i].subtype.includes(cmdSubType) || jeeP.genericsByFamily[group][i].subtype.length == 0)) {
           items[uniqId] = {
             //'name': '<span title="'+jeeP.genericsByFamily[group][i].comment+'">'+jeeP.genericsByFamily[group][i].name+'</span>',
@@ -491,7 +491,7 @@ new jeeCtxMenu({
           document.querySelector('li.cmd[data-id="' + cmdId + '"]').setAttribute('data-generic', '')
         } else {
           //var text = options.commands[key].id.split('::')[0] + jeephp2js.typeStringSep + options.commands[key].node.innerText
-          var text = options.commands[key].id.split('::')[0] + jeephp2js.typeStringSep + options.commands[key].name
+          const text = options.commands[key].id.split('::')[0] + jeephp2js.typeStringSep + options.commands[key].name
           document.querySelector('li.cmd[data-id="' + cmdId + '"] .genericType').textContent = text
           document.querySelector('li.cmd[data-id="' + cmdId + '"]').setAttribute('data-generic', options.commands[key].id.split('::')[1])
         }
@@ -514,16 +514,16 @@ new jeeCtxMenu({
   appendTo: 'div#div_pageContainer',
   build: function(trigger) {
     trigger.addClass('hover')
-    var eqGeneric = trigger.closest('.eqlogicSortable').getAttribute('data-id')
-    var eqIds = [trigger.getAttribute('data-id')]
+    const eqGeneric = trigger.closest('.eqlogicSortable').getAttribute('data-id')
+    let eqIds = [trigger.getAttribute('data-id')]
     trigger.closest('ul.eqLogicSortable').querySelectorAll('li.eqLogic.dragSelected').forEach(_hdl => {
       eqIds.push(_hdl.getAttribute('data-id'))
     })
     eqIds = [...new Set(eqIds)]
 
-    var contextmenuitems = {}
+    const contextmenuitems = {}
     contextmenuitems['none'] = { 'name': '{{Aucun}}', 'id': 'none' }
-    for (var group in jeeP.gen_families) {
+    for (const group in jeeP.gen_families) {
       contextmenuitems[group] = {
         'name': jeeP.gen_families[group],
         'id': group
@@ -532,10 +532,10 @@ new jeeCtxMenu({
 
     return {
       callback: function(key, options) {
-        var dataGeneric = options.commands[key].id
+        let dataGeneric = options.commands[key].id
         if (dataGeneric == 'none') dataGeneric = ''
-        var eqLogics = []
-        for (var idx in eqIds) {
+        const eqLogics = []
+        for (const idx in eqIds) {
           let eqlogic = document.querySelector('li.eqLogic[data-id="' + eqIds[idx] + '"]')
           eqLogics.push(eqlogic)
           eqlogic.setAttribute('data-generic', dataGeneric)
@@ -563,8 +563,8 @@ new jeeCtxMenu({
 //searching:
 document.getElementById('in_searchTypes')?.addEventListener('keyup', function(event) {
   try {
-    var search = this.value
-    var searchID = search
+    let search = this.value
+    let searchID = search
     if (isNaN(search)) searchID = false
 
     document.querySelectorAll('#genericsContainer .accordion-toggle').forEach(_panel => { _panel.setAttribute('data-show', 0) })
@@ -577,8 +577,8 @@ document.getElementById('in_searchTypes')?.addEventListener('keyup', function(ev
     }
 
     search = jeedomUtils.normTextLower(search)
-    var eqParent, eqId
-    var eqName, type, category
+    let eqParent, eqId
+    let eqName, type, category
     document.querySelectorAll('.eqLogic').forEach(_eqlogic => {
       eqParent = _eqlogic.closest('.panel.panel-default')
       if (searchID) {
@@ -610,7 +610,7 @@ document.getElementById('in_searchTypes')?.addEventListener('keyup', function(ev
 /*Events delegations
 */
 document.getElementById('div_pageContainer').addEventListener('click', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('#bt_openAll')) {
     document.querySelectorAll('#genericsContainer .accordion-toggle.collapsed').forEach(_panel => { _panel.click() })
     if (event.ctrlKey || event.metaKey) {
@@ -640,7 +640,7 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
 
   if ((_target = event.target.matches('li.eqLogic') || (_target = event.target.matches('li.eqLogic span.eqName')))) {
     _target = event.target.closest('li.eqLogic')
-    var el = _target.querySelector('ul.eqLogicCmds')
+    const el = _target.querySelector('ul.eqLogicCmds')
     if (el?.isVisible()) {
       el?.unseen()
     } else {
@@ -650,7 +650,7 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
   }
 
   if (_target = event.target.closest('.bt_resetCmdsTypes')) {
-    var eqLogics = []
+    const eqLogics = []
     _target.closest('ul.eqLogicSortable').querySelectorAll('li.eqLogic').forEach(_handle => {
       if (_handle.hasClass('dragSelected') || _handle == _target.closest('li.eqLogic')) {
         eqLogics.push(_handle)
@@ -666,7 +666,7 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
   }
 
   if (_target = event.target.closest('.cb_selCmd')) {
-    var state = _target.checked
+    const state = _target.checked
     if (event.ctrlKey) {
       _target.closest('.queryEq').querySelectorAll('.cb_selCmd').forEach(_selCmd => {
         _selCmd.checked = state

--- a/desktop/js/view.js
+++ b/desktop/js/view.js
@@ -60,8 +60,8 @@ if (!jeeFrontEnd.view) {
           }
 
           try {
-            var summary = ''
-            for (var i in html.raw.viewZone) {
+            let summary = ''
+            for (const i in html.raw.viewZone) {
               summary += '<li style="padding:0px 0px"><a style="padding:2px 20px" class="cursor bt_gotoViewZone" data-zone_id="' + html.raw.viewZone[i].id + '">' + html.raw.viewZone[i].name + '</a></li>'
             }
             document.getElementById('ul_viewSummary').empty().insertAdjacentHTML('beforeend', summary)
@@ -80,7 +80,7 @@ if (!jeeFrontEnd.view) {
             jeedomUtils.positionEqLogic()
 
             document.querySelectorAll('div.eqLogicZone').forEach(_zone => {
-              var pckry = new Packery(_zone, {
+              const pckry = new Packery(_zone, {
                 isLayoutInstant: true,
                 transitionDuration: 0,
             })
@@ -100,10 +100,10 @@ if (!jeeFrontEnd.view) {
           //draw graphs:
           document.querySelectorAll('.chartToDraw').forEach(_chart => {
             _chart.querySelectorAll('.viewZoneData').forEach(_zone => {
-              var cmdId = _zone.getAttribute('data-cmdid')
-              var el = _zone.getAttribute('data-el')
-              var options = json_decode(_zone.getAttribute('data-option').replace(/'/g, '"'))
-              var height = _zone.getAttribute('data-height')
+              const cmdId = _zone.getAttribute('data-cmdid')
+              const el = _zone.getAttribute('data-el')
+              const options = json_decode(_zone.getAttribute('data-option').replace(/'/g, '"'))
+              const height = _zone.getAttribute('data-height')
               jeedom.history.drawChart({
                 cmd_id: cmdId,
                 el: el,
@@ -137,7 +137,7 @@ if (!jeeFrontEnd.view) {
         }
         return
       }
-      var divEquipements = document.querySelector('div.div_displayView')
+      const divEquipements = document.querySelector('div.div_displayView')
       if (_mode == 0 || _mode == '0') { //Exit edit mode:
         jeeFrontEnd.modifyWithoutSave = false
         jeedomUI.isEditing = false
@@ -168,10 +168,10 @@ if (!jeeFrontEnd.view) {
         if (jeeFrontEnd.view.draggables.length == 0) {
           //No draggies set yet:
           document.querySelectorAll('div.eqLogicZone').forEach(_divObject => {
-            var pckry = Packery.data(_divObject)
+            const pckry = Packery.data(_divObject)
             pckry.getItemElements().forEach(function(itemElem, idx) {
               itemElem.setAttribute('data-vieworder', idx + 1)
-              var draggie = new Draggabilly(itemElem)
+              const draggie = new Draggabilly(itemElem)
               jeeFrontEnd.view.draggables.push(draggie)
               pckry.bindDraggabillyEvents(draggie)
 
@@ -193,7 +193,7 @@ if (!jeeFrontEnd.view) {
         }
 
         //show orders:
-        var value
+        let value
         divEquipements.querySelectorAll('.jeedomAlreadyPosition').forEach(_draggable => {
           value = _draggable.getAttribute('data-vieworder')
           if (_draggable.querySelector(".counterReorderJeedom") != null) {
@@ -236,7 +236,7 @@ jeeFrontEnd.view.init()
 
 //Event for App Mobile:
 document.body.addEventListener('jeeObject::summary::update', function(_event) {
-  for (var i in _event.detail) {
+  for (const i in _event.detail) {
     if(isset(_event.detail[i].force) && _event.detail[i].force == 1) continue
     if(_event.detail[i].object_id == 'global') {
       /* SEND UPDATE SUMMARY TO APP */
@@ -254,7 +254,7 @@ window.registerEvent("resize", function view(event) {
 /*Events delegations
 */
 document.getElementById('div_pageContainer').addEventListener('click', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('#bt_editViewWidgetOrder')) {
     if (_target.getAttribute('data-mode') == '1') {
       document.getElementById('md_dashEdit')?.remove()
@@ -297,7 +297,7 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
   }
 
   if (_target = event.target.closest('.editOptions')) {
-    var eqId = _target.closest('div.eqLogic-widget').getAttribute('data-eqlogic_id')
+    const eqId = _target.closest('div.eqLogic-widget').getAttribute('data-eqlogic_id')
     jeeDialog.dialog({
       id: 'md_dashEdit',
       width: '600px',

--- a/desktop/js/view_edit.js
+++ b/desktop/js/view_edit.js
@@ -45,9 +45,9 @@ if (!jeeFrontEnd.view_edit) {
     },
     saveView: function(_viewResult) {
       jeedomUtils.hideAlert()
-      var view = document.getElementById('div_view').getJeeValues('.viewAttr')[0]
+      const view = document.getElementById('div_view').getJeeValues('.viewAttr')[0]
       view.zones = []
-      var viewZoneInfo, line, col
+      let viewZoneInfo, line, col
       document.querySelectorAll('.viewZone').forEach(function(_viewZone) {
         viewZoneInfo = _viewZone.getJeeValues('.viewZoneAttr')[0]
         if (viewZoneInfo.type == 'table') {
@@ -101,8 +101,8 @@ if (!jeeFrontEnd.view_edit) {
         _viewZone.configuration = {};
       }
       if (init(_viewZone.emplacement) == '') {
-        var id = document.querySelectorAll('#div_viewZones .viewZone').length
-        var div = '<div class="viewZone" id="div_viewZone' + id + '">'
+        const id = document.querySelectorAll('#div_viewZones .viewZone').length
+        let div = '<div class="viewZone" id="div_viewZone' + id + '">'
         div += '<legend><span class="viewZoneAttr" data-l1key="name"></span><span class="small viewtype"></span>'
         div += '<div class="input-group pull-right" style="display:inline-flex">'
         div += '<span class="input-group-btn" style="width: 100%;">'
@@ -167,15 +167,15 @@ if (!jeeFrontEnd.view_edit) {
           div += '<thead>'
           div += '<tr>'
           div += '<td></td>'
-          for (var i = 0; i < _viewZone.configuration.nbcol; i++) {
+          for (let i = 0; i < _viewZone.configuration.nbcol; i++) {
             div += '<td><a class="btn btn-danger bt_removeAddViewTable" data-type="col"><i class="far fa-trash-alt"></a></td>'
           }
           div += '</thead>'
           div += '<tbody>'
-          for (var j = 0; j < _viewZone.configuration.nbline; j++) {
+          for (let j = 0; j < _viewZone.configuration.nbline; j++) {
             div += '<tr class="viewData">';
             div += '<td><a class="btn btn-danger bt_removeAddViewTable" data-type="line"><i class="far fa-trash-alt"></a></td>'
-            for (var i = 0; i < _viewZone.configuration.nbcol; i++) {
+            for (let i = 0; i < _viewZone.configuration.nbcol; i++) {
               div += '<td>'
               div += '<div class="input-group">'
               div += '<input class="form-control viewDataAttr roundedLeft" data-l1key="configuration" data-l2key="' + j + '" data-l3key="' + i + '" />'
@@ -221,7 +221,7 @@ if (!jeeFrontEnd.view_edit) {
       if (!isset(_viewData.configuration) || _viewData.configuration == '') {
         _viewData.configuration = {}
       }
-      var tr = '<tr>'
+      let tr = '<tr>'
       tr += '<td><i class="far fa-trash-alt cursor bt_removeViewData"></i></td>'
 
       tr += '<td>'
@@ -314,7 +314,7 @@ if (!jeeFrontEnd.view_edit) {
       if (!isset(_viewData.configuration) || _viewData.configuration == '') {
         _viewData.configuration = {}
       }
-      var tr = '<tr>'
+      let tr = '<tr>'
       tr += '<td><i class="far fa-trash-alt cursor bt_removeViewData"></i></td>'
       tr += '<td>'
       tr += '<input class="viewDataAttr" data-l1key="link_id" style="display  : none;"/>'
@@ -347,12 +347,12 @@ if (!jeeFrontEnd.view_edit) {
           jeedomUtils.addOrUpdateUrl('view_id', data.id)
           document.querySelectorAll('#div_viewZones').empty()
           document.getElementById('div_view').setJeeValues(data, '.viewAttr')
-          var viewZone
-          for (var i in data.viewZone) {
+          const viewZone
+          for (const i in data.viewZone) {
             viewZone = data.viewZone[i]
             jeeP.addEditviewZone(viewZone)
-            for (var j in viewZone.viewData) {
-              var viewData = viewZone.viewData[j]
+            for (const j in viewZone.viewData) {
+              const viewData = viewZone.viewData[j]
               if (init(viewZone.type, 'widget') == 'graph') {
                 document.querySelectorAll('#div_viewZones .viewZone').last().querySelector('.div_viewData tbody').appendChild(jeeP.addGraphService(viewData))
               } else if (init(viewZone.type, 'widget') == 'table') {
@@ -385,7 +385,7 @@ Sortable.create(document.getElementById('ul_view'), {
   handle: 'i.fa-arrows-alt-v',
   removeCloneOnHide: true,
   onEnd: function (event) {
-    var views = []
+    const views = []
     document.querySelectorAll('#ul_view .li_view').forEach(_li => {
       views.push(_li.getAttribute('data-view_id'))
     })
@@ -426,7 +426,7 @@ document.registerEvent('keydown', function(event) {
 /*Events delegations
 */
 document.getElementById('div_pageContainer').addEventListener('click', function(event) {
-  var _target = null
+  let _target = null
   //General ->
   if (_target = event.target.closest('#bt_viewResult')) {
     jeeP.saveView(true)
@@ -529,7 +529,7 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
             })
             return
           }
-          var viewZone = {
+          const viewZone = {
             name: result.name,
             emplacement: '',
             type: result.type
@@ -577,7 +577,7 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
             })
             return
           }
-          var viewZone = {
+          const viewZone = {
             name: result.name,
             emplacement: result.emplacement,
             type: result.type
@@ -701,7 +701,7 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
 })
 
 document.getElementById('div_pageContainer').addEventListener('change', function(event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('.viewZoneAttr')) {
     if (_target.isVisible()) jeeFrontEnd.modifyWithoutSave = true
   }


### PR DESCRIPTION
## Problem

All 34 catch blocks in `core/js/jeedom.class.js` use the pattern:

```js
(_params?.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
```

If `jeedom.private` is undefined (e.g. `private.class.js` fails to load), the catch block itself throws a **second uncaught TypeError**:
> `Cannot read properties of undefined (reading 'default_params')`

This is especially critical for the **16 functions with `paramsRequired = []`** (`jeedom.version`, `jeedom.changes`, `jeedom.backup`, etc.): their `try` block can **only** throw if `jeedom.private` is itself undefined — meaning their catch block is guaranteed to fail in that scenario, swallowing the real error and emitting a confusing one instead.

Reported at: `core/js/jeedom.class.js:963` — `jeedom.version` catch block.

## Fix

Use optional chaining to make the catch block resilient:

```js
(_params?.error || paramsSpecifics.error || jeedom.private?.default_params?.error || console.error)(e)
```

- `jeedom.private?.default_params?.error` — safely returns `undefined` if `jeedom.private` is not yet defined
- `|| console.error` — fallback so the original error is never silently lost
- `_params?.error` — defensive guard in case the function is called without arguments

Applied to all **34 catch blocks** (1 in `jeedom.changes`, 33 in other API functions).

## Testing

- Dashboard, widgets (`jeedom.version()` call), backup, administration pages tested
- No `Uncaught TypeError` in console on any page
- Normal AJAX flows unaffected (optional chaining only activates on the `undefined` path)