### PR TITLE
fix (update center): remove stale config keys and fix misleading badge when switching plugin source

### DIFF
--- a/core/ajax/repo.ajax.php
+++ b/core/ajax/repo.ajax.php
@@ -65,7 +65,23 @@ try {
 		if ($update->getConfiguration('doNotUpdate') == 1) {
 			throw new Exception(__('Mise à jour et réinstallation désactivées sur ', __FILE__) . ' ' . $repo->getLogicalId());
 		}
-		$update->setSource(init('repo'));
+		// Purge configuration keys not belonging to the new source to avoid orphaned data.
+		$newSource = init('repo');
+		$allSourceKeys = [
+			'market' => ['market'],
+			'github' => ['user', 'repository', 'token'],
+			'url'    => ['url'],
+			'samba'  => ['path'],
+			'file'   => ['path'],
+		];
+		$keysToKeep = $allSourceKeys[$newSource] ?? [];
+		foreach ($allSourceKeys as $source => $sourceKeys) {
+			if ($source === $newSource) continue;
+			foreach (array_diff($sourceKeys, $keysToKeep) as $key) {
+				$update->setConfiguration($key, null);
+			}
+		}
+		$update->setSource($newSource);
 		$update->setLogicalId($repo->getLogicalId());
 		$update->setType($repo->getType());
 		$update->setLocalVersion($repo->getDatetime(init('version', 'stable')));

--- a/core/ajax/update.ajax.php
+++ b/core/ajax/update.ajax.php
@@ -149,6 +149,22 @@ try {
 		}
 		$old_update = $update;
 		utils::a2o($update, $update_json);
+		// Purge configuration keys not belonging to the new source to avoid orphaned data.
+		$newSource = $update->getSource();
+		$allSourceKeys = [
+			'market' => ['market'],
+			'github' => ['user', 'repository', 'token'],
+			'url'    => ['url'],
+			'samba'  => ['path'],
+			'file'   => ['path'],
+		];
+		$keysToKeep = $allSourceKeys[$newSource] ?? [];
+		foreach ($allSourceKeys as $source => $sourceKeys) {
+			if ($source === $newSource) continue;
+			foreach (array_diff($sourceKeys, $keysToKeep) as $key) {
+				$update->setConfiguration($key, null);
+			}
+		}
 		$update->save();
 		try {
 			$update->doUpdate();

--- a/core/php/jeecli.php
+++ b/core/php/jeecli.php
@@ -53,6 +53,10 @@ switch ($argv[1]) {
                     if (!is_object($update)) {
                         $update = new update();
                     }
+                    // Purge configuration keys not belonging to market source to avoid orphaned data.
+                    foreach (['user', 'repository', 'token', 'url', 'path'] as $key) {
+                        $update->setConfiguration($key, null);
+                    }
                     $update->setLogicalId($argv[3]);
                     $update->setSource('market');
                     $update->setConfiguration('version', 'stable');

--- a/core/repo/market.repo.php
+++ b/core/repo/market.repo.php
@@ -139,12 +139,15 @@ class repo_market {
 				if (!is_object($update)) {
 					$update = new update();
 				}
+				// Purge configuration keys not belonging to market source to avoid orphaned data.
+				foreach (['user', 'repository', 'token', 'url', 'path'] as $key) {
+					$update->setConfiguration($key, null);
+				}
 				$update->setSource('market');
 				$update->setLogicalId($repo->getLogicalId());
 				$update->setType($repo->getType());
 				$update->setLocalVersion($repo->getDatetime($plugin['version']));
 				$update->setConfiguration('version', $plugin['version']);
-				$update->setConfiguration('user', null);
 				$update->save();
 				$update->doUpdate();
 				$nbInstall++;

--- a/desktop/js/update.js
+++ b/desktop/js/update.js
@@ -237,8 +237,8 @@ if (!jeeFrontEnd.update) {
             default:
               updClass = 'label-danger'
           }
-          if (typeof _update.configuration.user!== 'undefined'){
-            tr += ' <span class="label ' + updClass + ' hidden-992">' + _update.configuration.version +' - '+ _update.configuration.user + '</span>'
+          if (typeof _update.configuration.user !== 'undefined' && _update.source !== 'market') {
+            tr += ' <span class="label ' + updClass + ' hidden-992">' + _update.configuration.version + ' - ' + _update.configuration.user + '</span>'
           } else {
             tr += ' <span class="label ' + updClass + ' hidden-992">' + _update.configuration.version + '</span>'
           }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

<!--
Please target the `beta` branch when submitting your pull request, unless your change **only** applies to Jeedom 4.x.
-->

## Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
-->

### Problem

When a plugin is switched from one source to another (e.g. GitHub → Market), the
configuration keys specific to the previous source (`user`, `repository`, `token` for GitHub;
`market` for Market, etc.) are never removed from the database. They become orphaned data.

Example of configuration persisted in DB after switching from GitHub to Market:

```json
{"version":"beta","market":1,"doNotUpdate":"0","user":"TiTidom-RC","repository":"Discordlink","token":""}
```

while `source = 'market'`.

Visible consequence: the Update Center displays `beta - TiTidom-RC` for a plugin now managed
by the Market, because the JS renders the `version - user` badge whenever the `user` key
exists in the configuration, without checking `source`.

---

### Fix 1 — `core/ajax/update.ajax.php`

In the `save` action, purge all configuration keys not belonging to the new source after
`utils::a2o()` merges the submitted data. `array_diff` ensures that keys shared between
sources (e.g. `path` for both `samba` and `file`) are never purged on a transition between
those two sources. Shared keys (`version`, `doNotUpdate`) are never affected. This also
cleans up any pre-existing orphaned data from multi-hop transitions (e.g. GitHub → URL →
Market, where only `url` would have been purged with a source-comparison approach).

### Fix 1b — `core/ajax/repo.ajax.php` (install button from Market / repo store)

The `install` action sets the new source but never purged the old source's exclusive keys
either. Same purge logic applied here, before `setSource()`, covering the case where a plugin
previously added via GitHub is reinstalled directly from the Market store UI.

### Fix 1c — `core/repo/market.repo.php` (`pullInstall()`)

`pullInstall()` installs plugins pushed automatically from the Market but only nullified `user`,
leaving `repository`, `token`, `url`, and `path` as potential orphaned data. Full purge of
all non-market keys applied before `setSource('market')`.

### Fix 1d — `core/php/jeecli.php` (CLI `plugin install` without `--user`/`--repository`)

The `plugin install <id>` branch without GitHub arguments sets `source = 'market'` but never
purged any prior source keys. Same full purge applied.

### Fix 2 — `desktop/js/update.js`

Guard the `version - user` badge display with `_update.source !== 'market'`. This fixes the
visual for all existing installations that already have orphaned data in DB, without requiring
any reconfiguration.

---

### Tested transitions

| From | To | Keys purged | Covered by |
|------|----|-------------|------------|
| `github` | `market` | `user`, `repository`, `token` | Fix 1 + Fix 1b + Fix 1c + Fix 1d |
| `market` | `github` | `market` | Fix 1 + Fix 1b |
| `github` | `url` | `user`, `repository`, `token` | Fix 1 + Fix 1b |
| `samba` | `file` | *(none — `path` is shared)* | Fix 1 + Fix 1b |
| `url` | `github` | `url` | Fix 1 + Fix 1b |
| `github` → `url` → `market` *(multi-hop)* | `market` | `user`, `repository`, `token`, `url` | Fix 1 + Fix 1b |
| New install (no prior record) | any | *(none — purge is inoffensive on empty config)* | Fix 1b + Fix 1c + Fix 1d |

### Suggested changelog entry
<!-- Please provide a short description of the change for the changelog. -->

Amélioration de la gestion des clés liées à une source spécifique pour un plugin, ainsi que l'affichage dans le centre de mise à jour.

### Related issues/external references

Fixes #


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [x] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
