### PR TITLE
Fix core widget translations broken after migration to jeetranslate workflow

### DIFF
--- a/core/class/cmd.class.php
+++ b/core/class/cmd.class.php
@@ -1441,6 +1441,7 @@ class cmd {
 	}
 
 	public function getWidgetHelp($_version = 'dashboard', $_widgetName = '') {
+		$_version = jeedom::versionAlias($_version);
 		$widget = $this->getWidgetTemplateCode($_version, false, $_widgetName);
 		$widgetCode = $widget['template'];
 		$isCorewidget = $widget['isCoreWidget'];
@@ -1453,7 +1454,7 @@ class cmd {
 			} else {
 				$widgetHelp = strip_tags($widgetHelp, '<div>');
 				if ($isCorewidget) {
-					return translate::exec($widgetHelp, 'core/template/widgets.html');
+					return translate::exec($widgetHelp, 'core/template/' . $_version . '/' . $widget['widgetName'] . '.html');
 				} else {
 					return translate::exec($widgetHelp, $widget['widgetName']);
 				}
@@ -1611,7 +1612,7 @@ class cmd {
 		if ($_clean) {
 			$template = $this->cleanWidgetCode($template);
 		}
-		return array('template' => $template, 'isCoreWidget' => true);
+		return array('template' => $template, 'isCoreWidget' => true, 'widgetName' => $template_name);
 	}
 
 	public static function autoValueArray($_value, $_decimal = 99, $_unit = '', $_space = False) {
@@ -1851,7 +1852,7 @@ class cmd {
 			return translate::exec($template, 'core/template/scenario/' . $widget['widgetName'] . '.html');
 		}
 		if ($isCorewidget) {
-			return translate::exec($template, 'core/template/widgets.html');
+			return translate::exec($template, 'core/template/' . $_version . '/' . $widget['widgetName'] . '.html');
 		}
 		if (isset($widget['widgetName'])) {
 			return translate::exec($template, $widget['widgetName']);


### PR DESCRIPTION
## Problem

Since the migration from Jenkins to the `jeetranslate` GitHub Actions workflow, translations in core dashboard/mobile widgets (compass, gauge, etc.) were broken when using any language other than fr_FR.

The workflow generates one i18n key per source file (e.g. `core/template/dashboard/cmd.info.numeric.compass.html`), but `cmd.class.php` was still calling `translate::exec()` with the old aggregated key `core/template/widgets.html`, which no longer exists in the generated JSON.

The scenario case was already correct (line 1851 uses per-file paths since its own migration).

## Changes in `cmd.class.php`

**`getWidgetTemplateCode()`:** expose `widgetName` in the return array for core widgets. Previously only `template` and `isCoreWidget` were returned, leaving callers unable to build the per-file path.

**`getWidgetHelp()`:** alias `$_version` at the top of the method (same pattern as `toHtml()`) so the value is canonical before use, then call `translate::exec()` with the individual file path instead of the aggregated key.

**`toHtml()`:** same fix, replace the hardcoded `'core/template/widgets.html'` with `'core/template/' . $_version . '/' . $widget['widgetName'] . '.html'`.

## Future consideration - `common` key

`translate::exec()` already supports a `common` fallback key for strings shared across files ("Date de valeur", "Minimum", "Moyenne", etc.). With the new per-file format these strings are duplicated across widget JSON entries, functional but verbose. A future improvement to `jeetranslate` could detect strings appearing in N+ files and output them under `common` instead, reducing JSON size and aligning with the existing fallback mechanism in `translate::exec()`.
