### PR TITLE
fix: changelog button in core update modal is now functional

### DIFF
--- a/core/ajax/update.ajax.php
+++ b/core/ajax/update.ajax.php
@@ -48,14 +48,14 @@ try {
 			if ($update->getType() == 'core') {
 				if (config::byKey('core::repo::provider') == 'default') {
 					$infos['branch'] = config::byKey('core::branch', 'core', 'Unknown');
-				}else{
-					$infos['branch'] = config::byKey('core::repo::provider').' - custom';
+				} else {
+					$infos['branch'] = config::byKey('core::repo::provider') . ' - custom';
 				}
 				$theme = 'light';
 				if (strpos(config::byKey('jeedom_theme_main'), 'Dark') !== false) {
 					$theme = 'dark';
 				}
-				$infos['changelog_url'] = config::byKey('doc::base_url', 'core') . '/' . config::byKey('language', 'core', 'fr_FR') . '/core/' . substr(jeedom::version(), 0, 3) . '/changelog?theme=' . $theme;
+				$infos['changelog_url'] = config::byKey('doc::base_url', 'core') . '/' . config::byKey('language', 'core', 'fr_FR') . '/core/' . substr($update->getRemoteVersion(), 0, 3) . '/changelog?theme=' . $theme;
 			}
 			$return[] = $infos;
 		}
