### PR TITLE
feat(cmd): auto-convert electric current intensity (mA/A)

### DIFF
--- a/core/class/cmd.class.php
+++ b/core/class/cmd.class.php
@@ -109,6 +109,7 @@ class cmd {
 		'o/s' => array(1000, 'o/s', 'Ko/s', 'Mo/s', 'Go/s', 'To/s'),
 		'Bps' => array(1000, 'Bps', 'Kbps', 'Mbps', 'Gbps', 'Tbps'),
 		'Hz' => array(1000, 'Hz', 'kHz', 'MHz', 'GHz'),
+		'mA' => array(1000, 'mA', 'A'),
 		'l' => array(1000, 'l', 'm<sup>3</sup>')
 	);
 	/*	 * ***********************Méthodes statiques*************************** */


### PR DESCRIPTION
## Résumé

Ajoute la conversion automatique d'unité pour l'intensité électrique : une valeur exprimée en `mA` est désormais mise à l'échelle en `A` par `cmd::autoValueArray()`, comme c'est déjà le cas pour la puissance (`W`), l'énergie (`Wh`), la fréquence (`Hz`), etc.

## Détail

Nouvelle entrée dans la table `$_unite_conversion` de `core/class/cmd.class.php` :

```php
'mA' => array(1000, 'mA', 'A'),
```

Le facteur `1000` et la liste d'unités suivent exactement le format existant. Exemple de rendu : `1500 mA` → `1.5 A`.

Format retenu conformément à la discussion de l'issue (`'mA' => array(1000, 'mA', 'A')`) ; `kA` volontairement écarté car peu usuel en domotique.

Closes #2429