### PR TITLE
fix: drop obsolete global widgets.html i18n key

### DIFF
--- a/core/class/cmd.class.php
+++ b/core/class/cmd.class.php
@@ -19,11 +19,6 @@
 /* * ***************************Includes********************************* */
 require_once __DIR__ . '/../../core/php/core.inc.php';
 
-/*
-Translate system scan core/template/dashboard files and set them in i18n all under "core\/template\/widgets.html" path
--> translate::exec($string, 'core/template/widgets.html');
-*/
-
 /**
  * Jeedom command management class
  * @see eqLogic

--- a/core/class/cmd.class.php
+++ b/core/class/cmd.class.php
@@ -32,79 +32,79 @@ Translate system scan core/template/dashboard files and set them in i18n all und
 class cmd {
 	/*	 * *************************Attributs****************************** */
 
-    /** @var int|''|null Command ID */
+	/** @var int|''|null Command ID */
 	protected $id;
 
-    /** @var int|null Logical identifier for the command */
+	/** @var int|null Logical identifier for the command */
 	protected $logicalId;
 
-    /** @var string|null Generic type of command */
+	/** @var string|null Generic type of command */
 	protected $generic_type;
 
-    /** @var string|null Equipment type */
+	/** @var string|null Equipment type */
 	protected $eqType;
 
-    /** @var string|null Command name */
+	/** @var string|null Command name */
 	protected $name;
 
-    /** @var int|null Display order */
+	/** @var int|null Display order */
 	protected $order;
 
-    /** @var string|null Command type ('action'|'info'|'string') */
+	/** @var string|null Command type ('action'|'info'|'string') */
 	protected $type;
 
-    /** @var string|null Command subtype ('binary'|'numeric'|'message'|'color'|'slider'|'string') */
+	/** @var string|null Command subtype ('binary'|'numeric'|'message'|'color'|'slider'|'string') */
 	protected $subType;
 
-    /** @var int|''|null ID of parent equipment */
+	/** @var int|''|null ID of parent equipment */
 	protected $eqLogic_id;
 
-    /** @var int Historization flag */
+	/** @var int Historization flag */
 	protected $isHistorized = 0;
 
-    /** @var string Unit for values */
+	/** @var string Unit for values */
 	protected $unite = '';
 
-    /** @var string|null Command configuration */
+	/** @var string|null Command configuration */
 	protected $configuration;
 
-    /** @var array<string, mixed> Template configuration */
+	/** @var array<string, mixed> Template configuration */
 	protected $template;
 
-    /** @var array<string, mixed> Display configuration */
+	/** @var array<string, mixed> Display configuration */
 	protected $display;
 
-    /** @var mixed|null Current value */
+	/** @var mixed|null Current value */
 	protected $value = null;
 
-    /** @var int Visibility flag */
+	/** @var int Visibility flag */
 	protected $isVisible = 1;
 
-    /** @var array<string, mixed> Alert configuration */
+	/** @var array<string, mixed> Alert configuration */
 	protected $alert;
 
-    /** @var string Collect date */
+	/** @var string Collect date */
 	protected $_collectDate = '';
 
-    /** @var string Value date */
+	/** @var string Value date */
 	protected $_valueDate = '';
 
-    /** @var eqLogic|null Parent equipment object */
+	/** @var eqLogic|null Parent equipment object */
 	protected $_eqLogic = null;
 
-    /** @var bool Flag for widget refresh */
+	/** @var bool Flag for widget refresh */
 	protected $_needRefreshWidget;
 
-    /** @var bool Flag for alert refresh */
+	/** @var bool Flag for alert refresh */
 	protected $_needRefreshAlert;
 
-    /** @var bool Change tracking flag */
+	/** @var bool Change tracking flag */
 	protected $_changed = false;
 
-    /** @var array<string, string> Template array */
+	/** @var array<string, string> Template array */
 	protected static $_templateArray = array();
 
