### PR TITLE
Feat/check core branch validity

### DIFF
--- a/core/class/jeedom.class.php
+++ b/core/class/jeedom.class.php
@@ -191,6 +191,18 @@ class jeedom {
 			'key' => 'uptodate'
 		);
 
+		if (config::byKey('core::repo::provider') == 'default') {
+			$branch = config::byKey('core::branch', 'core', 'master');
+			$state = update::isCoreBranchValid();
+			$return[] = array(
+				'name' => __('Branche du core', __FILE__),
+				'state' => $state,
+				'result' => ($state) ? $branch : $branch . ' (' . __('introuvable', __FILE__) . ')',
+				'comment' => ($state) ? '' : __("La branche configurée pour le core n'existe plus sur le dépôt. Allez dans Réglages -> Système -> Mises à jour / Réinitialisation pour sélectionner une branche valide.", __FILE__),
+				'key' => 'core::branch'
+			);
+		}
+
 		$state = (config::byKey('enableCron', 'core', 1, true) != 0) ? true : false;
 		$return[] = array(
 			'name' => __('Cron actif', __FILE__),

--- a/core/class/update.class.php
+++ b/core/class/update.class.php
@@ -570,6 +570,11 @@ class update {
 				return;
 			}
 			if (config::byKey('core::repo::provider') == 'default') {
+				if (self::isCoreBranchValid()) {
+					message::removeAll('core', 'core::branch::invalid');
+				} else {
+					message::add('core', __('La branche configurée pour le core (', __FILE__) . config::byKey('core::branch', 'core', 'master') . __(") n'existe plus sur le dépôt. Les mises à jour ne fonctionneront pas tant qu'une branche valide n'est pas sélectionnée dans Réglages -> Système -> Mises à jour / Réinitialisation.", __FILE__), '', 'core::branch::invalid');
+				}
 				$this->setRemoteVersion(self::getLastAvailableVersion());
 			} else {
 				$class = 'repo_' . config::byKey('core::repo::provider');

--- a/core/class/update.class.php
+++ b/core/class/update.class.php
@@ -493,6 +493,73 @@ class update {
 		return null;
 	}
 
+	/**
+	 * Retourne la liste des branches et tags disponibles pour le core sur le dépôt par défaut.
+	 * Le résultat est mis en cache 24h (clé core::branch::default::list).
+	 * @param bool $_refresh force le rafraichissement du cache
+	 * @return array tableau contenant les clés 'branchs' et 'tags'
+	 */
+	public static function getCoreBranchList($_refresh = false) {
+		$lists = ($_refresh) ? array() : cache::byKey('core::branch::default::list')->getValue(array());
+		if (!isset($lists['branchs']) || !is_array($lists['branchs'])) {
+			$request_http = new com_http('https://api.github.com/repos/jeedom/core/branches');
+			$request_http->setHeader(array('User-agent: jeedom'));
+			try {
+				$lists['branchs'] = json_decode($request_http->exec(10, 1), true);
+			} catch (\Exception $e) {
+			}
+			cache::set('core::branch::default::list', $lists, 86400);
+		}
+		if (!isset($lists['tags']) || !is_array($lists['tags'])) {
+			$request_http = new com_http('https://api.github.com/repos/jeedom/core/tags');
+			$request_http->setHeader(array('User-agent: jeedom'));
+			try {
+				$lists['tags'] = json_decode($request_http->exec(10, 1), true);
+			} catch (\Exception $e) {
+			}
+			cache::set('core::branch::default::list', $lists, 86400);
+		}
+		return $lists;
+	}
+
+	/**
+	 * Vérifie que la branche (ou le tag) configurée pour le core existe toujours sur le dépôt.
+	 * Pour éviter les faux positifs, retourne true si la validité ne peut pas être déterminée
+	 * (fournisseur personnalisé, branche stable connue, ou liste distante indisponible).
+	 * @return bool true si la branche est valide (ou indéterminable), false si elle est introuvable
+	 */
+	public static function isCoreBranchValid() {
+		if (config::byKey('core::repo::provider') != 'default') {
+			return true;
+		}
+		$branch = config::byKey('core::branch', 'core', 'master');
+		if (in_array($branch, array('master', 'release', 'stable'))) {
+			return true;
+		}
+		$lists = self::getCoreBranchList();
+		if (strpos($branch, 'tag::') === 0) {
+			$tagName = substr($branch, strlen('tag::'));
+			if (!isset($lists['tags']) || !is_array($lists['tags']) || count($lists['tags']) == 0) {
+				return true;
+			}
+			foreach ($lists['tags'] as $tag) {
+				if (is_array($tag) && isset($tag['name']) && $tag['name'] == $tagName) {
+					return true;
+				}
+			}
+			return false;
+		}
+		if (!isset($lists['branchs']) || !is_array($lists['branchs']) || count($lists['branchs']) == 0) {
+			return true;
+		}
+		foreach ($lists['branchs'] as $remoteBranch) {
+			if (is_array($remoteBranch) && isset($remoteBranch['name']) && $remoteBranch['name'] == $branch) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	public function checkUpdate() {
 		if ($this->getConfiguration('doNotUpdate') == 1 && $this->getType() != 'core') {
 			log::add(__CLASS__, 'alert', __('Vérification des mises à jour, mise à jour et réinstallation désactivées sur', __FILE__) . ' ' . $this->getLogicalId());

--- a/desktop/php/administration.php
+++ b/desktop/php/administration.php
@@ -1822,25 +1822,7 @@ $productName = config::byKey('product_name');
 												</optgroup>
 												<?php
 												if (config::byKey('core::repo::provider') == 'default') {
-													$lists = cache::byKey('core::branch::default::list')->getValue(array());
-													if (!isset($lists['branchs']) || !is_array($lists['branchs'])) {
-														$request_http = new com_http('https://api.github.com/repos/jeedom/core/branches');
-														$request_http->setHeader(array('User-agent: jeedom'));
-														try {
-															$lists['branchs'] = json_decode($request_http->exec(10, 1), true);
-														} catch (\Exception $e) {
-														}
-														cache::set('core::branch::default::list', $lists, 86400);
-													}
-													if (!isset($lists['tags']) || !is_array($lists['tags'])) {
-														$request_http = new com_http('https://api.github.com/repos/jeedom/core/tags');
-														$request_http->setHeader(array('User-agent: jeedom'));
-														try {
-															$lists['tags'] = json_decode($request_http->exec(10, 1), true);
-														} catch (\Exception $e) {
-														}
-														cache::set('core::branch::default::list', $lists, 86400);
-													}
+													$lists = update::getCoreBranchList();
 													if (isset($lists['branchs']) && is_array($lists['branchs'])) {
 														echo '<optgroup label="{{Branches (Pas de support)}}">';
 														foreach ($lists['branchs'] as $branch) {

--- a/tests/updateBranchTest.php
+++ b/tests/updateBranchTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/* This file is part of Jeedom.
+*
+* Jeedom is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* Jeedom is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Jeedom. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use PHPUnit\Framework\TestCase;
+
+
+class updateBranchTest extends TestCase {
+
+	private $providerBackup;
+	private $branchBackup;
+
+	protected function setUp(): void {
+		$this->providerBackup = config::byKey('core::repo::provider');
+		$this->branchBackup = config::byKey('core::branch');
+		config::save('core::repo::provider', 'default');
+		// Liste distante simulée (branches + tags) pour éviter tout appel réseau.
+		cache::set('core::branch::default::list', array(
+			'branchs' => array(
+				array('name' => 'master'),
+				array('name' => 'beta'),
+				array('name' => 'alpha'),
+			),
+			'tags' => array(
+				array('name' => '4.4.0'),
+				array('name' => '4.4.1'),
+			),
+		), 86400);
+	}
+
+	protected function tearDown(): void {
+		config::save('core::repo::provider', $this->providerBackup);
+		config::save('core::branch', $this->branchBackup);
+		cache::byKey('core::branch::default::list')->remove();
+	}
+
+	public function testStableBranchIsAlwaysValid() {
+		echo "\n" . __CLASS__ . '::' . __FUNCTION__ . ' : ';
+		config::save('core::branch', 'master');
+		$this->assertTrue(update::isCoreBranchValid());
+	}
+
+	public function testExistingBranchIsValid() {
+		echo "\n" . __CLASS__ . '::' . __FUNCTION__ . ' : ';
+		config::save('core::branch', 'beta');
+		$this->assertTrue(update::isCoreBranchValid());
+	}
+
+	public function testMissingBranchIsInvalid() {
+		echo "\n" . __CLASS__ . '::' . __FUNCTION__ . ' : ';
+		config::save('core::branch', 'branche-supprimee');
+		$this->assertFalse(update::isCoreBranchValid());
+	}
+
+	public function testExistingTagIsValid() {
+		echo "\n" . __CLASS__ . '::' . __FUNCTION__ . ' : ';
+		config::save('core::branch', 'tag::4.4.0');
+		$this->assertTrue(update::isCoreBranchValid());
+	}
+
+	public function testMissingTagIsInvalid() {
+		echo "\n" . __CLASS__ . '::' . __FUNCTION__ . ' : ';
+		config::save('core::branch', 'tag::9.9.9');
+		$this->assertFalse(update::isCoreBranchValid());
+	}
+
+	public function testCustomProviderIsAlwaysValid() {
+		echo "\n" . __CLASS__ . '::' . __FUNCTION__ . ' : ';
+		config::save('core::repo::provider', 'custom');
+		config::save('core::branch', 'branche-supprimee');
+		$this->assertTrue(update::isCoreBranchValid());
+	}
+
+	public function testUnreachableListDoesNotRaiseFalsePositive() {
+		echo "\n" . __CLASS__ . '::' . __FUNCTION__ . ' : ';
+		// Liste distante indisponible (réseau KO) : on ne doit pas alerter à tort.
+		cache::set('core::branch::default::list', array('branchs' => array(), 'tags' => array()), 86400);
+		config::save('core::branch', 'branche-inconnue');
+		$this->assertTrue(update::isCoreBranchValid());
+	}
+}
+?>


### PR DESCRIPTION
## Summary
This PR adds functionality to validate that the configured core branch/tag still exists on the GitHub repository, and integrates this validation into the system health check and update process.

## Key Changes

- **New method `getCoreBranchList()`** in `update.class.php`: Fetches and caches the list of available branches and tags from the default GitHub repository for 24 hours. Extracted from duplicate code in `administration.php`.

- **New method `isCoreBranchValid()`** in `update.class.php`: Validates that the currently configured core branch or tag exists on the remote repository. Returns `true` for custom providers, known stable branches (master/release/stable), or when the remote list is unavailable to avoid false positives.

- **Branch validation in `checkUpdate()`**: Added validation check that creates a user-facing message if the configured branch is no longer available on the repository, alerting users to select a valid branch in Settings.

- **Health check integration** in `jeedom.class.php`: Added a new health check item that reports the validity of the configured core branch, displaying the branch name and an error message if it's no longer found on the repository.

- **Code refactoring** in `administration.php`: Replaced inline branch/tag fetching logic with a call to the new `getCoreBranchList()` method, reducing code duplication.

## Implementation Details

- The branch validation gracefully handles edge cases: custom repository providers, well-known branches, and unavailable remote lists all return `true` to prevent false alarms.
- Tag branches are identified by the `tag::` prefix and validated separately from regular branches.
- Caching is leveraged to minimize API calls to GitHub while allowing manual refresh when needed.

Fix #3166 