### PR TITLE
Remove useless floatval() cast in history::getHistoryFromCalcul

### DIFF
--- a/core/class/history.class.php
+++ b/core/class/history.class.php
@@ -985,7 +985,7 @@ class history {
 				if (count($matches[1]) != count($cmd_history)) {
 					continue;
 				}
-				$datetime = floatval(strtotime($datetime . ' UTC'));
+				$datetime = strtotime($datetime . ' UTC');
 				$calcul = template_replace($cmd_history, $_strcalcul);
 				if ($_noCalcul) {
 					$value[$datetime] = $calcul;


### PR DESCRIPTION
## Summary

`strtotime()` returns `int|false`. Wrapping it in `floatval()` converts the result to a float, but PHP silently truncates floats back to integers when used as array keys, making the cast a no-op with no effect on behavior.

Removing it makes the intent explicit: the key is a Unix timestamp (integer).

## Changes

- `history.class.php`: `$datetime = floatval(strtotime(...))` → `$datetime = strtotime(...)`
