### PR TITLE
chore: ignore .claude settings directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ Thumbs.db
 .DS_Store
 .buildpath
 .vscode
+.claude
 ui
 
 test.php


### PR DESCRIPTION
Add `.claude` to `.gitignore` to prevent Claude Code local settings and session files from being accidentally committed to the repository.