### PR TITLE
fix(history): set correct tableName for archived rows in all()

### DIFF
--- a/core/class/history.class.php
+++ b/core/class/history.class.php
@@ -368,7 +368,7 @@ class history {
 		}
 		$sql = '';
 		if ($_groupingType == null || strpos($_groupingType, '::') === false) {
-			$sql .= 'SELECT ' . DB::buildField(__CLASS__);
+			$sql .= 'SELECT ' . DB::buildField(__CLASS__) . ', a._tableName';
 		} else {
 			$goupingTypeDelta = explode('||', $_groupingType);
 			if (count($goupingTypeDelta) > 1) {
@@ -414,7 +414,7 @@ class history {
 			}
 			$sql .= ' FROM (';
 		}
-		$sql .= ' (SELECT * from history WHERE value is not null AND cmd_id=:cmd_id ';
+		$sql .= ' (SELECT *, \'history\' as _tableName from history WHERE value is not null AND cmd_id=:cmd_id ';
 		if ($_startTime !== null) {
 			$sql .= ' AND datetime>=:startTime';
 		}
@@ -423,7 +423,7 @@ class history {
 		}
 		$sql .= ') ';
 		$sql .= ' UNION ALL ';
-		$sql .= ' (SELECT * from historyArch WHERE value is not null AND cmd_id=:cmd_id ';
+		$sql .= ' (SELECT *, \'historyArch\' as _tableName from historyArch WHERE value is not null AND cmd_id=:cmd_id ';
 		if ($_startTime !== null) {
 			$sql .= ' AND `datetime`>=:startTime';
 		}
@@ -477,13 +477,13 @@ class history {
 				'cmd_id' => $_cmd_id,
 				'startTime' => $_startTime
 			);
-			$sql = 'SELECT ' . DB::buildField(__CLASS__);
+			$sql = 'SELECT ' . DB::buildField(__CLASS__) . ', a._tableName';
 			$sql .= ' FROM (';
-			$sql .= ' (SELECT * from history WHERE value is not null AND cmd_id=:cmd_id AND `datetime`<=:startTime';
+			$sql .= ' (SELECT *, \'history\' as _tableName from history WHERE value is not null AND cmd_id=:cmd_id AND `datetime`<=:startTime';
 			$sql .= ' ORDER BY datetime DESC LIMIT 1';
 			$sql .= ') ';
 			$sql .= ' UNION ALL ';
-			$sql .= ' (SELECT * from historyArch WHERE value is not null AND cmd_id=:cmd_id AND `datetime`<=:startTime';
+			$sql .= ' (SELECT *, \'historyArch\' as _tableName from historyArch WHERE value is not null AND cmd_id=:cmd_id AND `datetime`<=:startTime';
 			$sql .= ' ORDER BY datetime DESC LIMIT 1';
 			$sql .= ') ';
 			$sql .= ')a ';


### PR DESCRIPTION
## Problème

`history::all()` combine les tables `history` et `historyArch` via `UNION ALL`, puis hydrate **toutes** les lignes en objets `history` (`PDO::FETCH_CLASS`). La requête ne transporte pas la table d'origine, et la classe a `protected $_tableName = 'history'` par défaut. Résultat : les lignes provenant de `historyArch` renvoient quand même `_tableName = 'history'`.

C'est gênant car `getTableName()` cible la table en écriture (`REPLACE INTO ... getTableName()` dans `save()`, idem `remove()`). Éditer/supprimer un point archivé récupéré via `all()` visait donc `history` au lieu de `historyArch`.

## Correctif

On fait porter la table source à chaque ligne via une colonne littérale `_tableName`, que PDO mappe sur la propriété protégée `$_tableName` (comme `cmd_id`/`value`/`datetime`, également `protected`) :

- sous-requêtes internes : `SELECT *, 'history' as _tableName from history ...` / `SELECT *, 'historyArch' as _tableName from historyArch ...` ;
- la colonne n'est sélectionnée dans le `SELECT` externe que dans le cas **non groupé** — en mode groupé les lignes des deux tables sont agrégées ensemble (table source sans signification, objets non éditables) ;
- même traitement dans le bloc `_addFirstPreviousValue` (toujours non groupé).

## Notes

- Aucune migration ni changement de schéma : `'history'`/`'historyArch'` sont des littéraux SQL.
- Le marqueur ajouté aux sous-requêtes est inoffensif en mode groupé (colonne ignorée par les `SELECT` agrégés).
- `UNION ALL` reste valide : les deux sous-requêtes reçoivent la même colonne supplémentaire.

Closes #3097

---
_Generated by [Claude Code](https://claude.ai/code/session_01919VngS12QYM9YvYTQBiKD)_