-    /** @var array<string, int|string> Unit conversion mapping */
+	/** @var array<string, int|string> Unit conversion mapping */
 	protected static $_unite_conversion = array(
 		's' => array(60, 's', 'min', 'h'),
 		'W' => array(1000, 'W', 'kW', 'MW'),
@@ -118,13 +118,13 @@ class cmd {
 	);
 	/*	 * ***********************Méthodes statiques*************************** */
 
-    /**
-     * Cast an object or array of objects to specific command type
-     *
-     * @param object|static[] $_inputs Objects to cast
-     * @param eqLogic|null $_eqLogic Parent equipment
-     * @return static|static[] Casted object(s)
-     */
+	/**
+	 * Cast an object or array of objects to specific command type
+	 *
+	 * @param object|static[] $_inputs Objects to cast
+	 * @param eqLogic|null $_eqLogic Parent equipment
+	 * @return static|static[] Casted object(s)
+	 */
 	private static function cast($_inputs, $_eqLogic = null) {
 		if (is_object($_inputs) && class_exists($_inputs->getEqType() . 'Cmd')) {
 			if ($_eqLogic !== null) {
@@ -149,12 +149,12 @@ class cmd {
 		return $_inputs;
 	}
 
-    /**
-     * Get a command by ID
-     *
-     * @param int|string $_id Command ID
-     * @return void|static Null if ID not valid, command object otherwise
-     */
+	/**
+	 * Get a command by ID
+	 *
+	 * @param int|string $_id Command ID
+	 * @return void|static Null if ID not valid, command object otherwise
+	 */
 	public static function byId($_id) {
 		if ($_id == '') {
 			return;
@@ -168,12 +168,12 @@ class cmd {
 		return self::cast(DB::Prepare($sql, $values, DB::FETCH_TYPE_ROW, PDO::FETCH_CLASS, __CLASS__));
 	}
 
-    /**
-     * Get multiple commands by IDs
-     *
-     * @param array<string|int> $_ids Array of command IDs
-     * @return void|static[] Null if IDs not valid, array of commands otherwise
-     */
+	/**
+	 * Get multiple commands by IDs
+	 *
+	 * @param array<string|int> $_ids Array of command IDs
+	 * @return void|static[] Null if IDs not valid, array of commands otherwise
+	 */
 	public static function byIds($_ids) {
 		if (!is_array($_ids) || count($_ids) == 0) {
 			return;
@@ -187,11 +187,11 @@ class cmd {
 		}
 	}
 
-    /**
-     * Get all commands
-     *
-     * @return static[] Array of all commands
-     */
+	/**
+	 * Get all commands
+	 *
+	 * @return static[] Array of all commands
+	 */
 	public static function all() {
 		$sql = 'SELECT ' . DB::buildField(__CLASS__) . '
 		FROM cmd
@@ -199,13 +199,13 @@ class cmd {
 		return self::cast(DB::Prepare($sql, array(), DB::FETCH_TYPE_ALL, PDO::FETCH_CLASS, __CLASS__));
 	}
 
-    /**
-     * Get historized commands
-     *
-     * @param bool $_state Historization state to filter
-     * @return static[] Array of commands
-     * @throws Exception
-     */
+	/**
+	 * Get historized commands
+	 *
+	 * @param bool $_state Historization state to filter
+	 * @return static[] Array of commands
+	 * @throws Exception
+	 */
 	public static function isHistorized($_state = true) {
 		$values = array(
 			'isHistorized' => ($_state) ? 1 : 0
@@ -217,12 +217,12 @@ class cmd {
 		return self::cast(DB::Prepare($sql, $values, DB::FETCH_TYPE_ALL, PDO::FETCH_CLASS, __CLASS__));
 	}
 
-    /**
-     * Get all history commands
-     *
-     * @return static[] Array of historical commands
-     * @throws Exception
-     */
+	/**
+	 * Get all history commands
+	 *
+	 * @return static[] Array of historical commands
+	 * @throws Exception
+	 */
 	public static function allHistoryCmd() {
 		$sql = 'SELECT ' . DB::buildField(__CLASS__, 'c') . '
 		FROM cmd c
@@ -243,17 +243,17 @@ class cmd {
 		return array_merge($result1, $result2);
 	}
 
-    /**
-     * Get commands by equipment ID
-     *
-     * @param int|int[] $_eqLogic_id Equipment ID(s)
-     * @param string|null $_type Command type ('action'|'info'|null)
-     * @param bool $_visible Filter on visible commands
-     * @param eqLogic $_eqLogic Parent equipment
-     * @param bool $_has_generic_type Filter on commands with generic type
-     * @return static[] Array of commands
-     */
-    public static function byEqLogicId($_eqLogic_id, $_type = null, $_visible = null, $_eqLogic = null, $_has_generic_type = null) {
+	/**
+	 * Get commands by equipment ID
+	 *
+	 * @param int|int[] $_eqLogic_id Equipment ID(s)
+	 * @param string|null $_type Command type ('action'|'info'|null)
+	 * @param bool $_visible Filter on visible commands
+	 * @param eqLogic $_eqLogic Parent equipment
+	 * @param bool $_has_generic_type Filter on commands with generic type
+	 * @return static[] Array of commands
+	 */
+	public static function byEqLogicId($_eqLogic_id, $_type = null, $_visible = null, $_eqLogic = null, $_has_generic_type = null) {
 		$values = array();
 		if (is_array($_eqLogic_id)) {
 			$sql = 'SELECT ' . DB::buildField(__CLASS__) . '
@@ -284,13 +284,13 @@ class cmd {
 		return self::cast(DB::Prepare($sql, $values, DB::FETCH_TYPE_ALL, PDO::FETCH_CLASS, __CLASS__), $_eqLogic);
 	}
 
-    /**
-     * Get commands by logical ID
-     *
-     * @param string $_logical_id Logical ID to search
-     * @param string|null $_type Command type ('action'|'info'|null)
-     * @return static[] Array of commands
-     */
+	/**
+	 * Get commands by logical ID
+	 *
+	 * @param string $_logical_id Logical ID to search
+	 * @param string|null $_type Command type ('action'|'info'|null)
+	 * @return static[] Array of commands
+	 */
 	public static function byLogicalId($_logical_id, $_type = null) {
 		$values = array(
 			'logicalId' => $_logical_id,
@@ -306,14 +306,14 @@ class cmd {
 		return self::cast(DB::Prepare($sql, $values, DB::FETCH_TYPE_ALL, PDO::FETCH_CLASS, __CLASS__));
 	}
 
-    /**
-     * Get commands by generic type
-     *
-     * @param string|string[] $_generic_type Generic type(s) to search
-     * @param int|null $_eqLogic_id Equipment ID filter
-     * @param bool $_one Return only first result
-     * @return static|static[] First command if $_one is true otherwise array of commands
-     */
+	/**
+	 * Get commands by generic type
+	 *
+	 * @param string|string[] $_generic_type Generic type(s) to search
+	 * @param int|null $_eqLogic_id Equipment ID filter
+	 * @param bool $_one Return only first result
+	 * @return static|static[] First command if $_one is true otherwise array of commands
+	 */
 	public static function byGenericType($_generic_type, $_eqLogic_id = null, $_one = false) {
 		if (is_array($_generic_type)) {
 			$in = '';
@@ -344,12 +344,12 @@ class cmd {
 	}
 
 
-    /**
-     * Search commands by string
-     *
-     * @param string $_search Search string
-     * @return static[] Array of matching commands
-     */
+	/**
+	 * Search commands by string
+	 *
+	 * @param string $_search Search string
+	 * @return static[] Array of matching commands
+	 */
 	public static function searchByString($_search) {
 		$values = array(
 			'search' => '%' . $_search . '%'
@@ -360,13 +360,13 @@ class cmd {
 		return self::cast(DB::Prepare($sql, $values, DB::FETCH_TYPE_ALL, PDO::FETCH_CLASS, __CLASS__));
 	}
 
-    /**
-     * Search commands by configuration
-     *
-     * @param string|string[] $_configuration Configuration to search
-     * @param string $_eqType Equipment type filter
-     * @return static[] Array of matching commands
-     */
+	/**
+	 * Search commands by configuration
+	 *
+	 * @param string|string[] $_configuration Configuration to search
+	 * @param string $_eqType Equipment type filter
+	 * @return static[] Array of matching commands
+	 */
 	public static function searchConfiguration($_configuration, $_eqType = null) {
 		if (!is_array($_configuration)) {
 			$values = array(
@@ -398,14 +398,14 @@ class cmd {
 		return self::cast(DB::Prepare($sql, $values, DB::FETCH_TYPE_ALL, PDO::FETCH_CLASS, __CLASS__));
 	}
 
-    /**
-     * Search commands by display configuration
-     *
-     * @param array<string>|string $_display Display configuration to search
-     * @param string|null $_eqType Equipment type filter
-     * @return static[] Array of matching commands
-     * @throws Exception
-     */
+	/**
+	 * Search commands by display configuration
+	 *
+	 * @param array<string>|string $_display Display configuration to search
+	 * @param string|null $_eqType Equipment type filter
+	 * @return static[] Array of matching commands
+	 * @throws Exception
+	 */
 	public static function searchDisplay($_display, $_eqType = null) {
 		if (!is_array($_display)) {
 			$values = array(
@@ -434,15 +434,15 @@ class cmd {
 		return self::cast(DB::Prepare($sql, $values, DB::FETCH_TYPE_ALL, PDO::FETCH_CLASS, __CLASS__));
 	}
 
-    /**
-     * Search commands by equipment configuration
-     *
-     * @param int $_eqLogic_id Equipment ID
-     * @param string $_configuration Configuration to search
-     * @param string|null $_type Command type filter ('action'|'info'|null)
-     * @return static[] Array of matching commands
-     * @throws Exception
-     */
+	/**
+	 * Search commands by equipment configuration
+	 *
+	 * @param int $_eqLogic_id Equipment ID
+	 * @param string $_configuration Configuration to search
+	 * @param string|null $_type Command type filter ('action'|'info'|null)
+	 * @return static[] Array of matching commands
+	 * @throws Exception
+	 */
 	public static function searchConfigurationEqLogic($_eqLogic_id, $_configuration, $_type = null) {
 		$values = array(
 			'configuration' => '%' . $_configuration . '%',
@@ -459,16 +459,16 @@ class cmd {
 		return self::cast(DB::Prepare($sql, $values, DB::FETCH_TYPE_ALL, PDO::FETCH_CLASS, __CLASS__));
 	}
 
-    /**
-     * Search commands by template
-     *
-     * @param string $_template Template to search
-     * @param string|null $_eqType Equipment type filter
-     * @param string|null $_type Command type filter ('action'|'info'|null)
-     * @param string|null $_subtype Command subtype filter
-     * @return static[] Array of matching commands
-     * @throws Exception
-     */
+	/**
+	 * Search commands by template
+	 *
+	 * @param string $_template Template to search
+	 * @param string|null $_eqType Equipment type filter
+	 * @param string|null $_type Command type filter ('action'|'info'|null)
+	 * @param string|null $_subtype Command subtype filter
+	 * @return static[] Array of matching commands
+	 * @throws Exception
+	 */
 	public static function searchTemplate($_template, $_eqType = null, $_type = null, $_subtype = null) {
 		$values = array(
 			'template' => '%' . $_template . '%',
@@ -492,17 +492,17 @@ class cmd {
 		return self::cast(DB::Prepare($sql, $values, DB::FETCH_TYPE_ALL, PDO::FETCH_CLASS, __CLASS__));
 	}
 
-    /**
-     * Get command by equipment ID and logical ID
-     *
-     * @param int $_eqLogic_id Equipment ID
-     * @param int $_logicalId Logical ID
-     * @param bool $_multiple Allow multiple results
-     * @param string|null $_type Command type filter ('action'|'info'|null)
-     * @param eqLogic|null $_eqLogic Parent equipment
-     * @return static|static[] Command(s) found
-     * @throws Exception
-     */
+	/**
+	 * Get command by equipment ID and logical ID
+	 *
+	 * @param int $_eqLogic_id Equipment ID
+	 * @param int $_logicalId Logical ID
+	 * @param bool $_multiple Allow multiple results
+	 * @param string|null $_type Command type filter ('action'|'info'|null)
+	 * @param eqLogic|null $_eqLogic Parent equipment
+	 * @return static|static[] Command(s) found
+	 * @throws Exception
+	 */
 	public static function byEqLogicIdAndLogicalId($_eqLogic_id, $_logicalId, $_multiple = false, $_type = null, $_eqLogic = null) {
 		$values = array(
 			'eqLogic_id' => $_eqLogic_id,
@@ -529,17 +529,17 @@ class cmd {
 		return self::cast(DB::Prepare($sql, $values, DB::FETCH_TYPE_ROW, PDO::FETCH_CLASS, __CLASS__));
 	}
 
-    /**
-     * Get command by equipment ID and generic type
-     *
-     * @param int $_eqLogic_id Equipment ID
-     * @param string $_generic_type Generic type
-     * @param bool $_multiple Allow multiple results
-     * @param string|null $_type Command type filter ('action'|'info'|null)
-     * @param eqLogic|null $_eqLogic Parent equipment
-     * @return static|static[] Command(s) found
-     * @throws Exception
-     */
+	/**
+	 * Get command by equipment ID and generic type
+	 *
+	 * @param int $_eqLogic_id Equipment ID
+	 * @param string $_generic_type Generic type
+	 * @param bool $_multiple Allow multiple results
+	 * @param string|null $_type Command type filter ('action'|'info'|null)
+	 * @param eqLogic|null $_eqLogic Parent equipment
+	 * @return static|static[] Command(s) found
+	 * @throws Exception
+	 */
 	public static function byEqLogicIdAndGenericType($_eqLogic_id, $_generic_type, $_multiple = false, $_type = null, $_eqLogic = null) {
 		$values = array(
 			'eqLogic_id' => $_eqLogic_id,
@@ -565,15 +565,15 @@ class cmd {
 		return self::cast(DB::Prepare($sql, $values, DB::FETCH_TYPE_ROW, PDO::FETCH_CLASS, __CLASS__));
 	}
 
-    /**
-     * Get commands by generic type and object ID
-     *
-     * @param string $_generic_type Generic type
-     * @param int|null $_object_id Object ID filter
-     * @param string|null $_type Command type filter ('action'|'info'|null)
-     * @return static[]|void Array of commands or void if none found
-     * @throws Exception
-     */
+	/**
+	 * Get commands by generic type and object ID
+	 *
+	 * @param string $_generic_type Generic type
+	 * @param int|null $_object_id Object ID filter
+	 * @param string|null $_type Command type filter ('action'|'info'|null)
+	 * @return static[]|void Array of commands or void if none found
+	 * @throws Exception
+	 */
 	public static function byGenericTypeObjectId($_generic_type, $_object_id = null, $_type = null) {
 		$values = array(
 			'generic_type' => $_generic_type
@@ -607,15 +607,15 @@ class cmd {
 		return self::cast(DB::Prepare($sql, $values, DB::FETCH_TYPE_ALL, PDO::FETCH_CLASS, __CLASS__));
 	}
 
-    /**
-     * Get commands by value
-     *
-     * @param mixed $_value Value to search
-     * @param string|null $_type Command type filter ('action'|'info'|null)
-     * @param bool $_onlyEnable Filter on enabled equipment only
-     * @return static[] Array of matching commands
-     * @throws Exception
-     */
+	/**
+	 * Get commands by value
+	 *
+	 * @param mixed $_value Value to search
+	 * @param string|null $_type Command type filter ('action'|'info'|null)
+	 * @param bool $_onlyEnable Filter on enabled equipment only
+	 * @return static[] Array of matching commands
+	 * @throws Exception
+	 */
 	public static function byValue($_value, $_type = null, $_onlyEnable = false) {
 		$values = array(
 			'value' => $_value,
@@ -648,15 +648,15 @@ class cmd {
 		return self::cast(DB::Prepare($sql, $values, DB::FETCH_TYPE_ALL, PDO::FETCH_CLASS, __CLASS__));
 	}
 
-    /**
-     * Get command by equipment type, name and command name
-     *
-     * @param string $_eqType_name Equipment type
-     * @param string $_eqLogic_name Equipment name
-     * @param string $_cmd_name Command name
-     * @return static Matching command
-     * @throws Exception
-     */
+	/**
+	 * Get command by equipment type, name and command name
+	 *
+	 * @param string $_eqType_name Equipment type
+	 * @param string $_eqLogic_name Equipment name
+	 * @param string $_cmd_name Command name
+	 * @return static Matching command
+	 * @throws Exception
+	 */
 	public static function byTypeEqLogicNameCmdName($_eqType_name, $_eqLogic_name, $_cmd_name) {
 		$values = array(
 			'eqType_name' => $_eqType_name,
@@ -675,14 +675,14 @@ class cmd {
 		return self::cast(DB::Prepare($sql, $values, DB::FETCH_TYPE_ROW, PDO::FETCH_CLASS, __CLASS__));
 	}
 
-    /**
-     * Get command by equipment ID and command name
-     *
-     * @param int $_eqLogic_id Equipment ID
-     * @param string $_cmd_name Command name
-     * @return static Matching command
-     * @throws Exception
-     */
+	/**
+	 * Get command by equipment ID and command name
+	 *
+	 * @param int $_eqLogic_id Equipment ID
+	 * @param string $_cmd_name Command name
+	 * @return static Matching command
+	 * @throws Exception
+	 */
 	public static function byEqLogicIdCmdName($_eqLogic_id, $_cmd_name) {
 		$values = array(
 			'eqLogic_id' => $_eqLogic_id,
@@ -695,15 +695,15 @@ class cmd {
 		return self::cast(DB::Prepare($sql, $values, DB::FETCH_TYPE_ROW, PDO::FETCH_CLASS, __CLASS__));
 	}
 
-    /**
-     * Get command by object name, equipment name and command name
-     *
-     * @param string $_object_name Object name
-     * @param string $_eqLogic_name Equipment name
-     * @param string $_cmd_name Command name
-     * @return static Matching command
-     * @throws Exception
-     */
+	/**
+	 * Get command by object name, equipment name and command name
+	 *
+	 * @param string $_object_name Object name
+	 * @param string $_eqLogic_name Equipment name
+	 * @param string $_cmd_name Command name
+	 * @return static Matching command
+	 * @throws Exception
+	 */
 	public static function byObjectNameEqLogicNameCmdName($_object_name, $_eqLogic_name, $_cmd_name) {
 		$values = array(
 			'eqLogic_name' => $_eqLogic_name,
@@ -730,14 +730,14 @@ class cmd {
 		return self::cast(DB::Prepare($sql, $values, DB::FETCH_TYPE_ROW, PDO::FETCH_CLASS, __CLASS__));
 	}
 
-    /**
-     * Get command by object name and command name
-     *
-     * @param string $_object_name Object name
-     * @param string $_cmd_name Command name
-     * @return static Matching command
-     * @throws Exception
-     */
+	/**
+	 * Get command by object name and command name
+	 *
+	 * @param string $_object_name Object name
+	 * @param string $_cmd_name Command name
+	 * @return static Matching command
+	 * @throws Exception
+	 */
 	public static function byObjectNameCmdName($_object_name, $_cmd_name) {
 		$values = array(
 			'object_name' => $_object_name,
@@ -752,14 +752,14 @@ class cmd {
 		return self::cast(DB::Prepare($sql, $values, DB::FETCH_TYPE_ROW, PDO::FETCH_CLASS, __CLASS__));
 	}
 
-    /**
-     * Get commands by type and subtype
-     *
-     * @param string $_type Command type ('action'|'info')
-     * @param string $_subType Command subtype
-     * @return static[] Array of matching commands
-     * @throws Exception
-     */
+	/**
+	 * Get commands by type and subtype
+	 *
+	 * @param string $_type Command type ('action'|'info')
+	 * @param string $_subType Command subtype
+	 * @return static[] Array of matching commands
+	 * @throws Exception
+	 */
 	public static function byTypeSubType($_type, $_subType = '') {
 		$values = array(
 			'type' => $_type,
@@ -774,13 +774,13 @@ class cmd {
 		return self::cast(DB::Prepare($sql, $values, DB::FETCH_TYPE_ALL, PDO::FETCH_CLASS, __CLASS__));
 	}
 
-    /**
-     * Replace command IDs with human readable format
-     *
-     * @param object|array<string, mixed>|string $_input Input to convert
-     * @return object|array<string, mixed>|string Converted input
-     * @throws ReflectionException
-     */
+	/**
+	 * Replace command IDs with human readable format
+	 *
+	 * @param object|array<string, mixed>|string $_input Input to convert
+	 * @return object|array<string, mixed>|string Converted input
+	 * @throws ReflectionException
+	 */
 	public static function cmdToHumanReadable($_input) {
 		if (is_object($_input)) {
 			$reflections = array();
@@ -818,13 +818,13 @@ class cmd {
 		return str_replace(array_keys($replace), $replace, $_input);
 	}
 
-    /**
-     * Replace human readable format with command IDs
-     *
-     * @param string|object|array<string, mixed>|int|bool|null $_input Input to convert
-     * @return array|bool|int|mixed|string|string[]|null Converted input
-     * @throws ReflectionException
-     */
+	/**
+	 * Replace human readable format with command IDs
+	 *
+	 * @param string|object|array<string, mixed>|int|bool|null $_input Input to convert
+	 * @return array|bool|int|mixed|string|string[]|null Converted input
+	 * @throws ReflectionException
+	 */
 	public static function humanReadableToCmd($_input) {
 		$isJson = false;
 		if (is_json($_input)) {
@@ -878,14 +878,14 @@ class cmd {
 		return str_replace(array_keys($replace), $replace, $_input);
 	}
 
-    /**
-     * Get command from string representation
-     *
-     * @param string $_string String to convert to command
-     * @return static Command object
-     * @throws ReflectionException
-     * @throws Exception
-     */
+	/**
+	 * Get command from string representation
+	 *
+	 * @param string $_string String to convert to command
+	 * @return static Command object
+	 * @throws ReflectionException
+	 * @throws Exception
+	 */
 	public static function byString($_string) {
 		$cmd = self::byId(str_replace('#', '', self::humanReadableToCmd($_string)));
 		if (!is_object($cmd)) {
@@ -894,14 +894,14 @@ class cmd {
 		return $cmd;
 	}
 
-    /**
-     * Replace command IDs with their values
-     *
-     * @param object|array<string, mixed>|string $_input Input to convert
-     * @param bool $_quote Quote values
-     * @return object|array<string, mixed>|string Converted input
-     * @throws ReflectionException
-     */
+	/**
+	 * Replace command IDs with their values
+	 *
+	 * @param object|array<string, mixed>|string $_input Input to convert
+	 * @param bool $_quote Quote values
+	 * @return object|array<string, mixed>|string Converted input
+	 * @throws ReflectionException
+	 */
 	public static function cmdToValue($_input, $_quote = false) {
 		if (config::byKey('expression::autoQuote', 'core', 1) == 0) {
 			$_quote = false;
@@ -966,25 +966,25 @@ class cmd {
 		return str_replace(array_keys($replace), $replace, $_input);
 	}
 
-    /**
-     * Get all distinct command types
-     *
-     * @return string[] Array of command types
-     * @throws Exception
-     */
+	/**
+	 * Get all distinct command types
+	 *
+	 * @return string[] Array of command types
+	 * @throws Exception
+	 */
 	public static function allType() {
 		$sql = 'SELECT distinct(type) as type
 		FROM cmd';
 		return DB::Prepare($sql, array(), DB::FETCH_TYPE_ALL);
 	}
 
-    /**
-     * Get all distinct command subtypes
-     *
-     * @param string $_type Filter by command type
-     * @return string[] Array of command subtypes
-     * @throws Exception
-     */
+	/**
+	 * Get all distinct command subtypes
+	 *
+	 * @param string $_type Filter by command type
+	 * @return string[] Array of command subtypes
+	 * @throws Exception
+	 */
 	public static function allSubType($_type = '') {
 		$values = array();
 		$sql = 'SELECT distinct(subType) as subtype';
@@ -996,24 +996,24 @@ class cmd {
 		return DB::Prepare($sql, $values, DB::FETCH_TYPE_ALL);
 	}
 
-    /**
-     * Get all distinct command units
-     *
-     * @return string[] Array of units
-     * @throws Exception
-     */
+	/**
+	 * Get all distinct command units
+	 *
+	 * @return string[] Array of units
+	 * @throws Exception
+	 */
 	public static function allUnite() {
 		$sql = 'SELECT distinct(unite) as unite
 		FROM cmd';
 		return DB::Prepare($sql, array(), DB::FETCH_TYPE_ALL);
 	}
 
-    /**
-     * Get all distinct command units
-     *
-     * @return string[] Array of units
-     * @throws Exception
-     */
+	/**
+	 * Get all distinct command units
+	 *
+	 * @return string[] Array of units
+	 * @throws Exception
+	 */
 	public static function convertColor($_color) {
 		$colors = config::byKey('convertColor');
 		if (isset($colors[$_color])) {
@@ -1022,12 +1022,12 @@ class cmd {
 		throw new Exception(__('Impossible de traduire la couleur en code hexadécimal :', __FILE__) . $_color);
 	}
 
-    /**
-     * Get available widgets for version
-     *
-     * @param string $_version Version to check
-     * @return array<string, array<string, array<string, array<string, int|string>>>> Available widgets
-     */
+	/**
+	 * Get available widgets for version
+	 *
+	 * @param string $_version Version to check
+	 * @return array<string, array<string, array<string, array<string, int|string>>>> Available widgets
+	 */
 	public static function availableWidget($_version) {
 		global $JEEDOM_INTERNAL_CONFIG;
 		$return = array();
@@ -1139,16 +1139,16 @@ class cmd {
 		return $return;
 	}
 
-    /**
-     * Get widget selection options by type and subtype
-     *
-     * @param string|false $_type Command type ('action'|'info'|false)
-     * @param string|false $_subtype Command subtype
-     * @param string $_version Widget version
-     * @param bool $_availWidgets Pre-loaded available widgets
-     * @return int|string|void|null Options HTML string or error code
-     * @throws Exception
-     */
+	/**
+	 * Get widget selection options by type and subtype
+	 *
+	 * @param string|false $_type Command type ('action'|'info'|false)
+	 * @param string|false $_subtype Command subtype
+	 * @param string $_version Widget version
+	 * @param bool $_availWidgets Pre-loaded available widgets
+	 * @return int|string|void|null Options HTML string or error code
+	 * @throws Exception
+	 */
 	public static function getSelectOptionsByTypeAndSubtype($_type = false, $_subtype = false, $_version = 'dashboard', $_availWidgets = false) {
 		if ($_type === false || $_subtype === false) {
 			throw new Exception(__('Type ou sous-type de commande invalide', __FILE__));
@@ -1194,12 +1194,12 @@ class cmd {
 		}
 	}
 
-    /**
-     * Return state after delay
-     *
-     * @param array<string, int> $_options Command options
-     * @return void
-     */
+	/**
+	 * Return state after delay
+	 *
+	 * @param array<string, int> $_options Command options
+	 * @return void
+	 */
 	public static function returnState($_options) {
 		$cmd = cmd::byId($_options['cmd_id']);
 		if (is_object($cmd)) {
@@ -1207,11 +1207,11 @@ class cmd {
 		}
 	}
 
-    /**
-     * Find commands without valid references
-     *
-     * @return array<string, string>[] List of dead commands
-     */
+	/**
+	 * Find commands without valid references
+	 *
+	 * @return array<string, string>[] List of dead commands
+	 */
 	public static function deadCmd() {
 		$return = array();
 		foreach ((cmd::all()) as $cmd) {
@@ -1249,12 +1249,12 @@ class cmd {
 		return $return;
 	}
 
-    /**
-     * Process command alerts
-     *
-     * @param array<string, int> $_options Command options
-     * @return void
-     */
+	/**
+	 * Process command alerts
+	 *
+	 * @param array<string, int> $_options Command options
+	 * @return void
+	 */
 	public static function cmdAlert($_options) {
 		$cmd = cmd::byId($_options['cmd_id']);
 		if (!is_object($cmd)) {
@@ -1265,13 +1265,13 @@ class cmd {
 
 	/*	 * *********************Méthodes d'instance************************* */
 
-    /**
-     * Format command value according to its configuration
-     *
-     * @param array|object|null|string $_value Value to format
-     * @param bool $_quote Add quotes around value
-     * @return float|int|mixed|string Formatted value
-     */
+	/**
+	 * Format command value according to its configuration
+	 *
+	 * @param array|object|null|string $_value Value to format
+	 * @param bool $_quote Add quotes around value
+	 * @return float|int|mixed|string Formatted value
+	 */
 	public function formatValue($_value, $_quote = false) {
 		if (is_array($_value) || is_object($_value)) {
 			return '';
@@ -1347,40 +1347,40 @@ class cmd {
 		return $_value;
 	}
 
-    /**
-     * Get last stored value
-     *
-     * @return mixed|mixed[] Last value
-     */
+	/**
+	 * Get last stored value
+	 *
+	 * @return mixed|mixed[] Last value
+	 */
 	public function getLastValue() {
 		return $this->getConfiguration('lastCmdValue', null);
 	}
 
-    /**
-     * Check if command can be removed
-     *
-     * @return bool False by default
-     */
+	/**
+	 * Check if command can be removed
+	 *
+	 * @return bool False by default
+	 */
 	public function dontRemoveCmd() {
 		return false;
 	}
 
-    /**
-     * Get database table name
-     *
-     * @return string Table name
-     */
+	/**
+	 * Get database table name
+	 *
+	 * @return string Table name
+	 */
 	public function getTableName() {
 		return 'cmd';
 	}
 
-    /**
-     * Save command to database
-     *
-     * @param bool $_direct Direct save without trigger
-     * @return bool Success status
-     * @throws Exception
-     */
+	/**
+	 * Save command to database
+	 *
+	 * @param bool $_direct Direct save without trigger
+	 * @return bool Success status
+	 * @throws Exception
+	 */
 	public function save($_direct = false) {
 		if ($this->getName() == '') {
 			throw new Exception(__('Le nom de la commande ne peut pas être vide :', __FILE__) . print_r($this, true));
@@ -1439,21 +1439,21 @@ class cmd {
 		return true;
 	}
 
-    /**
-     * Refresh command from database
-     *
-     * @return void
-     * @throws Exception
-     */
+	/**
+	 * Refresh command from database
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
 	public function refresh() {
 		DB::refresh($this);
 	}
 
-    /**
-     * Remove command
-     *
-     * @return bool Success status
-     */
+	/**
+	 * Remove command
+	 *
+	 * @return bool Success status
+	 */
 	public function remove() {
 		viewData::removeByTypeLinkId('cmd', $this->getId());
 		dataStore::removeByTypeLinkId('cmd', $this->getId());
@@ -1471,23 +1471,23 @@ class cmd {
 		return DB::remove($this);
 	}
 
-    /**
-     * Execute command
-     *
-     * @param array<string, mixed> $_options Execution options
-     * @return bool Execution status
-     */
+	/**
+	 * Execute command
+	 *
+	 * @param array<string, mixed> $_options Execution options
+	 * @return bool Execution status
+	 */
 	public function execute($_options = array()) {
 		return false;
 	}
 
-    /**
-     * Execute pre/post command actions
-     *
-     * @param array<string, string> $_values Action values
-     * @param string $_type Action type ('jeedomPreExecCmd'|'jeedomPostExecCmd')
-     * @return void
-     */
+	/**
+	 * Execute pre/post command actions
+	 *
+	 * @param array<string, string> $_values Action values
+	 * @param string $_type Action type ('jeedomPreExecCmd'|'jeedomPostExecCmd')
+	 * @return void
+	 */
 	private function pre_postExecCmd($_values = array(), $_type = 'jeedomPreExecCmd') {
 
 		if (!is_array($this->getConfiguration($_type)) || count($this->getConfiguration($_type)) == 0) {
@@ -1526,12 +1526,12 @@ class cmd {
 		}
 	}
 
-    /**
-     * Execute pre-command actions
-     *
-     * @param array<string, string> $_values Action values
-     * @return void
-     */
+	/**
+	 * Execute pre-command actions
+	 *
+	 * @param array<string, string> $_values Action values
+	 * @return void
+	 */
 	public function preExecCmd($_values = array()) {
 		if (isset($_values['user_login'])) {
 			$this->setCache('lastExecutionUser', $_values['user_login']);
@@ -1541,21 +1541,21 @@ class cmd {
 		$this->pre_postExecCmd($_values, 'jeedomPreExecCmd');
 	}
 
-    /**
-     * Execute post-command actions
-     *
-     * @param array<string, string> $_values Action values
-     * @return void
-     */
+	/**
+	 * Execute post-command actions
+	 *
+	 * @param array<string, string> $_values Action values
+	 * @return void
+	 */
 	public function postExecCmd($_values = array()) {
 		$this->pre_postExecCmd($_values, 'jeedomPostExecCmd');
 	}
 
-    /**
-     * Check if command is already in desired state
-     *
-     * @return bool State check result
-     */
+	/**
+	 * Check if command is already in desired state
+	 *
+	 * @return bool State check result
+	 */
 	public function isAlreadyInStateAllow() {
 		if ($this->getConfiguration('alreadyInState') == 'deny') {
 			return false;
@@ -1576,13 +1576,13 @@ class cmd {
 		return true;
 	}
 
-    /**
-     * Check if command is in specific state
-     *
-     * @param array<string, mixed> $_options Command options
-     * @return bool State verification result
-     * @throws Exception
-     */
+	/**
+	 * Check if command is in specific state
+	 *
+	 * @param array<string, mixed> $_options Command options
+	 * @return bool State verification result
+	 * @throws Exception
+	 */
 	public function alreadyInState($_options) {
 		if ($this->getSubType() == 'message') {
 			return false;
@@ -1615,15 +1615,15 @@ class cmd {
 		return false;
 	}
 
-    /**
-     * Execute command with options
-     *
-     * @param null|string|array<string, mixed> $_options Execution options
-     * @param bool $_sendNodeJsEvent Send NodeJS event
-     * @param bool $_quote Quote values
-     * @return void|string Command execution result
-     * @throws Exception
-     */
+	/**
+	 * Execute command with options
+	 *
+	 * @param null|string|array<string, mixed> $_options Execution options
+	 * @param bool $_sendNodeJsEvent Send NodeJS event
+	 * @param bool $_quote Quote values
+	 * @return void|string Command execution result
+	 * @throws Exception
+	 */
 	public function execCmd($_options = null, $_sendNodeJsEvent = false, $_quote = false) {
 		if ($this->getType() == 'info') {
 			$state = $this->getCache(array('collectDate', 'valueDate', 'value', 'usage'));
@@ -1751,14 +1751,14 @@ class cmd {
 	}
 
 	// Used by modals eqLogic.dashboard.edit and cmd.configure
-    /**
-     * Get widget select options for version
-     *
-     * @param string $_version Widget version
-     * @param bool $_availWidgets Pre-loaded available widgets
-     * @return string HTML options string
-     * @throws Exception
-     */
+	/**
+	 * Get widget select options for version
+	 *
+	 * @param string $_version Widget version
+	 * @param bool $_availWidgets Pre-loaded available widgets
+	 * @return string HTML options string
+	 * @throws Exception
+	 */
 	public function getWidgetsSelectOptions($_version = 'dashboard', $_availWidgets = false) {
 		if (!$_availWidgets) {
 			$_availWidgets = self::availableWidget($_version);
@@ -1771,11 +1771,11 @@ class cmd {
 		return $display .= self::getSelectOptionsByTypeAndSubtype($this->getType(), $this->getSubType(), $_version, $_availWidgets);
 	}
 
-    /**
-     * Get generic type select options
-     *
-     * @return string HTML options string
-     */
+	/**
+	 * Get generic type select options
+	 *
+	 * @return string HTML options string
+	 */
 	public function getGenericTypeSelectOptions() {
 		$display = '<option value="">{{Aucun}}</option>';
 		$groups = array();
@@ -1812,13 +1812,13 @@ class cmd {
 		return $display;
 	}
 
-    /**
-     * Get widget help text
-     *
-     * @param string $_version Widget version
-     * @param string $_widgetName Widget name
-     * @return string Help text
-     */
+	/**
+	 * Get widget help text
+	 *
+	 * @param string $_version Widget version
+	 * @param string $_widgetName Widget name
+	 * @return string Help text
+	 */
 	public function getWidgetHelp($_version = 'dashboard', $_widgetName = '') {
 		$_version = jeedom::versionAlias($_version);
 		$widget = $this->getWidgetTemplateCode($_version, false, $_widgetName);
@@ -1843,26 +1843,26 @@ class cmd {
 		}
 	}
 
-    /**
-     * Clean widget code from template and helper content
-     *
-     * @param string $_template Widget template code
-     * @return string Cleaned widget code
-     */
+	/**
+	 * Clean widget code from template and helper content
+	 *
+	 * @param string $_template Widget template code
+	 * @return string Cleaned widget code
+	 */
 	public function cleanWidgetCode($_template) {
 		$_template = preg_replace('/<template>[\s\S]+?<\/template>/', '', $_template);
 		$_template = str_replace(array('<template>', '</template>'), '', $_template);
 		return $_template;
 	}
 
-    /**
-     * Get widget template code
-     *
-     * @param string $_version Widget version
-     * @param bool $_clean Clean template code
-     * @param string $_widgetName Widget name
-     * @return array<string, mixed> Widget template data
-     */
+	/**
+	 * Get widget template code
+	 *
+	 * @param string $_version Widget version
+	 * @param bool $_clean Clean template code
+	 * @param string $_widgetName Widget name
+	 * @return array<string, mixed> Widget template data
+	 */
 	public function getWidgetTemplateCode($_version = 'dashboard', $_clean = true, $_widgetName = '') {
 		global $JEEDOM_INTERNAL_CONFIG;
 		$_version = jeedom::versionAlias($_version);
@@ -2008,15 +2008,15 @@ class cmd {
 		return array('template' => $template, 'isCoreWidget' => true, 'widgetName' => $template_name);
 	}
 
-    /**
-     * Auto-format value and unit
-     *
-     * @param int|float $_value Value to format
-     * @param int $_decimal Number of decimals
-     * @param string $_unit Unit string
-     * @param bool $_space Add space between value and unit
-     * @return array<float|int|string> Array with formatted value and unit
-     */
+	/**
+	 * Auto-format value and unit
+	 *
+	 * @param int|float $_value Value to format
+	 * @param int $_decimal Number of decimals
+	 * @param string $_unit Unit string
+	 * @param bool $_space Add space between value and unit
+	 * @return array<float|int|string> Array with formatted value and unit
+	 */
 	public static function autoValueArray($_value, $_decimal = 99, $_unit = '', $_space = False) {
 		$_unit = str_replace("\"", "", $_unit);
 		$_unit = str_replace("\'", "", $_unit);
@@ -2030,14 +2030,14 @@ class cmd {
 		}
 	}
 
-    /**
-     * Format value based on modulo
-     *
-     * @param int|float $_value Value to format
-     * @param int|float $_mod Modulo value
-     * @param int|float $_maxdiv Maximum division
-     * @return array<int|float> Formatted value array
-     */
+	/**
+	 * Format value based on modulo
+	 *
+	 * @param int|float $_value Value to format
+	 * @param int|float $_mod Modulo value
+	 * @param int|float $_maxdiv Maximum division
+	 * @return array<int|float> Formatted value array
+	 */
 	private static function autoValueFormat($_value, $_mod = 1000, $_maxdiv = 10) {
 		if ($_value < 0) {
 			$val = floatval(-$_value);
@@ -2056,14 +2056,14 @@ class cmd {
 		return array($val, $div);
 	}
 
-    /**
-     * Generate HTML representation
-     *
-     * @param string $_version Template version
-     * @param mixed $_options Widget options
-     * @return string HTML code
-     * @throws Exception
-     */
+	/**
+	 * Generate HTML representation
+	 *
+	 * @param string $_version Template version
+	 * @param mixed $_options Widget options
+	 * @return string HTML code
+	 * @throws Exception
+	 */
 	public function toHtml($_version = 'dashboard', $_options = '') {
 		$_version = jeedom::versionAlias($_version);
 		$html = '';
@@ -2278,15 +2278,15 @@ class cmd {
 		return $template;
 	}
 
-    /**
-     * Process command event
-     *
-     * @param mixed $_value Event value
-     * @param string|null $_datetime Event datetime
-     * @param int $_loop Current loop count
-     * @return void
-     * @throws Exception
-     */
+	/**
+	 * Process command event
+	 *
+	 * @param mixed $_value Event value
+	 * @param string|null $_datetime Event datetime
+	 * @param int $_loop Current loop count
+	 * @return void
+	 * @throws Exception
+	 */
 	public function event($_value, $_datetime = null, $_loop = 1) {
 		if ($_loop > 4 || $this->getType() != 'info') {
 			return;
@@ -2403,12 +2403,12 @@ class cmd {
 		}
 	}
 
-    /**
-     * Check command return state
-     *
-     * @param mixed $_value Value to check
-     * @return void
-     */
+	/**
+	 * Check command return state
+	 *
+	 * @param mixed $_value Value to check
+	 * @return void
+	 */
 	public function checkReturnState($_value) {
 		if (is_numeric($this->getConfiguration('returnStateTime')) && $this->getConfiguration('returnStateTime') > 0 && $_value != $this->getConfiguration('returnStateValue') && trim($this->getConfiguration('returnStateValue')) != '') {
 			$cron = cron::byClassAndFunction('cmd', 'returnState', array('cmd_id' => intval($this->getId())));
@@ -2426,12 +2426,12 @@ class cmd {
 		}
 	}
 
-    /**
-     * Check command alerts
-     *
-     * @param mixed $_value Value to check
-     * @return void
-     */
+	/**
+	 * Check command alerts
+	 *
+	 * @param mixed $_value Value to check
+	 * @return void
+	 */
 	public function checkCmdAlert($_value) {
 		if ($this->getConfiguration('jeedomCheckCmdOperator') == '' || $this->getConfiguration('jeedomCheckCmdTest') == '' || !is_numeric($this->getConfiguration('jeedomCheckCmdTime', 0))) {
 			return;
@@ -2472,11 +2472,11 @@ class cmd {
 		}
 	}
 
-    /**
-     * Execute command alert actions
-     *
-     * @return void
-     */
+	/**
+	 * Execute command alert actions
+	 *
+	 * @return void
+	 */
 	public function executeAlertCmdAction() {
 		if (!is_array($this->getConfiguration('actionCheckCmd'))) {
 			return;
@@ -2495,14 +2495,14 @@ class cmd {
 		}
 	}
 
-    /**
-     * Check alert level for value
-     *
-     * @param string $_value Value to check
-     * @param bool $_allowDuring Allow duration check
-     * @param string $_checkLevel Level to check
-     * @return string Alert level
-     */
+	/**
+	 * Check alert level for value
+	 *
+	 * @param string $_value Value to check
+	 * @param bool $_allowDuring Allow duration check
+	 * @param string $_checkLevel Level to check
+	 * @return string Alert level
+	 */
 	public function checkAlertLevel($_value, $_allowDuring = true, $_checkLevel = 'none') {
 		if ($this->getType() != 'info' || ($this->getAlert('warningif') == '' && $this->getAlert('dangerif') == '')) {
 			return 'none';
@@ -2557,13 +2557,13 @@ class cmd {
 		return $returnLevel;
 	}
 
-    /**
-     * Check alert level duration
-     *
-     * @param array<string, mixed> $_options Alert options
-     * @return void
-     * @throws Exception
-     */
+	/**
+	 * Check alert level duration
+	 *
+	 * @param array<string, mixed> $_options Alert options
+	 * @return void
+	 * @throws Exception
+	 */
 	public static function duringAlertLevel($_options) {
 		$cmd = cmd::byId($_options['cmd_id']);
 		if (!is_object($cmd)) {
@@ -2582,14 +2582,14 @@ class cmd {
 		}
 	}
 
-    /**
-     * Execute alert level actions
-     *
-     * @param string $_level Alert level
-     * @param mixed $_value Trigger value
-     * @return void
-     * @throws Exception
-     */
+	/**
+	 * Execute alert level actions
+	 *
+	 * @param string $_level Alert level
+	 * @param mixed $_value Trigger value
+	 * @return void
+	 * @throws Exception
+	 */
 	public function actionAlertLevel($_level, $_value) {
 		if ($this->getType() != 'info') {
 			return;
@@ -2658,12 +2658,12 @@ class cmd {
 		}
 	}
 
-    /**
-     * Push command value to configured URL
-     *
-     * @param string $_value Value to push
-     * @return void
-     */
+	/**
+	 * Push command value to configured URL
+	 *
+	 * @param string $_value Value to push
+	 * @return void
+	 */
 	public function pushUrl($_value) {
 		$url = $this->getConfiguration('jeedomPushUrl');
 		if ($url == '') {
@@ -2691,13 +2691,13 @@ class cmd {
 		}
 	}
 
-    /**
-     * Compute InfluxDB data point
-     *
-     * @param mixed $_value Value to store
-     * @param string $_timestamp Optional timestamp
-     * @return \InfluxDB\Point|'' InfluxDB point or empty string
-     */
+	/**
+	 * Compute InfluxDB data point
+	 *
+	 * @param mixed $_value Value to store
+	 * @param string $_timestamp Optional timestamp
+	 * @return \InfluxDB\Point|'' InfluxDB point or empty string
+	 */
 	public function computeInfluxData($_value, $_timestamp = '') {
 		$point = '';
 		try {
@@ -2755,12 +2755,12 @@ class cmd {
 		return $point;
 	}
 
-    /**
-     * Get InfluxDB connection
-     *
-     * @param int|null $_cmdId Command ID
-     * @return \InfluxDB\Database|string|void InfluxDB connection
-     */
+	/**
+	 * Get InfluxDB connection
+	 *
+	 * @param int|null $_cmdId Command ID
+	 * @return \InfluxDB\Database|string|void InfluxDB connection
+	 */
 	public static function getInflux($_cmdId = null) {
 		try {
 			if ($_cmdId) {
@@ -2797,12 +2797,12 @@ class cmd {
 		return '';
 	}
 
-    /**
-     * Push value to InfluxDB
-     *
-     * @param mixed $_value Value to push
-     * @return void
-     */
+	/**
+	 * Push value to InfluxDB
+	 *
+	 * @param mixed $_value Value to push
+	 * @return void
+	 */
 	public function pushInflux($_value = null) {
 		try {
 			$database = cmd::getInflux($this->getId());
@@ -2833,11 +2833,11 @@ class cmd {
 		return;
 	}
 
-    /**
-     * Drop InfluxDB database
-     *
-     * @return void
-     */
+	/**
+	 * Drop InfluxDB database
+	 *
+	 * @return void
+	 */
 	public function dropInflux() {
 		try {
 			$database = cmd::getInflux($this->getId());
@@ -2918,15 +2918,15 @@ class cmd {
 		$cron->save();
 	}
 
-    /**
-     * Generate API URL for ask response
-     *
-     * @param string $_response Response value
-     * @param string $_plugin Plugin name
-     * @param string $_network Network type
-     * @return string Generated URL
-     * @throws Exception
-     */
+	/**
+	 * Generate API URL for ask response
+	 *
+	 * @param string $_response Response value
+	 * @param string $_plugin Plugin name
+	 * @param string $_network Network type
+	 * @return string Generated URL
+	 * @throws Exception
+	 */
 	public function generateAskResponseLink($_response, $_plugin = 'core', $_network = 'external') {
 		if ($this->getCache('ask::token') == null || $this->getCache('ask::token') == '' || strlen($this->getCache('ask::token')) < 60) {
 			$this->setCache('ask::token', config::genKey());
@@ -2939,13 +2939,13 @@ class cmd {
 		return $return;
 	}
 
-    /**
-     * Process ask response
-     *
-     * @param mixed $_response Response value
-     * @return bool Success status
-     * @throws Exception
-     */
+	/**
+	 * Process ask response
+	 *
+	 * @param mixed $_response Response value
+	 * @return bool Success status
+	 * @throws Exception
+	 */
 	public function askResponse($_response) {
 		if ($this->getCache('ask::variable', 'none') == 'none') {
 			return false;
@@ -2967,12 +2967,12 @@ class cmd {
 		return true;
 	}
 
-    /**
-     * Empty command history
-     *
-     * @param string $_date Date before which to empty history
-     * @return null Operation result
-     */
+	/**
+	 * Empty command history
+	 *
+	 * @param string $_date Date before which to empty history
+	 * @return null Operation result
+	 */
 	public function emptyHistory($_date = '') {
 		if ($_date == '-1') {
 			$_date = '';
@@ -2980,13 +2980,13 @@ class cmd {
 		return history::emptyHistory($this->getId(), $_date);
 	}
 
-    /**
-     * Add value to command history
-     *
-     * @param mixed $_value Value to historize
-     * @param string $_datetime Date of the value
-     * @return void
-     */
+	/**
+	 * Add value to command history
+	 *
+	 * @param mixed $_value Value to historize
+	 * @param string $_datetime Date of the value
+	 * @return void
+	 */
 	public function addHistoryValue($_value, $_datetime = '') {
 		if ($this->getIsHistorized() == 1 && ($_value === null || ($_value !== '' && $this->getType() == 'info' && $_value <= $this->getConfiguration('maxValue', $_value) && $_value >= $this->getConfiguration('minValue', $_value)))) {
 			$history = new history();
@@ -2997,13 +2997,13 @@ class cmd {
 		}
 	}
 
-    /**
-     * Get command statistics
-     *
-     * @param string $_startTime Start date
-     * @param string $_endTime End date
-     * @return array<string, mixed> Statistics data
-     */
+	/**
+	 * Get command statistics
+	 *
+	 * @param string $_startTime Start date
+	 * @param string $_endTime End date
+	 * @return array<string, mixed> Statistics data
+	 */
 	public function getStatistique($_startTime, $_endTime) {
 		if ($this->getType() != 'info' || $this->getType() == 'string') {
 			return array();
@@ -3011,13 +3011,13 @@ class cmd {
 		return history::getStatistique($this->getId(), $_startTime, $_endTime);
 	}
 
-    /**
-     * Get temporal average
-     *
-     * @param string $_startTime Start date
-     * @param string $_endTime End date
-     * @return array|float|int Average value
-     */
+	/**
+	 * Get temporal average
+	 *
+	 * @param string $_startTime Start date
+	 * @param string $_endTime End date
+	 * @return array|float|int Average value
+	 */
 	public function getTemporalAvg($_startTime, $_endTime) {
 		if ($this->getType() != 'info' || $this->getType() == 'string') {
 			return array();
@@ -3025,22 +3025,22 @@ class cmd {
 		return history::getTemporalAvg($this->getId(), $_startTime, $_endTime);
 	}
 
-    /**
-     * Get value trend
-     *
-     * @param string $_startTime Start date
-     * @param string $_endTime End date
-     * @return float Trend value
-     */
+	/**
+	 * Get value trend
+	 *
+	 * @param string $_startTime Start date
+	 * @param string $_endTime End date
+	 * @return float Trend value
+	 */
 	public function getTendance($_startTime, $_endTime) {
 		return history::getTendance($this->getId(), $_startTime, $_endTime);
 	}
 
-    /**
-     * Get associated info command
-     *
-     * @return static|static[]|false Associated command(s) or false if none
-     */
+	/**
+	 * Get associated info command
+	 *
+	 * @return static|static[]|false Associated command(s) or false if none
+	 */
 	public function getCmdValue() {
 		if (is_object($cmd = cmd::byId($this->getValue()))) {
 			return $cmd;
@@ -3065,13 +3065,13 @@ class cmd {
 		return false;
 	}
 
-    /**
-     * Get human readable name
-     *
-     * @param bool $_tag Include HTML tags
-     * @param bool $_prettify Prettify output
-     * @return string Human readable name
-     */
+	/**
+	 * Get human readable name
+	 *
+	 * @param bool $_tag Include HTML tags
+	 * @param bool $_prettify Prettify output
+	 * @return string Human readable name
+	 */
 	public function getHumanName($_tag = false, $_prettify = false) {
 		$name = '';
 		$eqLogic = $this->getEqLogic();
@@ -3086,26 +3086,26 @@ class cmd {
 		return $name;
 	}
 
-    /**
-     * Get command history
-     *
-     * @param string|null $_dateStart Start date
-     * @param string|null $_dateEnd End date
-     * @param string|null $_groupingType Grouping type
-     * @param bool $_addFirstPreviousValue Include previous value
-     * @return history[] History data
-     */
+	/**
+	 * Get command history
+	 *
+	 * @param string|null $_dateStart Start date
+	 * @param string|null $_dateEnd End date
+	 * @param string|null $_groupingType Grouping type
+	 * @param bool $_addFirstPreviousValue Include previous value
+	 * @return history[] History data
+	 */
 	public function getHistory($_dateStart = null, $_dateEnd = null, $_groupingType = null, $_addFirstPreviousValue = false) {
 		return history::all($this->id, $_dateStart, $_dateEnd, $_groupingType, $_addFirstPreviousValue);
 	}
 
-    /**
-     * Get last history entry
-     *
-     * @param string $_time Reference time
-     * @param bool $_previous Include previous value
-     * @return array<string, mixed> History data with value and unit
-     */
+	/**
+	 * Get last history entry
+	 *
+	 * @param string $_time Reference time
+	 * @param bool $_previous Include previous value
+	 * @return array<string, mixed> History data with value and unit
+	 */
 	public function getLastHistory($_time, $_previous = true) {
 		$value = 0;
 		if ($this->getIsHistorized() == 1) {
@@ -3121,37 +3121,37 @@ class cmd {
 		return (array('value' => $value, 'unite' => $this->getUnite()));
 	}
 
-    /**
-     * Get oldest history entries
-     *
-     * @return historyArch[] Array of oldest history entries
-     */
+	/**
+	 * Get oldest history entries
+	 *
+	 * @return historyArch[] Array of oldest history entries
+	 */
 	public function getOldest() {
 		return history::getOldestValue($this->id);
 	}
 
-    /**
-     * Get history with multiple points
-     *
-     * @param string|null $_dateStart Start date
-     * @param string|null $_dateEnd End date
-     * @param string $_period Period type
-     * @param int $_offset Time offset
-     * @return history[] Array of history points
-     * @throws Exception
-     */
+	/**
+	 * Get history with multiple points
+	 *
+	 * @param string|null $_dateStart Start date
+	 * @param string|null $_dateEnd End date
+	 * @param string $_period Period type
+	 * @param int $_offset Time offset
+	 * @return history[] Array of history points
+	 * @throws Exception
+	 */
 	public function getPluralityHistory($_dateStart = null, $_dateEnd = null, $_period = 'day', $_offset = 0) {
 		return history::getPlurality($this->id, $_dateStart, $_dateEnd, $_period, $_offset);
 	}
 
-    /**
-     * Check widget customization possibilities
-     *
-     * @param string $_key Feature key to check
-     * @param bool $_default Default value if not found
-     * @return array<string, bool>|bool|mixed Feature availability
-     * @throws ReflectionException
-     */
+	/**
+	 * Check widget customization possibilities
+	 *
+	 * @param string $_key Feature key to check
+	 * @param bool $_default Default value if not found
+	 * @return array<string, bool>|bool|mixed Feature availability
+	 * @throws ReflectionException
+	 */
 	public function widgetPossibility($_key = '', $_default = true) {
 		$class = new ReflectionClass($this->getEqType_name());
 		$method_toHtml = $class->getMethod('toHtml');
@@ -3205,14 +3205,14 @@ class cmd {
 		return $return;
 	}
 
-    /**
-     * Migrate command configuration to another command
-     *
-     * @param int $_sourceId Source command ID
-     * @param int $_targetId Target command ID
-     * @return static Migrated command
-     * @throws Exception
-     */
+	/**
+	 * Migrate command configuration to another command
+	 *
+	 * @param int $_sourceId Source command ID
+	 * @param int $_targetId Target command ID
+	 * @return static Migrated command
+	 * @throws Exception
+	 */
 	public static function migrateCmd($_sourceId, $_targetId) {
 		$sourceCmd = cmd::byId($_sourceId);
 		if (!is_object($sourceCmd)) {
@@ -3346,11 +3346,11 @@ class cmd {
 		}
 	}
 
-    /**
-     * Export command configuration
-     *
-     * @return array<string, mixed> Exported configuration
-     */
+	/**
+	 * Export command configuration
+	 *
+	 * @return array<string, mixed> Exported configuration
+	 */
 	public function export() {
 		$cmd = clone $this;
 		$cmd->setId('');
@@ -3386,11 +3386,11 @@ class cmd {
 		return $return;
 	}
 
-    /**
-     * Get direct URL access
-     *
-     * @return string Access URL
-     */
+	/**
+	 * Get direct URL access
+	 *
+	 * @return string Access URL
+	 */
 	public function getDirectUrlAccess() {
 		$url = '/core/api/jeeApi.php?apikey=' . config::byKey('api') . '&type=cmd&id=' . $this->getId();
 		if ($this->getType() == 'action') {
@@ -3412,12 +3412,12 @@ class cmd {
 		return network::getNetworkAccess('external') . $url;
 	}
 
-    /**
-     * Check access code
-     *
-     * @param string $_code Code to verify
-     * @return bool Access granted
-     */
+	/**
+	 * Check access code
+	 *
+	 * @param string $_code Code to verify
+	 * @return bool Access granted
+	 */
 	public function checkAccessCode($_code) {
 		if ($this->getType() != 'action' || trim($this->getConfiguration('actionCodeAccess')) == '') {
 			return true;
@@ -3428,27 +3428,27 @@ class cmd {
 		return false;
 	}
 
-    /**
-     * Export command data for API
-     *
-     * @return mixed[]|mixed[][] Exported data
-     * @throws Exception
-     */
+	/**
+	 * Export command data for API
+	 *
+	 * @return mixed[]|mixed[][] Exported data
+	 * @throws Exception
+	 */
 	public function exportApi() {
 		$return = utils::o2a($this);
 		$return['currentValue'] = ($this->getType() !== 'action') ? $this->execCmd() : $this->getConfiguration('lastCmdValue', null);
 		return $return;
 	}
 
-    /**
-     * Get command dependency graph data
-     *
-     * @param array<string, array<string, array<string, mixed>>> $_data Existing graph data
-     * @param int $_level Current graph level
-     * @param string|null $_drill Maximum drill level
-     * @param bool $_include_use Include use
-     * @return array[]|mixed|void Graph data
-     */
+	/**
+	 * Get command dependency graph data
+	 *
+	 * @param array<string, array<string, array<string, mixed>>> $_data Existing graph data
+	 * @param int $_level Current graph level
+	 * @param string|null $_drill Maximum drill level
+	 * @param bool $_include_use Include use
+	 * @return array[]|mixed|void Graph data
+	 */
 	public function getLinkData(&$_data = array('node' => array(), 'link' => array()), $_level = 0, $_drill = null, $_include_use = true) {
 		if ($_drill === null) {
 			$_drill = config::byKey('graphlink::cmd::drill');
@@ -3496,12 +3496,12 @@ class cmd {
 		return $_data;
 	}
 
-    /**
-     * Get elements using this command
-     *
-     * @param bool $_array Return as array instead of objects
-     * @return array<string, array<int, object>> List of using elements
-     */
+	/**
+	 * Get elements using this command
+	 *
+	 * @param bool $_array Return as array instead of objects
+	 * @return array<string, array<int, object>> List of using elements
+	 */
 	public function getUsedBy($_array = false) {
 		$return = array('cmd' => array(), 'eqLogic' => array(), 'scenario' => array(), 'plan' => array(), 'view' => array());
 		$cmds = array_merge(self::searchConfiguration('#' . $this->getId() . '#'), cmd::byValue($this->getId()));
@@ -3531,21 +3531,21 @@ class cmd {
 		return $return;
 	}
 
-    /**
-     * Get elements used by this command
-     *
-     * @return array<string, array<int, object>> List of used elements
-     */
+	/**
+	 * Get elements used by this command
+	 *
+	 * @return array<string, array<int, object>> List of used elements
+	 */
 	public function getUse() {
 		return jeedom::getTypeUse(jeedom::fromHumanReadable(json_encode(utils::o2a($this))));
 	}
 
-    /**
-     * Check command access rights
-     *
-     * @param user|null $_user User to check
-     * @return bool Access granted
-     */
+	/**
+	 * Check command access rights
+	 *
+	 * @param user|null $_user User to check
+	 * @return bool Access granted
+	 */
 	public function hasRight($_user = null) {
 		if ($this->getType() == 'action') {
 			return $this->getEqLogic()->hasRight('x', $_user);
@@ -3556,104 +3556,104 @@ class cmd {
 
 	/*	 * **********************Getteur Setteur*************************** */
 
-    /**
-     * Get command ID
-     *
-     * @return int|''
-     */
+	/**
+	 * Get command ID
+	 *
+	 * @return int|''
+	 */
 	public function getId() {
 		return $this->id;
 	}
 
-    /**
-     * Get command name
-     *
-     * @return string|null
-     */
+	/**
+	 * Get command name
+	 *
+	 * @return string|null
+	 */
 	public function getName() {
 		return $this->name;
 	}
 
-    /**
-     * Get command generic type
-     *
-     * @return string|null
-     */
+	/**
+	 * Get command generic type
+	 *
+	 * @return string|null
+	 */
 	public function getGeneric_type() {
 		return $this->generic_type;
 	}
 
-    /**
-     * Set command generic type
-     *
-     * @param string $_generic_type Generic type to set
-     * @return static
-     */
+	/**
+	 * Set command generic type
+	 *
+	 * @param string $_generic_type Generic type to set
+	 * @return static
+	 */
 	public function setGeneric_type($_generic_type) {
 		$this->_changed = utils::attrChanged($this->_changed, $this->generic_type, $_generic_type);
 		$this->generic_type = $_generic_type;
 		return $this;
 	}
 
-    /**
-     * Get command type
-     *
-     * @return string|null 'action'|'info'|'string'
-     */
+	/**
+	 * Get command type
+	 *
+	 * @return string|null 'action'|'info'|'string'
+	 */
 	public function getType() {
 		return $this->type;
 	}
 
-    /**
-     * Get command subtype
-     *
-     * @return string|null 'binary'|'numeric'|'message'|'color'|'slider'|'string'
-     */
+	/**
+	 * Get command subtype
+	 *
+	 * @return string|null 'binary'|'numeric'|'message'|'color'|'slider'|'string'
+	 */
 	public function getSubType() {
 		return $this->subType;
 	}
 
-    /**
-     * Get equipment type name
-     *
-     * @return string|null
-     */
+	/**
+	 * Get equipment type name
+	 *
+	 * @return string|null
+	 */
 	public function getEqType_name() {
 		return $this->eqType;
 	}
 
-    /**
-     * Get parent equipment ID
-     *
-     * @return int|null
-     */
+	/**
+	 * Get parent equipment ID
+	 *
+	 * @return int|null
+	 */
 	public function getEqLogic_id() {
 		return $this->eqLogic_id;
 	}
 
-    /**
-     * Get historization state
-     *
-     * @return int
-     */
+	/**
+	 * Get historization state
+	 *
+	 * @return int
+	 */
 	public function getIsHistorized() {
 		return $this->isHistorized;
 	}
 
-    /**
-     * Get command unit
-     *
-     * @return string
-     */
+	/**
+	 * Get command unit
+	 *
+	 * @return string
+	 */
 	public function getUnite() {
 		return $this->unite;
 	}
 
-    /**
-     * Get parent equipment object
-     *
-     * @return eqLogic|null
-     */
+	/**
+	 * Get parent equipment object
+	 *
+	 * @return eqLogic|null
+	 */
 	public function getEqLogic() {
 		if ($this->_eqLogic === null) {
 			$this->setEqLogic(eqLogic::byId($this->eqLogic_id));
@@ -3661,44 +3661,44 @@ class cmd {
 		return $this->_eqLogic;
 	}
 
-    /**
-     * Set parent equipment object
-     *
-     * @param eqLogic|null $_eqLogic Parent equipment
-     * @return static
-     */
+	/**
+	 * Set parent equipment object
+	 *
+	 * @param eqLogic|null $_eqLogic Parent equipment
+	 * @return static
+	 */
 	public function setEqLogic($_eqLogic) {
 		$this->_eqLogic = $_eqLogic;
 		return $this;
 	}
 
-    /**
-     * Get event only status
-     *
-     * @return int
-     */
+	/**
+	 * Get event only status
+	 *
+	 * @return int
+	 */
 	public function getEventOnly() {
 		return 1;
 	}
 
-    /**
-     * Set command ID
-     *
-     * @param int|'' $_id ID to set
-     * @return static
-     */
+	/**
+	 * Set command ID
+	 *
+	 * @param int|'' $_id ID to set
+	 * @return static
+	 */
 	public function setId($_id = '') {
 		$this->_changed = utils::attrChanged($this->_changed, $this->id, $_id);
 		$this->id = $_id;
 		return $this;
 	}
 
-    /**
-     * Set command name
-     *
-     * @param string $_name Name to set
-     * @return static
-     */
+	/**
+	 * Set command name
+	 *
+	 * @param string $_name Name to set
+	 * @return static
+	 */
 	public function setName($_name) {
 		$_name = substr(cleanComponanteName($_name), 0, 127);
 		$_name = trim($_name);
@@ -3710,12 +3710,12 @@ class cmd {
 		return $this;
 	}
 
-    /**
-     * Set command type
-     *
-     * @param string $_type Type to set
-     * @return static
-     */
+	/**
+	 * Set command type
+	 *
+	 * @param string $_type Type to set
+	 * @return static
+	 */
 	public function setType($_type) {
 		if ($this->type != $_type) {
 			$this->_needRefreshWidget = true;
@@ -3725,12 +3725,12 @@ class cmd {
 		return $this;
 	}
 
-    /**
-     * Set command subtype
-     *
-     * @param string $_subType Subtype to set
-     * @return static
-     */
+	/**
+	 * Set command subtype
+	 *
+	 * @param string $_subType Subtype to set
+	 * @return static
+	 */
 	public function setSubType($_subType) {
 		if ($this->subType != $_subType) {
 			$this->_needRefreshWidget = true;
@@ -3740,36 +3740,36 @@ class cmd {
 		return $this;
 	}
 
-    /**
-     * Set parent equipment ID
-     *
-     * @param int|'' $_eqLogic_id Equipment ID to set
-     * @return static
-     */
+	/**
+	 * Set parent equipment ID
+	 *
+	 * @param int|'' $_eqLogic_id Equipment ID to set
+	 * @return static
+	 */
 	public function setEqLogic_id($_eqLogic_id) {
 		$this->_changed = utils::attrChanged($this->_changed, $this->eqLogic_id, $_eqLogic_id);
 		$this->eqLogic_id = $_eqLogic_id;
 		return $this;
 	}
 
-    /**
-     * Set historization state
-     *
-     * @param int $_isHistorized State to set
-     * @return static
-     */
+	/**
+	 * Set historization state
+	 *
+	 * @param int $_isHistorized State to set
+	 * @return static
+	 */
 	public function setIsHistorized($_isHistorized) {
 		$this->_changed = utils::attrChanged($this->_changed, $this->isHistorized, $_isHistorized);
 		$this->isHistorized = $_isHistorized;
 		return $this;
 	}
 
-    /**
-     * Set command unit
-     *
-     * @param string $_unite Unit to set
-     * @return static
-     */
+	/**
+	 * Set command unit
+	 *
+	 * @param string $_unite Unit to set
+	 * @return static
+	 */
 	public function setUnite($_unite) {
 		if ($this->unite != $_unite) {
 			$this->_needRefreshWidget = true;
@@ -3779,24 +3779,24 @@ class cmd {
 		return $this;
 	}
 
-    /**
-     * Get template configuration
-     *
-     * @param string $_key Key to get
-     * @param mixed $_default Default value
-     * @return mixed|array<string, mixed>
-     */
+	/**
+	 * Get template configuration
+	 *
+	 * @param string $_key Key to get
+	 * @param mixed $_default Default value
+	 * @return mixed|array<string, mixed>
+	 */
 	public function getTemplate($_key = '', $_default = '') {
 		return utils::getJsonAttr($this->template, $_key, $_default);
 	}
 
-    /**
-     * Set template configuration
-     *
-     * @param string $_key Key to set
-     * @param mixed $_value Value to set
-     * @return static
-     */
+	/**
+	 * Set template configuration
+	 *
+	 * @param string $_key Key to set
+	 * @param mixed $_value Value to set
+	 * @return static
+	 */
 	public function setTemplate($_key, $_value) {
 		if (($_key == 'dashboard' || $_key == 'mobile') && strpos($_value, '::') === false) {
 			$_value = 'core::' . $_value;
@@ -3809,24 +3809,24 @@ class cmd {
 		return $this;
 	}
 
-    /**
-     * Get configuration value
-     *
-     * @param string $_key Key to get
-     * @param mixed $_default Default value
-     * @return array<string, mixed>|mixed
-     */
+	/**
+	 * Get configuration value
+	 *
+	 * @param string $_key Key to get
+	 * @param mixed $_default Default value
+	 * @return array<string, mixed>|mixed
+	 */
 	public function getConfiguration($_key = '', $_default = '') {
 		return utils::getJsonAttr($this->configuration, $_key, $_default);
 	}
 
-    /**
-     * Set configuration value
-     *
-     * @param array<string, mixed>|string|int $_key
-     * @param mixed $_value Value to set
-     * @return static
-     */
+	/**
+	 * Set configuration value
+	 *
+	 * @param array<string, mixed>|string|int $_key
+	 * @param mixed $_value Value to set
+	 * @return static
+	 */
 	public function setConfiguration($_key, $_value) {
 		if ($_key == 'actionCodeAccess' && $_value != '') {
 			if (!is_sha1($_value) && !is_sha512($_value)) {
@@ -3839,24 +3839,24 @@ class cmd {
 		return $this;
 	}
 
-    /**
-     * Get display configuration
-     *
-     * @param string $_key Key to get
-     * @param mixed $_default Default value
-     * @return array<string, mixed>|mixed
-     */
+	/**
+	 * Get display configuration
+	 *
+	 * @param string $_key Key to get
+	 * @param mixed $_default Default value
+	 * @return array<string, mixed>|mixed
+	 */
 	public function getDisplay($_key = '', $_default = '') {
 		return utils::getJsonAttr($this->display, $_key, $_default);
 	}
 
-    /**
-     * Set display configuration
-     *
-     * @param string $_key Key to set
-     * @param mixed $_value Value to set
-     * @return static
-     */
+	/**
+	 * Set display configuration
+	 *
+	 * @param string $_key Key to set
+	 * @param mixed $_value Value to set
+	 * @return static
+	 */
 	public function setDisplay($_key, $_value) {
 		if ($this->getDisplay($_key, null) !== $_value) {
 			$this->_needRefreshWidget = true;
@@ -3866,24 +3866,24 @@ class cmd {
 		return $this;
 	}
 
-    /**
-     * Get alert configuration
-     *
-     * @param string $_key Key to get
-     * @param mixed $_default Default value
-     * @return array<string, mixed>|mixed
-     */
+	/**
+	 * Get alert configuration
+	 *
+	 * @param string $_key Key to get
+	 * @param mixed $_default Default value
+	 * @return array<string, mixed>|mixed
+	 */
 	public function getAlert($_key = '', $_default = '') {
 		return utils::getJsonAttr($this->alert, $_key, $_default);
 	}
 
-    /**
-     * Set alert configuration
-     *
-     * @param string $_key Key to set
-     * @param mixed $_value Value to set
-     * @return static
-     */
+	/**
+	 * Set alert configuration
+	 *
+	 * @param string $_key Key to set
+	 * @param mixed $_value Value to set
+	 * @return static
+	 */
 	public function setAlert($_key, $_value) {
 		$alert = utils::setJsonAttr($this->alert, $_key, $_value);
 		$this->_changed = utils::attrChanged($this->_changed, $this->alert, $alert);
@@ -3892,12 +3892,12 @@ class cmd {
 		return $this;
 	}
 
-    /**
-     * Get collect date
-     *
-     * @return string
-     * @throws Exception
-     */
+	/**
+	 * Get collect date
+	 *
+	 * @return string
+	 * @throws Exception
+	 */
 	public function getCollectDate() {
 		if ($this->_collectDate == '' && $this->getType() == 'info') {
 			$this->execCmd();
@@ -3905,23 +3905,23 @@ class cmd {
 		return $this->_collectDate;
 	}
 
-    /**
-     * Set collect date
-     *
-     * @param string $_collectDate Date to set
-     * @return static
-     */
+	/**
+	 * Set collect date
+	 *
+	 * @param string $_collectDate Date to set
+	 * @return static
+	 */
 	public function setCollectDate($_collectDate) {
 		$this->_collectDate = $_collectDate;
 		return $this;
 	}
 
-    /**
-     * Get value date
-     *
-     * @return string
-     * @throws Exception
-     */
+	/**
+	 * Get value date
+	 *
+	 * @return string
+	 * @throws Exception
+	 */
 	public function getValueDate() {
 		if ($this->_valueDate == '' && $this->getType() == 'info') {
 			$this->execCmd();
@@ -3929,53 +3929,53 @@ class cmd {
 		return $this->_valueDate;
 	}
 
-    /**
-     * Set value date
-     *
-     * @param string $_valueDate Date to set
-     * @return static
-     */
+	/**
+	 * Set value date
+	 *
+	 * @param string $_valueDate Date to set
+	 * @return static
+	 */
 	public function setValueDate($_valueDate) {
 		$this->_valueDate = $_valueDate;
 		return $this;
 	}
 
-    /**
-     * Get command value
-     *
-     * @return mixed|null
-     */
+	/**
+	 * Get command value
+	 *
+	 * @return mixed|null
+	 */
 	public function getValue() {
 		return $this->value;
 	}
 
-    /**
-     * Set command value
-     *
-     * @param mixed|null $_value Value to set
-     * @return static
-     */
+	/**
+	 * Set command value
+	 *
+	 * @param mixed|null $_value Value to set
+	 * @return static
+	 */
 	public function setValue($_value) {
 		$this->_changed = utils::attrChanged($this->_changed, $this->value, $_value);
 		$this->value = $_value;
 		return $this;
 	}
 
-    /**
-     * Get visibility state
-     *
-     * @return int
-     */
+	/**
+	 * Get visibility state
+	 *
+	 * @return int
+	 */
 	public function getIsVisible() {
 		return $this->isVisible;
 	}
 
-    /**
-     * Set visibility state
-     *
-     * @param int $isVisible State to set
-     * @return static
-     */
+	/**
+	 * Set visibility state
+	 *
+	 * @param int $isVisible State to set
+	 * @return static
+	 */
 	public function setIsVisible($isVisible) {
 		if ($this->isVisible != $isVisible) {
 			$this->_needRefreshWidget = true;
@@ -3985,11 +3985,11 @@ class cmd {
 		return $this;
 	}
 
-    /**
-     * Get display order
-     *
-     * @return int
-     */
+	/**
+	 * Get display order
+	 *
+	 * @return int
+	 */
 	public function getOrder() {
 		if ($this->order == '') {
 			return 0;
@@ -3997,12 +3997,12 @@ class cmd {
 		return $this->order;
 	}
 
-    /**
-     * Set display order
-     *
-     * @param int $order Order to set
-     * @return static
-     */
+	/**
+	 * Set display order
+	 *
+	 * @param int $order Order to set
+	 * @return static
+	 */
 	public function setOrder($order) {
 		if ($this->order != $order) {
 			$this->_needRefreshWidget = true;
@@ -4012,87 +4012,87 @@ class cmd {
 		return $this;
 	}
 
-    /**
-     * Get logical ID
-     *
-     * @return int|null
-     */
+	/**
+	 * Get logical ID
+	 *
+	 * @return int|null
+	 */
 	public function getLogicalId() {
 		return $this->logicalId;
 	}
 
-    /**
-     * Set logical ID
-     *
-     * @param int $_logicalId ID to set
-     * @return static
-     */
+	/**
+	 * Set logical ID
+	 *
+	 * @param int $_logicalId ID to set
+	 * @return static
+	 */
 	public function setLogicalId($_logicalId) {
 		$this->_changed = utils::attrChanged($this->_changed, $this->logicalId, $_logicalId);
 		$this->logicalId = $_logicalId;
 		return $this;
 	}
 
-    /**
-     * Get equipment type
-     *
-     * @return string|null
-     */
+	/**
+	 * Get equipment type
+	 *
+	 * @return string|null
+	 */
 	public function getEqType() {
 		return $this->eqType;
 	}
 
-    /**
-     * Set equipment type
-     *
-     * @param string $_eqType Type to set
-     * @return static
-     */
+	/**
+	 * Set equipment type
+	 *
+	 * @param string $_eqType Type to set
+	 * @return static
+	 */
 	public function setEqType($_eqType) {
 		$this->_changed = utils::attrChanged($this->_changed, $this->eqType, $_eqType);
 		$this->eqType = $_eqType;
 		return $this;
 	}
 
-    /**
-     * Get cache value
-     *
-     * @param string $_key Key to get
-     * @param mixed $_default Default value
-     * @return mixed
-     */
+	/**
+	 * Get cache value
+	 *
+	 * @param string $_key Key to get
+	 * @param mixed $_default Default value
+	 * @return mixed
+	 */
 	public function getCache($_key = '', $_default = '') {
 		$cache = cache::byKey('cmdCacheAttr' . $this->getId())->getValue();
 		return utils::getJsonAttr($cache, $_key, $_default);
 	}
 
-    /**
-     * Set cache value
-     *
-     * @param string $_key Key to set
-     * @param mixed|null $_value Value to set
-     * @return static
-     */
+	/**
+	 * Set cache value
+	 *
+	 * @param string $_key Key to set
+	 * @param mixed|null $_value Value to set
+	 * @return static
+	 */
 	public function setCache($_key, $_value = null) {
 		cache::set('cmdCacheAttr' . $this->getId(), utils::setJsonAttr(cache::byKey('cmdCacheAttr' . $this->getId())->getValue(), $_key, $_value));
 		return $this;
 	}
 
-    /**
-     * Get changed state
-     *
-     * @return bool
-     */
+	/**
+	 * Get changed state
+	 *
+	 * @return bool
+	 */
 	public function getChanged() {
 		return $this->_changed;
 	}
 
-    /**
-     * Set changed state
-     *
-     * @param bool $_changed State to set
-     * @return static
-     */
+	/**
+	 * Set changed state
+	 *
+	 * @param bool $_changed State to set
+	 * @return static
+	 */
 	public function setChanged($_changed) {
 		$this->_changed = $_changed;
 		return $this;

--- a/core/class/scenario.class.php
+++ b/core/class/scenario.class.php
@@ -45,7 +45,7 @@ class scenario {
 	private $_realTriggerValue = '';
 	/** @var bool */
 	private $_return = true;
-	private $_tags = array('#trigger#' => '','#trigger_name#' => '','#trigger_id#' => '','#trigger_message#' => '','#trigger_value#' => '');
+	private $_tags = array('#trigger#' => '', '#trigger_name#' => '', '#trigger_id#' => '', '#trigger_message#' => '', '#trigger_value#' => '');
 	private $_do = true;
 	private $_changed = false;
 
@@ -107,7 +107,7 @@ class scenario {
 			if (!is_array($result3)) {
 				$result3 = array();
 			}
-			return array_merge($result1, $result2,$result3);
+			return array_merge($result1, $result2, $result3);
 		} elseif ($_group === null) {
 			$sql = 'SELECT ' . DB::buildField(__CLASS__, 's') . '
 			FROM scenario s
@@ -138,7 +138,7 @@ class scenario {
 			if (!is_array($result3)) {
 				$result3 = array();
 			}
-			return array_merge($result1, $result2,$result3);
+			return array_merge($result1, $result2, $result3);
 		} else {
 			$values = array(
 				'group' => $_group,
@@ -169,7 +169,7 @@ class scenario {
 			if (!is_array($result3)) {
 				$result3 = array();
 			}
-			return array_merge($result1, $result2,$result3);
+			return array_merge($result1, $result2, $result3);
 		}
 	}
 	/**
@@ -375,14 +375,14 @@ class scenario {
 							} else {
 								$trigger_message .= ' genericType(' . $_generic . ')' . ' from ' . $_event->getHumanName();
 							}
-							$scenario->addTag('trigger_message',$trigger_message);
-							$scenario->addTag('trigger_value',$_value);
+							$scenario->addTag('trigger_message', $trigger_message);
+							$scenario->addTag('trigger_value', $_value);
 							if (is_object($_event)) {
-								$scenario->addTag('trigger_name',trim($_event->getHumanName(),'#'));
-								$scenario->addTag('trigger_id',$_event->getId());
-								$scenario->addTag('trigger',get_class($_event));
-							}else{
-								$scenario->addTag('trigger',trim($_event,'#'));
+								$scenario->addTag('trigger_name', trim($_event->getHumanName(), '#'));
+								$scenario->addTag('trigger_id', $_event->getId());
+								$scenario->addTag('trigger', get_class($_event));
+							} else {
+								$scenario->addTag('trigger', trim($_event, '#'));
 							}
 							$scenario->launch($_forceSyncMode);
 						}
@@ -414,19 +414,19 @@ class scenario {
 
 		if (count($scenarios) > 0) {
 			foreach ($scenarios as $scenario_) {
-				$scenario_->addTag('trigger_message',$trigger_message);
+				$scenario_->addTag('trigger_message', $trigger_message);
 
-				$scenario_->addTag('trigger_value',$_value);
+				$scenario_->addTag('trigger_value', $_value);
 				if (is_object($_event)) {
-					$scenario_->addTag('trigger_name',trim($_event->getHumanName(),'#'));
-					$scenario_->addTag('trigger_id',$_event->getId());
-					$scenario_->addTag('trigger',get_class($_event));
-				}else{
-					$scenario_->addTag('trigger',$_event);
+					$scenario_->addTag('trigger_name', trim($_event->getHumanName(), '#'));
+					$scenario_->addTag('trigger_id', $_event->getId());
+					$scenario_->addTag('trigger', get_class($_event));
+				} else {
+					$scenario_->addTag('trigger', $_event);
 				}
 				if (is_array($_options) && count($_options) > 0) {
 					foreach ($_options as $key => $value) {
-						$scenario_->addTag($key,$value);
+						$scenario_->addTag($key, $value);
 					}
 				}
 				$scenario_->launch($_forceSyncMode);
@@ -684,7 +684,7 @@ class scenario {
 	 * @return string|object|array return value will depends on $_input received
 	 */
 	public static function fromHumanReadable($_input) {
-		if(empty($_input)){
+		if (empty($_input)) {
 			return $_input;
 		}
 		$isJson = false;
@@ -872,12 +872,12 @@ class scenario {
 			return $this->execute();
 		} else {
 			$instance_id = config::genKey(16);
-			cache::set('scenarioInstanceAttr'.$this->getId().'::'.$instance_id,array(
+			cache::set('scenarioInstanceAttr' . $this->getId() . '::' . $instance_id, array(
 				'tags' => $this->getTags()
 			));
 			$cmd = __DIR__ . '/../../core/php/jeeScenario.php ';
 			$cmd .= ' scenario_id=' . $this->getId();
-			$cmd .= ' intance_id='.$instance_id;
+			$cmd .= ' intance_id=' . $instance_id;
 			$cmd .= ' >> ' . log::getPathToLog('scenario_execution') . ' 2>&1 &';
 			system::php($cmd);
 		}
@@ -891,9 +891,9 @@ class scenario {
 		if (config::byKey('enableScenario') != 1) {
 			return;
 		}
-		if($instance_id != ''){
-			$this->setTags(cache::byKey('scenarioInstanceAttr'.$this->getId().'::'.$instance_id)->getValue()['tags']);
-			cache::byKey('scenarioInstanceAttr'.$this->getId().'::'.$instance_id)->remove();
+		if ($instance_id != '') {
+			$this->setTags(cache::byKey('scenarioInstanceAttr' . $this->getId() . '::' . $instance_id)->getValue()['tags']);
+			cache::byKey('scenarioInstanceAttr' . $this->getId() . '::' . $instance_id)->remove();
 		}
 		if ($this->getIsActive() != 1) {
 			$this->setLog($GLOBALS['JEEDOM_SCLOG_TEXT']['disableScenario']['txt']  . $this->getHumanName() . ' ' . __('sur :', __FILE__) . ' ' . $this->getTag('message') . ' ' . __('car il est désactivé', __FILE__));
@@ -911,9 +911,9 @@ class scenario {
 				return;
 			}
 		}
-		if($this->getTag('trigger') == 'scenario'){
+		if ($this->getTag('trigger') == 'scenario') {
 			$obj_trigger = scenario::byId(str_replace('#', '', $this->getTag('trigger_id')));
-		}else{
+		} else {
 			$obj_trigger = cmd::byId(str_replace('#', '', $this->getTag('trigger_id')));
 		}
 		if (is_object($obj_trigger)) {
@@ -1188,12 +1188,12 @@ class scenario {
 					$c = new Cron\CronExpression(checkAndFixCron($schedule), new Cron\FieldFactory);
 					$calculatedDate_tmp['prevDate'] = $c->getPreviousRunDate()->format('Y-m-d H:i:s');
 					$calculatedDate_tmp['nextDate'] = $c->getNextRunDate()->format('Y-m-d H:i:s');
-					$schedule_exp = explode(' ',trim($schedule));
-					if(is_array($schedule_exp) && count($schedule_exp) == 6 ){
-					 	if($schedule_exp[5] != $c->getPreviousRunDate()->format('Y')){
+					$schedule_exp = explode(' ', trim($schedule));
+					if (is_array($schedule_exp) && count($schedule_exp) == 6) {
+						if ($schedule_exp[5] != $c->getPreviousRunDate()->format('Y')) {
 							$calculatedDate['prevDate'] = '';
 						}
-						if($schedule_exp[5] != $c->getNextRunDate()->format('Y')){
+						if ($schedule_exp[5] != $c->getNextRunDate()->format('Y')) {
 							$calculatedDate['nextDate'] = '';
 						}
 					}
@@ -1211,11 +1211,11 @@ class scenario {
 				$c = new Cron\CronExpression(checkAndFixCron($this->getSchedule()), new Cron\FieldFactory);
 				$calculatedDate['prevDate'] = $c->getPreviousRunDate()->format('Y-m-d H:i:s');
 				$calculatedDate['nextDate'] = $c->getNextRunDate()->format('Y-m-d H:i:s');
-				$schedule = explode(' ',$this->getSchedule());
-				if(count($schedule) == 6 && $schedule[5] != $c->getPreviousRunDate()->format('Y')){
+				$schedule = explode(' ', $this->getSchedule());
+				if (count($schedule) == 6 && $schedule[5] != $c->getPreviousRunDate()->format('Y')) {
 					$calculatedDate['prevDate'] = '';
 				}
-				if(count($schedule) == 6 && $schedule[5] != $c->getNextRunDate()->format('Y')){
+				if (count($schedule) == 6 && $schedule[5] != $c->getNextRunDate()->format('Y')) {
 					$calculatedDate['nextDate'] = '';
 				}
 			} catch (\Throwable $exc) {
@@ -1236,11 +1236,11 @@ class scenario {
 			return false;
 		}
 		$schedules = $this->getSchedule();
-		if(!is_array($schedules)){
+		if (!is_array($schedules)) {
 			$schedules = [$schedules];
 		}
 		foreach ($schedules as $schedule) {
-			if(cronIsDue($schedule,$_datetime,$this->getLastLaunch())){
+			if (cronIsDue($schedule, $_datetime, $this->getLastLaunch())) {
 				return true;
 			}
 		}
@@ -1645,23 +1645,23 @@ class scenario {
 		}
 	}
 
-	public function addTag($_key,$value){
+	public function addTag($_key, $value) {
 		$tag = $this->getTags();
-		$_key = '#'.trim($_key,'#').'#';
+		$_key = '#' . trim($_key, '#') . '#';
 		$tag[$_key] = $value;
 		$this->setTags($tag);
 	}
 
-	public function getTag($_key,$_default = ''){
+	public function getTag($_key, $_default = '') {
 		$tag = $this->getTags();
-		if(isset($tag[$_key])){
+		if (isset($tag[$_key])) {
 			return $tag[$_key];
 		}
-		if(isset($tag[trim($_key,'#')])){
-			return $tag[trim($_key,'#')];
+		if (isset($tag[trim($_key, '#')])) {
+			return $tag[trim($_key, '#')];
 		}
-		if(isset($tag['#'.trim($_key,'#').'#'])){
-			return $tag['#'.trim($_key,'#').'#'];
+		if (isset($tag['#' . trim($_key, '#') . '#'])) {
+			return $tag['#' . trim($_key, '#') . '#'];
 		}
 		return $_default;
 	}
@@ -2012,7 +2012,7 @@ class scenario {
 	 * @return array
 	 */
 	public function getTags() {
-		if(!is_array($this->_tags)){
+		if (!is_array($this->_tags)) {
 			return [];
 		}
 		return $this->_tags;

--- a/core/class/scenario.class.php
+++ b/core/class/scenario.class.php
@@ -1023,7 +1023,7 @@ class scenario {
 			$replace['#isVerticalAlign#'] = 'verticalAlign';
 		}
 		$html = template_replace($replace, self::$_templateArray[$version]);
-		$html =  translate::exec($html, 'core/template/widgets.html');
+		$html = translate::exec($html, 'core/template/' . $version . '/scenario.html');
 		return $html;
 	}
 	/**

--- a/core/class/translate.class.php
+++ b/core/class/translate.class.php
@@ -106,11 +106,8 @@ class translate {
 	 * @return array<string, array<string, string>> Translation mappings
 	 */
 	public static function getWidgetTranslation($_widget) {
-		if (!isset(self::$translation[self::getLanguage()]['core/template/widgets.html'])) {
-			self::$translation[self::getLanguage()]['core/template/widgets.html'] = array();
-		}
 		if (!isset(self::$widgetLoad[$_widget])) {
-			self::$widgetLoad[$_widget][$_widget] = array_merge(self::$translation[self::getLanguage()]['core/template/widgets.html'], self::loadTranslation($_widget));
+			self::$widgetLoad[$_widget][$_widget] = self::loadTranslation($_widget);
 		}
 		return self::$widgetLoad[$_widget];
 	}

--- a/core/class/translate.class.php
+++ b/core/class/translate.class.php
@@ -47,31 +47,31 @@ require_once  'event.class.php';
 class translate {
 	/*     * *************************Attributs****************************** */
 
-    /** @var array<string, array<string, array<string, string>>> Cached translations by language and namespace */
+	/** @var array<string, array<string, array<string, string>>> Cached translations by language and namespace */
 	protected static $translation = array();
 
-    /** @var string|null Current active language */
+	/** @var string|null Current active language */
 	protected static $language = null;
 
-    /** @var array<string, string>|null System configuration cache */
+	/** @var array<string, string>|null System configuration cache */
 	private static $config = null;
 
-    /** @var array<string, bool> Loaded plugins tracking */
+	/** @var array<string, bool> Loaded plugins tracking */
 	private static $pluginLoad = array();
 
-    /** @var array<string, array<string, array<string, string>>> Loaded widgets translations */
+	/** @var array<string, array<string, array<string, string>>> Loaded widgets translations */
 	private static $widgetLoad = array();
 
 	/*     * ***********************Methode static*************************** */
 
-    /**
-     * Retrieves a configuration value
-     *
-     * @param string $_key Configuration key to retrieve
-     * @param string $_default Default value if key not found
-     * @return string Configuration value
-     * @see config::byKeys() For configuration retrieval
-     */
+	/**
+	 * Retrieves a configuration value
+	 *
+	 * @param string $_key Configuration key to retrieve
+	 * @param string $_default Default value if key not found
+	 * @return string Configuration value
+	 * @see config::byKeys() For configuration retrieval
+	 */
 	public static function getConfig($_key, $_default = '') {
 		if (self::$config === null) {
 			self::$config = config::byKeys(array('language'));
@@ -82,12 +82,12 @@ class translate {
 		return $_default;
 	}
 
-    /**
-     * Gets translations for a plugin
-     *
-     * @param string $_plugin Plugin identifier
-     * @return array<string, array<string, string>> Translation mappings
-     */
+	/**
+	 * Gets translations for a plugin
+	 *
+	 * @param string $_plugin Plugin identifier
+	 * @return array<string, array<string, string>> Translation mappings
+	 */
 	public static function getTranslation($_plugin) {
 		if (!isset(self::$translation[self::getLanguage()])) {
 			self::$translation[self::getLanguage()] = array();
@@ -99,12 +99,12 @@ class translate {
 		return self::$translation[self::getLanguage()];
 	}
 
-    /**
-     * Gets translations for a widget
-     *
-     * @param string $_widget Widget identifier
-     * @return array<string, array<string, string>> Translation mappings
-     */
+	/**
+	 * Gets translations for a widget
+	 *
+	 * @param string $_widget Widget identifier
+	 * @return array<string, array<string, string>> Translation mappings
+	 */
 	public static function getWidgetTranslation($_widget) {
 		if (!isset(self::$translation[self::getLanguage()]['core/template/widgets.html'])) {
 			self::$translation[self::getLanguage()]['core/template/widgets.html'] = array();
@@ -115,25 +115,25 @@ class translate {
 		return self::$widgetLoad[$_widget];
 	}
 
-    /**
-     * Translates a single text key
-     *
-     * @param string $_content Translation key
-     * @param string $_name Plugin/widget identifier or path
-     * @param bool $_backslash Whether to escape single quotes
-     * @return string Translated text
-     * @see self::exec() For full translation processing
-     */
+	/**
+	 * Translates a single text key
+	 *
+	 * @param string $_content Translation key
+	 * @param string $_name Plugin/widget identifier or path
+	 * @param bool $_backslash Whether to escape single quotes
+	 * @return string Translated text
+	 * @see self::exec() For full translation processing
+	 */
 	public static function sentence($_content, $_name, $_backslash = false) {
 		return self::exec("{{" . $_content . "}}", $_name, $_backslash);
 	}
 
-    /**
-     * Extracts plugin name from file path
-     *
-     * @param string $_name File path
-     * @return string Plugin name or 'core'
-     */
+	/**
+	 * Extracts plugin name from file path
+	 *
+	 * @param string $_name File path
+	 * @return string Plugin name or 'core'
+	 */
 	public static function getPluginFromName($_name) {
 		if (strpos($_name, 'plugins/') === false) {
 			return 'core';
@@ -148,17 +148,17 @@ class translate {
 		return $matches[1];
 	}
 
-    /**
-     * Processes text content for internationalization
-     *
-     * @param string $_content Text with {{translation_keys}}
-     * @param string $_name Plugin/widget identifier or path
-     * @param bool $_backslash Whether to escape single quotes
-     * @return string Translated content
-     * @see self::getLanguage() For current language
-     * @see self::getTranslation() For plugin translations
-     * @see self::getWidgetTranslation() For widget translations
-     */
+	/**
+	 * Processes text content for internationalization
+	 *
+	 * @param string $_content Text with {{translation_keys}}
+	 * @param string $_name Plugin/widget identifier or path
+	 * @param bool $_backslash Whether to escape single quotes
+	 * @return string Translated content
+	 * @see self::getLanguage() For current language
+	 * @see self::getTranslation() For plugin translations
+	 * @see self::getWidgetTranslation() For widget translations
+	 */
 	public static function exec($_content, $_name = '', $_backslash = false) {
 		if ($_content == '' || $_name == '') {
 			return $_content;
@@ -227,34 +227,34 @@ class translate {
 		return str_replace(array_keys($replace), $replace, $_content);
 	}
 
-    /**
-     * Returns path to language translation file
-     *
-     * @param string $_language Language code
-     * @return string File path
-     */
+	/**
+	 * Returns path to language translation file
+	 *
+	 * @param string $_language Language code
+	 * @return string File path
+	 */
 	public static function getPathTranslationFile($_language) {
 		return __DIR__ . '/../i18n/' . $_language . '.json';
 	}
 
 
-    /**
-     * Returns path to widget translation file
-     *
-     * @param string $_widgetName Widget name
-     * @return string File path
-     */
+	/**
+	 * Returns path to widget translation file
+	 *
+	 * @param string $_widgetName Widget name
+	 * @return string File path
+	 */
 	public static function getWidgetPathTranslationFile($_widgetName) {
 		return __DIR__ . '/../../data/customTemplates/i18n/' . $_widgetName . '.json';
 	}
 
-    /**
-     * Loads translations for core or plugin
-     *
-     * @param string|null $_plugin Plugin name or null for core
-     * @return array<string, array<string, string>> Translation mappings
-     * @see plugin::getTranslation() For plugin translations
-     */
+	/**
+	 * Loads translations for core or plugin
+	 *
+	 * @param string|null $_plugin Plugin name or null for core
+	 * @return array<string, array<string, string>> Translation mappings
+	 * @see plugin::getTranslation() For plugin translations
+	 */
 	public static function loadTranslation($_plugin = null) {
 		$return = array();
 		if ($_plugin == null || $_plugin == 'core') {
@@ -286,11 +286,11 @@ class translate {
 		return $return;
 	}
 
-    /**
-     * Gets current active language
-     *
-     * @return string Language code
-     */
+	/**
+	 * Gets current active language
+	 *
+	 * @return string Language code
+	 */
 	public static function getLanguage() {
 		if (self::$language == null) {
 			self::$language = self::getConfig('language', 'fr_FR');
@@ -298,12 +298,12 @@ class translate {
 		return self::$language;
 	}
 
-    /**
-     * Sets active language
-     *
-     * @param string $_langage Language code
-     * @return void
-     */
+	/**
+	 * Sets active language
+	 *
+	 * @param string $_langage Language code
+	 * @return void
+	 */
 	public static function setLanguage($_langage) {
 		self::$language = $_langage;
 	}


### PR DESCRIPTION
Following a07bbec which replaced `core/template/widgets.html` as a global i18n key in `cmd.class.php`, two remaining references were left:

- `scenario.class.php`: now uses `core/template/{version}/scenario.html` as translation key, consistent with the per-file approach
- `translate.class.php`: `getWidgetTranslation()` no longer merges against the obsolete key, simplified to load widget translations directly
- `cmd.class.php`: removed the comment describing the old global-key behavior
