### PR TITLE
fix test expression result

### DIFF
--- a/core/ajax/scenario.ajax.php
+++ b/core/ajax/scenario.ajax.php
@@ -89,11 +89,12 @@ try {
 	if (init('action') == 'testExpression') {
 		$return = array();
 		$scenario = null;
-		$expr = jeedom::fromHumanReadable(init('expression'));
+		$expression = trim(init('expression'));
+		$expr = jeedom::fromHumanReadable($expression);
 		$return['evaluate'] = scenarioExpression::setTags($expr, $scenario, true);
 		$return['result'] = evaluate($return['evaluate']);
 		$return['correct'] = 'ok';
-		if (trim($return['result']) == trim($return['evaluate'])) {
+		if (!is_numeric($expression) && trim($return['result']) == $expression) {
 			$return['correct'] = 'nok';
 		}
 		ajax::success($return);

--- a/desktop/modal/expression.test.php
+++ b/desktop/modal/expression.test.php
@@ -23,14 +23,14 @@ if (!isConnect('admin')) {
 <div id="md_expressionTest" data-modalType="md_expressionTest">
   <form class="form-horizontal" onsubmit="return false;">
     <div class="input-group input-group-sm" style="width: 100%">
-      <span class="input-group-addon roundedLeft" style="width: 100px"><i class="fas fa-random"></i>  {{Test}}</span>
+      <span class="input-group-addon roundedLeft" style="width: 100px"><i class="fas fa-random"></i> {{Test}}</span>
       <input class="form-control input-sm" id="in_testExpression">
       <span class="input-group-btn">
         <a class="btn btn-default btn-sm cursor tooltips" id="bt_searchInfoCmd" title="{{Rechercher une commande}}"><i class="fas fa-list-alt"></i>
-        <a class="btn btn-default btn-sm cursor tooltips" id="bt_selectGenericExpression" title="{{Rechercher un type générique}}"><i class="fas fa-puzzle-piece"></i>
-        </a><a class="btn btn-default btn-sm cursor tooltips"  id="bt_searchScenario" title="{{Rechercher un scénario}}"><i class="fas fa-history"></i>
-        </a><a class="btn btn-default btn-sm cursor tooltips"  id="bt_searchEqLogic" title="{{Rechercher un équipement}}"><i class="fas fa-cube"></i>
-        </a><a class="btn btn-sm btn-default btn-success roundedRight" id="bt_testExpression"><i class="fas fa-bolt"></i> {{Exécuter}}</a>
+          <a class="btn btn-default btn-sm cursor tooltips" id="bt_selectGenericExpression" title="{{Rechercher un type générique}}"><i class="fas fa-puzzle-piece"></i>
+          </a><a class="btn btn-default btn-sm cursor tooltips" id="bt_searchScenario" title="{{Rechercher un scénario}}"><i class="fas fa-history"></i>
+          </a><a class="btn btn-default btn-sm cursor tooltips" id="bt_searchEqLogic" title="{{Rechercher un équipement}}"><i class="fas fa-cube"></i>
+          </a><a class="btn btn-sm btn-default btn-success roundedRight" id="bt_testExpression"><i class="fas fa-bolt"></i> {{Exécuter}}</a>
       </span>
     </div>
   </form>
@@ -42,112 +42,119 @@ if (!isConnect('admin')) {
 </div>
 
 <script>
-if (!jeeFrontEnd.md_expressionTest) {
-  jeeFrontEnd.md_expressionTest = {
-    init: function() {
-      //Show all IF expression if from scenario page:
-      if (document.body.getAttribute('data-page') == 'scenario' && document.getElementById('div_editScenario').isVisible()) {
-        document.querySelectorAll('.subElementIF .expressions input[data-l1key="expression"]').forEach(_expr => {
-          expression = _expr.value.trim().replace(/"/g, '\'')
-          newLi = '<li class="cursor list-group-item list-group-item-success bt_expressionHistory" data-command="'+ expression +'"><a>' + expression + '</a></li>'
-          document.getElementById('ul_expressionHistory').insertAdjacentHTML('beforeend', newLi)
+  if (!jeeFrontEnd.md_expressionTest) {
+    jeeFrontEnd.md_expressionTest = {
+      init: function() {
+        //Show all IF expression if from scenario page:
+        if (document.body.getAttribute('data-page') == 'scenario' && document.getElementById('div_editScenario').isVisible()) {
+          document.querySelectorAll('.subElementIF .expressions input[data-l1key="expression"]').forEach(_expr => {
+            expression = _expr.value.trim().replace(/"/g, '\'')
+            newLi = '<li class="cursor list-group-item list-group-item-success bt_expressionHistory" data-command="' + expression + '"><a>' + expression + '</a></li>'
+            document.getElementById('ul_expressionHistory').insertAdjacentHTML('beforeend', newLi)
+          })
+        }
+      },
+      testExpression: function() {
+        let expression = document.getElementById('in_testExpression').value.trim()
+        if (expression == '') {
+          jeedomUtils.showAlert({
+            attachTo: jeeDialog.get('#md_expressionTest', 'dialog'),
+            message: '{{L\'expression de test ne peut être vide}}',
+            level: 'danger'
+          })
+          return
+        }
+
+        if (!document.querySelector('.bt_expressionHistory[data-command="' + expression.replace(/"/g, '\\"') + '"]')) {
+          let li = '<li class="cursor list-group-item list-group-item-success bt_expressionHistory"  data-command="' + expression.replace(/"/g, '\\"') + '"><a>' + expression + '</a></li>'
+          document.getElementById('ul_expressionHistory').insertAdjacentHTML('afterbegin', li)
+        }
+        jeedom.scenario.testExpression({
+          expression: expression,
+          error: function(error) {
+            jeedomUtils.showAlert({
+              attachTo: jeeDialog.get('#md_expressionTest', 'dialog'),
+              message: error.message,
+              level: 'danger'
+            });
+          },
+          success: function(data) {
+            let divResult = document.getElementById('div_expressionTestResult')
+            divResult.empty()
+            var html = '<ul><div class="alert alert-info">'
+            if (data.correct == 'nok') {
+              html += '<strong>{{Attention : il doit y avoir un souci, car le résultat est le même que l\'expression}}</strong><br\>'
+            }
+            html += '{{Je vais évaluer :}} <strong>' + data.evaluate + '</strong><br/>'
+            html += '{{Résultat :}} <strong>' + data.result + '</strong>'
+            html += '</div></ul>'
+            divResult.insertAdjacentHTML('beforeend', html)
+          }
         })
+      },
+    }
+  }
+
+  (function() { // Self Isolation!
+    var jeeM = jeeFrontEnd.md_expressionTest
+    jeeM.init()
+
+    //Manage events outside parents delegations:
+    document.getElementById('in_testExpression')?.addEventListener('keypress', function(event) {
+      if (event.which == 13) {
+        jeeFrontEnd.md_expressionTest.testExpression()
       }
-    },
-    testExpression: function() {
-      let expression = document.getElementById('in_testExpression').value
-      if (expression == '') {
-        jeedomUtils.showAlert({
-          attachTo: jeeDialog.get('#md_expressionTest', 'dialog'),
-          message: '{{L\'expression de test ne peut être vide}}',
-          level: 'danger'
+    })
+
+    /*Events delegations
+     */
+    document.getElementById('md_expressionTest')?.addEventListener('click', function(event) {
+      var _target = null
+      if (_target = event.target.closest('#bt_searchInfoCmd')) {
+        jeedom.cmd.getSelectModal({
+          cmd: {
+            type: 'info'
+          }
+        }, function(result) {
+          document.getElementById('in_testExpression').insertAtCursor(result.human)
         })
         return
       }
 
-      if (!document.querySelector('.bt_expressionHistory[data-command="' + expression.replace(/"/g, '\\"') + '"]')) {
-        let li = '<li class="cursor list-group-item list-group-item-success bt_expressionHistory"  data-command="' + expression.replace(/"/g, '\\"') + '"><a>' + expression + '</a></li>'
-        document.getElementById('ul_expressionHistory').insertAdjacentHTML('afterbegin', li)
+      if (_target = event.target.closest('#bt_searchScenario')) {
+        jeedom.scenario.getSelectModal({}, function(result) {
+          document.getElementById('in_testExpression').insertAtCursor(result.human)
+        })
+        return
       }
-      jeedom.scenario.testExpression({
-        expression: expression,
-        error: function(error) {
-          jeedomUtils.showAlert({
-            attachTo: jeeDialog.get('#md_expressionTest', 'dialog'),
-            message: error.message,
-            level: 'danger'
-          });
-        },
-        success: function(data) {
-          let divResult = document.getElementById('div_expressionTestResult')
-          divResult.empty()
-          var html = '<ul><div class="alert alert-info">'
-          if (data.correct == 'nok') {
-            html += '<strong>{{Attention : il doit y avoir un souci, car le résultat est le même que l\'expression}}</strong><br\>'
-          }
-          html += '{{Je vais évaluer :}} <strong>' + data.evaluate + '</strong><br/>'
-          html += '{{Résultat :}} <strong>' + data.result + '</strong>'
-          html += '</div></ul>'
-          divResult.insertAdjacentHTML('beforeend', html)
-        }
-      })
-    },
-  }
-}
 
-(function() {// Self Isolation!
-  var jeeM = jeeFrontEnd.md_expressionTest
-  jeeM.init()
+      if (_target = event.target.closest('#bt_searchEqLogic')) {
+        jeedom.eqLogic.getSelectModal({}, function(result) {
+          document.getElementById('in_testExpression').insertAtCursor(result.human)
+        })
+        return
+      }
 
-  //Manage events outside parents delegations:
-  document.getElementById('in_testExpression')?.addEventListener('keypress', function(event) {
-    if (event.which == 13) {
-      jeeFrontEnd.md_expressionTest.testExpression()
-    }
-  })
+      if (_target = event.target.closest('#bt_selectGenericExpression')) {
+        jeedom.config.getGenericTypeModal({
+          type: 'info',
+          object: true
+        }, function(result) {
+          document.getElementById('in_testExpression').insertAtCursor(result.human)
+        })
+        return
+      }
 
-  /*Events delegations
-  */
-  document.getElementById('md_expressionTest')?.addEventListener('click', function(event) {
-    var _target = null
-    if (_target = event.target.closest('#bt_searchInfoCmd')) {
-      jeedom.cmd.getSelectModal({cmd: {type: 'info'}}, function(result) {
-        document.getElementById('in_testExpression').insertAtCursor(result.human)
-      })
-      return
-    }
+      if (_target = event.target.closest('#bt_testExpression')) {
+        jeeFrontEnd.md_expressionTest.testExpression()
+        return
+      }
 
-    if (_target = event.target.closest('#bt_searchScenario')) {
-      jeedom.scenario.getSelectModal({}, function(result) {
-        document.getElementById('in_testExpression').insertAtCursor(result.human)
-      })
-      return
-    }
-
-    if (_target = event.target.closest('#bt_searchEqLogic')) {
-      jeedom.eqLogic.getSelectModal({}, function(result) {
-        document.getElementById('in_testExpression').insertAtCursor(result.human)
-      })
-      return
-    }
-
-    if (_target = event.target.closest('#bt_selectGenericExpression')) {
-      jeedom.config.getGenericTypeModal({type: 'info', object: true}, function(result) {
-        document.getElementById('in_testExpression').insertAtCursor(result.human)
-      })
-      return
-    }
-
-    if (_target = event.target.closest('#bt_testExpression')) {
-      jeeFrontEnd.md_expressionTest.testExpression()
-      return
-    }
-
-    if (_target = event.target.closest('.bt_expressionHistory')) {
-      document.getElementById('in_testExpression').value = _target.getAttribute('data-command')
-      jeeFrontEnd.md_expressionTest.testExpression()
-      return
-    }
-  })
-})()
+      if (_target = event.target.closest('.bt_expressionHistory')) {
+        document.getElementById('in_testExpression').value = _target.getAttribute('data-command')
+        jeeFrontEnd.md_expressionTest.testExpression()
+        return
+      }
+    })
+  })()
 </script>


### PR DESCRIPTION
## Description
For the moment, when a user evaluate a simple command, the result give a small warning about a potential issue which doesn't exist, example: 

<img width="537" height="221" alt="image" src="https://github.com/user-attachments/assets/6391e38b-106d-4105-9b8e-a8f638609a6a" />

It confuses a lot users, some even try to find solutions for a problem that does not exist: https://community.jeedom.com/t/retex-message-log-general/149045
In the case above, we expect to not get any warning message


### Suggested changelog entry
Correction du testeur d'expression pour ne plus signaler un problème qui n'existe pas


### Related issues/external references

Fixes #


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have checked there is no other PR open for the same change.
- [X] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [X] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [X] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.

## Tests
true case:
<img width="340" height="209" alt="image" src="https://github.com/user-attachments/assets/f2dc07df-f651-47f6-9913-9770dbf200cf" />

a numeric:
<img width="244" height="199" alt="image" src="https://github.com/user-attachments/assets/3999d47b-0cd3-4fef-ae08-b8200e7ffc82" />

<img width="365" height="204" alt="image" src="https://github.com/user-attachments/assets/fe486817-8b06-4c9a-9e43-4c9b621bf3b2" />

error case:
<img width="543" height="231" alt="image" src="https://github.com/user-attachments/assets/94fb9ba0-0435-491d-a4f0-a2b623917cf2" />

random incorrect value:
<img width="542" height="221" alt="image" src="https://github.com/user-attachments/assets/4507e093-00fd-4755-8317-0eadbbe0294b" />