@@ -165,7 +165,7 @@ try {
 
 	if (init('action') == 'saves') {
 		unautorizedInDemo();
-		utils::processJsonObject('update', init('updates'),null,false);
+		utils::processJsonObject('update', init('updates'), null, false);
 		ajax::success();
 	}
 

--- a/desktop/js/update.js
+++ b/desktop/js/update.js
@@ -280,7 +280,7 @@ if (!jeeFrontEnd.update) {
           }
         }
       } else {
-        tr += '<a class="btn btn-xs" target="_blank" href="' + _update.changelog_url + '"><i class="fas fa-book"></i><span class="hidden-1280"> {{Changelog}}</span></a> '
+        tr += '<a class="btn btn-xs" target="_blank" href="' + _update.changelog_url + '" id="bt_changelogCore"><i class="fas fa-book"></i><span class="hidden-1280"> {{Changelog}}</span></a> '
       }
       if (_update.type != 'core') {
         if (_update.status == 'UPDATE') {
@@ -542,6 +542,7 @@ if (!jeeFrontEnd.update) {
             var newContent = document.getElementById('md_specifyUpdate-template').cloneNode(true)
             newContent.setAttribute('id', 'md_specifyUpdate')
             contentEl.appendChild(newContent)
+            newContent.querySelector('#bt_warnChangelogCore').href = document.getElementById('bt_changelogCore').href
             newContent.querySelectorAll('[data-title]').forEach(_tooltip => {
               _tooltip.setAttribute('title', _tooltip.getAttribute('data-title'))
               _tooltip.removeAttribute('data-title')

--- a/desktop/js/update.js
+++ b/desktop/js/update.js
@@ -237,8 +237,8 @@ if (!jeeFrontEnd.update) {
             default:
               updClass = 'label-danger'
           }
-          if (typeof _update.configuration.user!== 'undefined'){
-            tr += ' <span class="label ' + updClass + ' hidden-992">' + _update.configuration.version +' - '+ _update.configuration.user + '</span>'
+          if (typeof _update.configuration.user !== 'undefined') {
+            tr += ' <span class="label ' + updClass + ' hidden-992">' + _update.configuration.version + ' - ' + _update.configuration.user + '</span>'
           } else {
             tr += ' <span class="label ' + updClass + ' hidden-992">' + _update.configuration.version + '</span>'
           }
@@ -267,7 +267,7 @@ if (!jeeFrontEnd.update) {
         if (_update.configuration && _update.configuration.version == 'beta') {
           if (isset(_update.plugin) && isset(_update.plugin.changelog_beta) && _update.plugin.changelog_beta != '') {
             tr += '<a class="btn btn-xs cursor" target="_blank" href="' + _update.plugin.changelog_beta + '"><i class="fas fa-book"></i><span class="hidden-1280"> {{Changelog}}</span></a> '
-          } else if (isset(_update.plugin) && isset(_update.plugin.changelog) && _update.plugin.changelog != '') { 
+          } else if (isset(_update.plugin) && isset(_update.plugin.changelog) && _update.plugin.changelog != '') {
             tr += '<a class="btn btn-xs cursor" target="_blank" href="' + _update.plugin.changelog + '"><i class="fas fa-book"></i><span class="hidden-1280"> {{Changelog}}</span></a> '
           } else {
             tr += '<a class="btn btn-xs disabled"><i class="fas fa-book"></i><span class="hidden-1280"> {{Changelog}}</span></a> '
@@ -280,7 +280,7 @@ if (!jeeFrontEnd.update) {
           }
         }
       } else {
-        tr += '<a class="btn btn-xs" target="_blank" href="'+_update.changelog_url+'"><i class="fas fa-book"></i><span class="hidden-1280"> {{Changelog}}</span></a> '
+        tr += '<a class="btn btn-xs" target="_blank" href="' + _update.changelog_url + '"><i class="fas fa-book"></i><span class="hidden-1280"> {{Changelog}}</span></a> '
       }
       if (_update.type != 'core') {
         if (_update.status == 'UPDATE') {
@@ -640,50 +640,50 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
   }
 
   if (_target = event.target.closest('#table_update .update')) {
-    if (_target.hasClass('disabled')) return;
-    var id = _target.closest('tr').getAttribute('data-id');
-    var logicalId = _target.closest('tr').getAttribute('data-logicalid');
+    if (_target.hasClass('disabled')) return
+    var id = _target.closest('tr').getAttribute('data-id')
+    var logicalId = _target.closest('tr').getAttribute('data-logicalid')
 
     jeedom.plugin.get({
-        id: logicalId,
-        error: function(error) {
-            jeedomUtils.showAlert({
-                message: error.message,
-                level: 'danger'
-            });
-        },
-        success: function(data) {
-            var isActivated = (data.activate !== undefined && data.activate !== null) ? data.activate : 1;
-            var confirmationMessage = '{{Êtes-vous sûr de vouloir mettre à jour le plugin :}} ' + logicalId + ' ?';
-            if (isActivated != 1) {
-                confirmationMessage = '{{Attention : Le plugin ' + logicalId + ' n\'est pas activé. Êtes-vous sûr de vouloir le mettre à jour ?}}';
-            }
-
-            jeeDialog.confirm(confirmationMessage, function(result) {
-                if (result) {
-                    jeeP.progress = -1;
-                    document.getElementById('progressbarContainer').removeClass('hidden');
-                    document.querySelector('.bt_refreshOsPackageUpdate').addClass('disabled');
-                    jeeP.updateProgressBar();
-                    jeedomUtils.hideAlert();
-                    jeedom.update.do({
-                        id: id,
-                        error: function(error) {
-                            jeedomUtils.showAlert({
-                                message: error.message,
-                                level: 'danger'
-                            });
-                        },
-                        success: function() {
-                            jeeP.getJeedomLog(1, 'update');
-                        }
-                    });
-                }
-            });
+      id: logicalId,
+      error: function(error) {
+        jeedomUtils.showAlert({
+          message: error.message,
+          level: 'danger'
+        })
+      },
+      success: function(data) {
+        var isActivated = (data.activate !== undefined && data.activate !== null) ? data.activate : 1
+        var confirmationMessage = '{{Êtes-vous sûr de vouloir mettre à jour le plugin :}} ' + logicalId + ' ?'
+        if (isActivated != 1) {
+          confirmationMessage = '{{Attention : Le plugin ' + logicalId + ' n\'est pas activé. Êtes-vous sûr de vouloir le mettre à jour ?}}'
         }
-    });
-    return;
-}
+
+        jeeDialog.confirm(confirmationMessage, function(result) {
+          if (result) {
+            jeeP.progress = -1
+            document.getElementById('progressbarContainer').removeClass('hidden')
+            document.querySelector('.bt_refreshOsPackageUpdate').addClass('disabled')
+            jeeP.updateProgressBar()
+            jeedomUtils.hideAlert()
+            jeedom.update.do({
+              id: id,
+              error: function(error) {
+                jeedomUtils.showAlert({
+                  message: error.message,
+                  level: 'danger'
+                })
+              },
+              success: function() {
+                jeeP.getJeedomLog(1, 'update')
+              }
+            })
+          }
+        })
+      }
+    })
+    return
+  }
 
   if (_target = event.target.closest('#table_update .remove')) {
     var id = _target.closest('tr').getAttribute('data-id')

--- a/desktop/php/update.php
+++ b/desktop/php/update.php
@@ -136,7 +136,7 @@ if (strpos($logUpdate, 'END UPDATE') || count(system::ps('install/update.php', '
 					<?php $branch = config::byKey('core::branch');
 					if (!in_array($branch, ['master', 'release'])) { ?>
 						<div class="alert alert-danger">
-							{{Veuillez noter que vous n'êtes pas sur la version stable du core, la mise à jour se fera donc sur la branche : }} <?= $branch ?>.
+							{{Attention, vous n'êtes pas sur la version stable du core, la mise à jour se fera donc sur la branche : }} <?= $branch ?>.
 							{{Cette version ne bénéficie pas du support officiel.}}
 						</div>
 					<?php } ?>

--- a/desktop/php/update.php
+++ b/desktop/php/update.php
@@ -127,11 +127,17 @@ if (strpos($logUpdate, 'END UPDATE') || count(system::ps('install/update.php', '
 			<form class="form-horizontal">
 				<fieldset>
 					<div class="alert alert-warning">
-						{{Avant toute mise à jour, merci de consulter le}} <span class="bt_changelogCore label cursor alert-info">{{changelog}}</span> {{du Core}}.
+						{{En cas de mise à jour du core, veuillez prendre connaissance du}}
+						<a class="btn btn-xs" id="bt_warnChangelogCore" target="_blank"><i class="fas fa-book"></i>
+							{{Changelog}}
+						</a>
+						{{au préalable}}.
 					</div>
-					<?php if (config::byKey('core::branch') == 'beta' || config::byKey('core::branch') == 'alpha') { ?>
+					<?php $branch = config::byKey('core::branch');
+					if (!in_array($branch, ['master', 'release'])) { ?>
 						<div class="alert alert-danger">
-							{{Attention vous n'êtes pas sur la branche stable du core, vous allez donc mettre à jour sur la version : }} <?php echo config::byKey('core::branch'); ?>. {{Cette version ne bénéficie d'aucun support de Jeedom SAS.}}
+							{{Veuillez noter que vous n'êtes pas sur la version stable du core, la mise à jour se fera donc sur la branche : }} <?= $branch ?>.
+							{{Cette version ne bénéficie pas du support officiel.}}
 						</div>
 					<?php } ?>
 


### PR DESCRIPTION
The changelog button shown in the confirmation modal before a core update was a `<span>` with no `href` and no JS handler, it did nothing.

## Changes

- Replaced the inert `<span>` with a proper `<a id="bt_warnChangelogCore">` whose `href` is set from the already-rendered changelog link in the update table (`bt_changelogCore`), no extra AJAX call, no URL duplication
- The changelog URL now uses `getRemoteVersion()` instead of `jeedom::version()`, so it points to the version being installed rather than the currently installed one
- Branch alert: broadened the unstable-branch check from hardcoded `beta`/`alpha` to `!in_array($branch, ['master', 'release'])`, covering any non-stable branch; minor rewording

<img width="350" alt="image" src="https://github.com/user-attachments/assets/0cc12d5c-3d24-4359-a1f2-dd0b565394d3" />

Fixes #3247