### PR TITLE
fix: resolve TDZ ReferenceError for 'wg' in widgets.js

### DIFF
--- a/desktop/js/widgets.js
+++ b/desktop/js/widgets.js
@@ -368,6 +368,7 @@ try {
       const widgetsList = []
       widgetsList['info'] = []
       widgetsList['action'] = []
+      let groupWidgets, items, wg, wgName, wgId
       for (let i = 0; i < _widgets.length; i++) {
         wg = _widgets[i]
         if (wg.type == 'info') widgetsList['info'].push([wg.name, wg.id])
@@ -377,7 +378,6 @@ try {
       //set context menu!
       const contextmenuitems = {}
       let uniqId = 0
-      let groupWidgets, items, wg, wgName, wgId
       for (const group in widgetsList) {
         groupWidgets = widgetsList[group]
         items = {}


### PR DESCRIPTION
## Summary

- Move the `let groupWidgets, items, wg, wgName, wgId` declaration before the first `for` loop in `desktop/js/widgets.js`
- In strict mode (`"use strict"`), accessing a `let` variable before its declaration in the same block scope throws a `ReferenceError` (Temporal Dead Zone). `wg` was used at line 372 but declared at line 380, causing the widgets page to be inaccessible.

## Error

<img width="406" height="76" alt="image" src="https://github.com/user-attachments/assets/5153f7bf-c55c-452b-89b8-2dc1a8e41b0b" />

