### PR TITLE
fix TypeError in log::chunk() when maxSizeLog is empty

### DIFF
--- a/core/class/log.class.php
+++ b/core/class/log.class.php
@@ -147,7 +147,7 @@ class log extends AbstractLogger {
 		}
 		foreach ($paths as $path) {
 			if (is_file($path)) {
-				if ($_onlyIfSizeExceeded && filesize($path) < (self::getConfig('maxSizeLog') * 1024 * 1024)) {
+				if ($_onlyIfSizeExceeded && filesize($path) < ((int)self::getConfig('maxSizeLog', 5) * 1024 * 1024)) {
 					continue;
 				}
 				self::chunkLog($path);
@@ -165,7 +165,7 @@ class log extends AbstractLogger {
 			$maxLineLog = self::DEFAULT_MAX_LINE;
 		}
 
-		$maxSizeLog = (int)self::getConfig('maxSizeLog', 10);
+		$maxSizeLog = (int)self::getConfig('maxSizeLog', 5);
 		$maxSizeLog = max(1, $maxSizeLog);
 		$maxBytes = $maxSizeLog * 1024 * 1024;
 


### PR DESCRIPTION
## Problem

`log::chunk()` throws a PHP 8 TypeError (`Unsupported operand types: string * int`) during `cronHourly`, reported on the forum: https://community.jeedom.com/t/erreur-dans-cron-hourly-jeedom-4-6-0/149636

Root cause: `config::byKeys()` returns `''` for `maxSizeLog` when the key exists in the database with an empty value, bypassing the `default.config.ini` fallback. Multiplying an empty string by an int throws a TypeError in PHP 8.

## Fix

- Cast `getConfig('maxSizeLog')` to `int` in `log::chunk()` to prevent the TypeError
- Add the correct default value `5` (matching `default.config.ini`) on both call sites
- The previous hard-coded default of `10` in `chunkLog()` was inconsistent with the config default
