### PR TITLE
fix (eqLogic plugin page) : Fix unit on cmd state (cmd table tab)

### DIFF
--- a/core/class/cmd.class.php
+++ b/core/class/cmd.class.php
@@ -1926,7 +1926,7 @@ class cmd {
 			if (is_array($value_cmd) && count($value_cmd) > 0) {
 				foreach ($value_cmd as $cmd) {
 					if ($cmd->getType() == 'action') {
-						$events[] = array('cmd_id' => $cmd->getId(), 'value' => (strlen($value) < 3096) ? $value : substr($value, 0, 3096), 'display_value' => (strlen($display_value) < 3096) ? $display_value :  substr($display_value, 0, 3096), 'valueDate' => $this->getValueDate(), 'collectDate' => $this->getCollectDate(), 'unit' => $unit);
+						$events[] = array('cmd_id' => $cmd->getId(), 'value' => (strlen($value) < 3096) ? $value : substr($value, 0, 3096), 'display_value' => (strlen($display_value) < 3096) ? $display_value :  substr($display_value, 0, 3096), 'valueDate' => $this->getValueDate(), 'collectDate' => $this->getCollectDate(), 'unit' => $unit, 'raw_unit' => $raw_unit);
 					} else {
 						if ($_loop > 1) {
 							$cmd->event($cmd->execute(), null, $_loop);

--- a/core/js/plugin.template.js
+++ b/core/js/plugin.template.js
@@ -142,7 +142,7 @@ if (!jeeFrontEnd.pluginTemplate) {
                 title += ' - ' + _options.value
               }
               cmd.setAttribute('title', title)
-              cmd.empty().innerHTML = _options.value.substring(0, 50) + ' ' + _options.unit
+              cmd.empty().innerHTML = _options.value.substring(0, 50) + ' ' + _options.raw_unit
               cmd.style.color = 'var(--logo-primary-color)'
               setTimeout(function() {
                 cmd.style.color = null


### PR DESCRIPTION
Comment by @Mips2648 : After a cmd update, the unit is converted (e.g. second to hour) but the value is still the original value so we must display the raw unit (coming from the configuration) and not the converted unit