### PR TITLE
Fix & improvement: add safe guard in scenario in "for" loop, "wait" & "sleep" actions

### DIFF
--- a/core/class/config.class.php
+++ b/core/class/config.class.php
@@ -44,7 +44,9 @@ class config {
 
 			if (file_exists(__DIR__ . '/../../data/custom/custom.config.ini')) {
 				$custom =  parse_ini_file(__DIR__ . '/../../data/custom/custom.config.ini', true);
-				self::$defaultConfiguration[$_plugin]['core'] = array_merge(self::$defaultConfiguration[$_plugin]['core'], $custom['core']);
+				if ($custom !== false && isset($custom['core'])) {
+					self::$defaultConfiguration[$_plugin]['core'] = array_merge(self::$defaultConfiguration[$_plugin]['core'], $custom['core']);
+				}
 			}
 		} else {
 			self::$defaultConfiguration[$_plugin] = array();

--- a/core/class/config.class.php
+++ b/core/class/config.class.php
@@ -44,7 +44,7 @@ class config {
 
 			if (file_exists(__DIR__ . '/../../data/custom/custom.config.ini')) {
 				$custom =  parse_ini_file(__DIR__ . '/../../data/custom/custom.config.ini', true);
-				if ($custom !== false && isset($custom['core'])) {
+				if (isset($custom['core'])) {
 					self::$defaultConfiguration[$_plugin]['core'] = array_merge(self::$defaultConfiguration[$_plugin]['core'], $custom['core']);
 				}
 			}

--- a/core/class/scenarioElement.class.php
+++ b/core/class/scenarioElement.class.php
@@ -202,9 +202,15 @@ class scenarioElement {
 			if (!is_numeric($limits)) {
 				throw new Exception(__('La condition pour une boucle doit être numérique :', __FILE__) . ' ' . $limits);
 			}
+			$endTime = time() + 3600;
 			$return = false;
 			for ($i = 1; $i <= $limits; $i++) {
 				$return = $this->getSubElement('do')->execute($_scenario);
+				if (time() > $endTime) {
+					$_scenario->setLog(__('[For] Arrêt de la boucle pour cause de durée d\'exécution trop longue', __FILE__));
+					return false;
+				}
+				sleep(1);
 			}
 			return $return;
 		} elseif ($this->getType() == 'while') {
@@ -232,7 +238,7 @@ class scenarioElement {
 				$return = $this->getSubElement('do')->execute($_scenario);
 				if (time() > $endTime) {
 					$_scenario->setLog(__('[While] Arrêt de la boucle pour cause de durée d\'exécution trop longue', __FILE__));
-					return;
+					return false;
 				}
 				sleep(1);
 				$result = $this->getSubElement('while')->execute($_scenario);

--- a/core/class/scenarioElement.class.php
+++ b/core/class/scenarioElement.class.php
@@ -202,7 +202,7 @@ class scenarioElement {
 			if (!is_numeric($limits)) {
 				throw new Exception(__('La condition pour une boucle doit être numérique :', __FILE__) . ' ' . $limits);
 			}
-			$endTime = time() + 3600;
+			$endTime = time() + (int)config::byKey('scenario::element::maxExecutionTime', 'core', 3600);
 			$return = false;
 			for ($i = 1; $i <= $limits; $i++) {
 				$return = $this->getSubElement('do')->execute($_scenario);
@@ -232,7 +232,7 @@ class scenarioElement {
 				message::add('scenario', $message, $action, $logicalId);
 				return;
 			}
-			$endTime = time() + 3600;
+			$endTime = time() + (int)config::byKey('scenario::element::maxExecutionTime', 'core', 3600);
 			$return = false;
 			while ($result) {
 				$return = $this->getSubElement('do')->execute($_scenario);

--- a/core/class/scenarioExpression.class.php
+++ b/core/class/scenarioExpression.class.php
@@ -473,7 +473,7 @@ class scenarioExpression {
 		$occurence = 0;
 		$limit = 7200;
 		$timeout = jeedom::evaluateExpression($_timeout, $_scenario);
-		$limit = is_numeric($timeout) ? min(7200, $timeout) : 7200;
+		$limit = is_numeric($timeout) ? min($timeout, 7200) : 7200;
 
 		while ($occurence < $limit) {
 			$result = jeedom::evaluateExpression($_condition, $_scenario);
@@ -1451,18 +1451,18 @@ class scenarioExpression {
 				} elseif ($this->getExpression() == 'sleep') {
 					if (isset($options['duration'])) {
 						try {
-							$options['duration'] = floatval(evaluate($options['duration']));
-						} catch (Exception $e) {
-						} catch (Error $e) {
-						}
-						if ((is_float($options['duration']) || is_int($options['duration'])) && $options['duration'] > 0) {
-							$this->setLog($scenario, __('Pause de', __FILE__) . ' ' . $options['duration'] . ' ' . __('seconde(s)', __FILE__));
-							if ($options['duration'] < 1) {
-								usleep($options['duration'] * 1000000);
+							$duration = floatval(jeedom::evaluateExpression($options['duration'], $scenario));
+							if ($duration > 0) {
+								$seconds = min((float)$duration, 3600);
+								$this->setLog($scenario, sprintf(__('Pause de %s seconde(s)', __FILE__), $seconds));
+								if ($seconds < 1) {
+									usleep((int) round($seconds * 1000000));
+									return;
+								}
+								sleep((int) floor($seconds));
 								return;
 							}
-							sleep($options['duration']);
-							return;
+						} catch (\Throwable $e) {
 						}
 					}
 					$this->setLog($scenario, $GLOBALS['JEEDOM_SCLOG_TEXT']['invalidDuration']['txt'] . $options['duration']);

--- a/core/class/scenarioExpression.class.php
+++ b/core/class/scenarioExpression.class.php
@@ -468,21 +468,22 @@ class scenarioExpression {
 		return round($historyStatistique['max'], $_round);
 	}
 
-	public static function wait($_condition, $_timeout = 7200) {
+	public static function wait($_condition, $_timeout = 7200, $_scenario = null) {
 		$result = false;
 		$occurence = 0;
 		$limit = 7200;
-		$timeout = jeedom::evaluateExpression($_timeout);
-		$limit = (is_numeric($timeout)) ? $timeout : 7200;
-		while ($result !== true) {
-			$result = jeedom::evaluateExpression($_condition);
-			if ($occurence > $limit) {
-				return 0;
+		$timeout = jeedom::evaluateExpression($_timeout, $_scenario);
+		$limit = is_numeric($timeout) ? min(7200, $timeout) : 7200;
+
+		while ($occurence < $limit) {
+			$result = jeedom::evaluateExpression($_condition, $_scenario);
+			if ($result === true) {
+				return 1;
 			}
 			$occurence++;
 			sleep(1);
 		}
-		return 1;
+		return 0;
 	}
 
 	public static function minBetween($_cmd_id, $_startDate, $_endDate, $_round = 1) {
@@ -1435,24 +1436,17 @@ class scenarioExpression {
 					if (!isset($options['condition'])) {
 						return;
 					}
-					$result = false;
-					$occurence = 0;
-					$limit = 7200;
-					if (isset($options['timeout'])) {
-						$timeout = jeedom::evaluateExpression($options['timeout']);
-						$limit = (is_numeric($timeout)) ? $timeout : 7200;
+					$limit = $options['timeout'] ?? 7200;
+
+					$result = self::wait($options['condition'], $limit, $scenario);
+					$expression = self::setTags($options['condition'], $scenario, true);
+					if ($result === 0) {
+						$limitWithTags = self::setTags($limit, $scenario, true);
+						$resultLimit = evaluate($limitWithTags);
+						$this->setLog($scenario, sprintf(__('[Wait] Dépassement de limite: %s => %s - condition: %s', __FILE__), $limitWithTags, $resultLimit, $expression));
+					} else {
+						$this->setLog($scenario, sprintf(__('[Wait] Condition valide: %s', __FILE__), $expression));
 					}
-					while (!$result) {
-						$expression = self::setTags($options['condition'], $scenario, true);
-						$result = evaluate($expression);
-						if ($occurence > $limit) {
-							$this->setLog($scenario, __('[Wait] Condition valide par dépassement de temps :', __FILE__) . ' ' . $expression . ' => ' . $result);
-							return;
-						}
-						$occurence++;
-						sleep(1);
-					}
-					$this->setLog($scenario, __('[Wait] Condition valide :', __FILE__) . ' ' . $expression . ' => ' . $result);
 					return;
 				} elseif ($this->getExpression() == 'sleep') {
 					if (isset($options['duration'])) {

--- a/core/class/scenarioExpression.class.php
+++ b/core/class/scenarioExpression.class.php
@@ -468,13 +468,19 @@ class scenarioExpression {
 		return round($historyStatistique['max'], $_round);
 	}
 
-	public static function wait($_condition, $_timeout = 7200, $_scenario = null) {
+	public static function wait($_condition, $_timeout = null, $_scenario = null) {
 		$result = false;
 		$occurence = 0;
-		$limit = 7200;
-		$timeout = jeedom::evaluateExpression($_timeout, $_scenario);
-		$limit = is_numeric($timeout) ? min($timeout, 7200) : 7200;
 
+		$limit = (int)config::byKey('scenario::element::maxExecutionTime', 'core', 3600);
+		$timeout = is_string($_timeout) ? jeedom::evaluateExpression($_timeout, $_scenario) : $_timeout;
+
+		if (is_numeric($timeout) && $timeout > 0) {
+			$limit = min((int) $timeout, $limit);
+		}
+		if ($_scenario !== null && is_object($_scenario)) {
+			$_scenario->setLog(sprintf(__('[Wait] Début du wait, timeout: %ss', __FILE__), $limit));
+		}
 		while ($occurence < $limit) {
 			$result = jeedom::evaluateExpression($_condition, $_scenario);
 			if ($result === true) {
@@ -1436,14 +1442,10 @@ class scenarioExpression {
 					if (!isset($options['condition'])) {
 						return;
 					}
-					$limit = $options['timeout'] ?? 7200;
-
-					$result = self::wait($options['condition'], $limit, $scenario);
+					$result = self::wait($options['condition'], $options['timeout'], $scenario);
 					$expression = self::setTags($options['condition'], $scenario, true);
 					if ($result === 0) {
-						$limitWithTags = self::setTags($limit, $scenario, true);
-						$resultLimit = evaluate($limitWithTags);
-						$this->setLog($scenario, sprintf(__('[Wait] Dépassement de limite: %s => %s - condition: %s', __FILE__), $limitWithTags, $resultLimit, $expression));
+						$this->setLog($scenario, sprintf(__('[Wait] Dépassement du timeout: %s', __FILE__), $expression));
 					} else {
 						$this->setLog($scenario, sprintf(__('[Wait] Condition valide: %s', __FILE__), $expression));
 					}
@@ -1453,7 +1455,7 @@ class scenarioExpression {
 						try {
 							$duration = floatval(jeedom::evaluateExpression($options['duration'], $scenario));
 							if ($duration > 0) {
-								$seconds = min((float)$duration, 3600);
+								$seconds = min($duration, (int)config::byKey('scenario::element::maxExecutionTime', 'core', 3600));
 								$this->setLog($scenario, sprintf(__('Pause de %s seconde(s)', __FILE__), $seconds));
 								if ($seconds < 1) {
 									usleep((int) round($seconds * 1000000));

--- a/core/config/default.config.ini
+++ b/core/config/default.config.ini
@@ -107,6 +107,7 @@ event::waitPollingTime = 1
 
 ;Scénario
 enableScenario = 1
+scenario::element::maxExecutionTime = 3600
 
 ;Update
 update::allowCore = 1

--- a/core/config/default.config.ini
+++ b/core/config/default.config.ini
@@ -99,13 +99,13 @@ battery::warning = 30
 battery::danger = 5
 numberOfTryBeforeEqLogicDisable = 3
 
-;deamon
+;daemon
 deamonsSleepTime = 1
 
 ;event
 event::waitPollingTime = 1
 
-;Scénario
+;Scenario
 enableScenario = 1
 scenario::element::maxExecutionTime = 3600
 


### PR DESCRIPTION
## Description

As mentioned in comments [here](https://github.com/jeedom/core/issues/3164#issuecomment-3876220442) and [here](https://github.com/jeedom/core/issues/3164#issuecomment-3925571298) we should prevent infinite loop and implement safeguard in case a scenario is executed with invalide configuration.

During development of [the "while block"](https://github.com/jeedom/core/issues/3164), I realized that it is not the case for the FOR, WAIT and SLEEP that could run for almost infinite time so I propose to fix this

I took the opportunity to restructure the code and remove duplicated code.

### Suggested changelog entry
- Sécurisation des scénarios:
  - limitation du temps d’exécution de la boucle **for** à maximum 1h 
  - limitation de l'action **sleep** à maximum 1h
  - limitation de l'action **wait** à maximum 3600 occurrences (~1h). La valeur par défaut est de 3600
 - Corrections: les tags sont dorénavant correctement pris en compte lors de l'évaluation des limites pour les actions **sleep** & **wait**

### Related issues/external references

Fixes #


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have checked there is no other PR open for the same change.
- [X] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [X] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [X] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.
