### PR TITLE
fix jeeDialogMain positioning when using hidden class

### DIFF
--- a/core/dom/dom.ui.js
+++ b/core/dom/dom.ui.js
@@ -1582,6 +1582,7 @@ var jeeDialog = (function() {
         show: function() {
           setBackDrop(_options, true)
           this.dialog._jeeDialog.options.onShown()
+          this.dialog.seen()
           if (!_options.retainPosition || this.dialog.style.width == '') {
             if (!_options.fullScreen) {
               this.dialog.setAttribute('data-maximize', '0')
@@ -1592,7 +1593,6 @@ var jeeDialog = (function() {
           }
           document.querySelectorAll('div.jeeDialog.jeeDialogMain').removeClass('active')
           this.dialog.addClass('active')
-          this.dialog.seen()
           setTimeout(function() {
             dialogContainer.querySelector('button[data-type="confirm"]')?.focus()
           })
@@ -1608,7 +1608,7 @@ var jeeDialog = (function() {
           this.dialog.unseen()
           this.dialog._jeeDialog.options.onClose()
           this.dialog.removeClass('active')
-          let _dialog = document.querySelectorAll('div.jeeDialog.jeeDialogMain:not([style*="display: none;"])')
+          let _dialog = document.querySelectorAll('div.jeeDialog.jeeDialogMain:not(.hidden)')
           _dialog[_dialog.length - 1]?.addClass('active')
           cleanBackdrop()
         },


### PR DESCRIPTION
## Summary

- Call `seen()` before `setPosition()` in `jeeDialogMain.show()` so the dialog is visible when its dimensions are measured for horizontal centering
- Fix the `close()` selector from `:not([style*="display: none;"])` to `:not(.hidden)` to correctly exclude hidden dialogs when restoring the `active` class

## Context

After the refactor of `unseen()` to use `addClass('hidden')` instead of `style.display = 'none'` (#3342), `setPosition()` was measuring dialog dimensions while the element was still hidden via the CSS class (`display: none !important`). This caused `getBoundingClientRect()` to return `{width: 0}`, placing the dialog at `left = viewport/2` (right half of the screen) instead of centered. The old code relied on `_dialog.style = null` clearing the inline `display: none` to make the element temporarily visible for measurement.
