### PR TITLE
refactor(dom.ui): seen(), unseen() and toggle() use hidden class consistently

### DIFF
--- a/core/dom/dom.ui.js
+++ b/core/dom/dom.ui.js
@@ -58,7 +58,7 @@ Element.prototype.isHidden = function() {
   return (this.offsetParent === null)
 }
 Element.prototype.seen = function() {
-  this.classList.remove('hidden')
+  this.removeClass('hidden')
   this.style.display = ''
   return this
 }
@@ -69,7 +69,7 @@ NodeList.prototype.seen = function() {
   return this
 }
 Element.prototype.unseen = function() {
-  this.style.display = 'none'
+  this.addClass('hidden')
   return this
 }
 NodeList.prototype.unseen = function() {
@@ -79,11 +79,10 @@ NodeList.prototype.unseen = function() {
   return this
 }
 Element.prototype.toggle = function() {
-  if (this.offsetParent === null) {
-    this.classList.remove('hidden')
-    this.style.display = ''
+  if (this.isHidden()) {
+    this.seen()
   } else {
-    this.style.display = 'none'
+    this.unseen()
   }
   return this
 }

--- a/core/dom/dom.ui.js
+++ b/core/dom/dom.ui.js
@@ -78,7 +78,7 @@ NodeList.prototype.unseen = function() {
   return this
 }
 Element.prototype.toggle = function() {
-  if (this.offsetParent === null){
+  if (this.offsetParent === null) {
     this.style.display = ''
   } else {
     this.style.display = 'none'
@@ -921,12 +921,12 @@ var jeeDialog = (function() {
       template.appendChild(dialogFooter)
 
       let buttons = {}
-      for ( let button of Object.entries(_params.buttons)) {
-        buttons[button[0]] = domUtils.extend(_params.defaultButtons[button[0]],button[1])
+      for (let button of Object.entries(_params.buttons)) {
+        buttons[button[0]] = domUtils.extend(_params.defaultButtons[button[0]], button[1])
       }
 
       for (let defaultButton of Object.entries(_params.defaultButtons)) {
-        if (! isset(buttons[defaultButton[0]])) {
+        if (!isset(buttons[defaultButton[0]])) {
           buttons[defaultButton[0]] = defaultButton[1]
         }
       }
@@ -2106,10 +2106,10 @@ var jeeCtxMenu = function(_options) {
         ctxInstance.hide(event)
       }, 100)
     })
-  }else{
+  } else {
     document.addEventListener('click', event => {
       if (ctxMenuContainer.contains(event.target)) {
-        return;
+        return
       }
       setTimeout(function() {
         if (!ctxMenuContainer.closest('div.jeeCtxMenu').isVisible()) return //May be closed by click, avoir twice hide

--- a/core/dom/dom.ui.js
+++ b/core/dom/dom.ui.js
@@ -58,6 +58,7 @@ Element.prototype.isHidden = function() {
   return (this.offsetParent === null)
 }
 Element.prototype.seen = function() {
+  this.classList.remove('hidden')
   this.style.display = ''
   return this
 }
@@ -79,6 +80,7 @@ NodeList.prototype.unseen = function() {
 }
 Element.prototype.toggle = function() {
   if (this.offsetParent === null) {
+    this.classList.remove('hidden')
     this.style.display = ''
   } else {
     this.style.display = 'none'


### PR DESCRIPTION
## Summary
- `seen()` now removes the `hidden` CSS class in addition to clearing inline `style.display`
- `toggle()` (show branch) applies the same fix for consistency

## Context
Elements initially hidden via the `hidden` CSS class were not revealed by `seen()` since it only cleared inline styles. The fix relies on `classList.remove()` being a no-op when the class is absent, and on `style.display = ''` deferring to CSS cascade so elements with other display-related classes (e.g. `d-flex`) are correctly restored.
