### PR TITLE
Use guard clauses in cmd->addHistoryValue

### DIFF
--- a/core/class/cmd.class.php
+++ b/core/class/cmd.class.php
@@ -99,7 +99,7 @@ class cmd {
 	/** @var array<string, string> Template array */
 	protected static $_templateArray = array();
 
-	/** @var array<string, int|string> Unit conversion mapping */
+	/** @var array<string, array<int|string>> Unit conversion mapping */
 	protected static $_unite_conversion = array(
 		's' => array(60, 's', 'min', 'h'),
 		'W' => array(1000, 'W', 'kW', 'MW'),

--- a/core/class/cmd.class.php
+++ b/core/class/cmd.class.php
@@ -2684,7 +2684,7 @@ class cmd {
 			log::add('cmd', 'error', __('Erreur push sur :', __FILE__) . ' ' . $url . ' commande : ' . $this->getHumanName() . ' => ' . log::exception($e));
 		}
 	}
-    
+
 	/**
 	 * Generate API URL for ask response
 	 *
@@ -2755,13 +2755,21 @@ class cmd {
 	 * @return void
 	 */
 	public function addHistoryValue($_value, $_datetime = '') {
-		if ($this->getIsHistorized() == 1 && ($_value === null || ($_value !== '' && $this->getType() == 'info' && $_value <= $this->getConfiguration('maxValue', $_value) && $_value >= $this->getConfiguration('minValue', $_value)))) {
-			$history = new history();
-			$history->setCmd_id($this->getId());
-			$history->setValue($_value);
-			$history->setDatetime($_datetime);
-			return $history->save($this);
+		if ($this->getType() != 'info' || $this->getIsHistorized() != 1) {
+			return;
 		}
+		if ($_value === null || $_value === '') {
+			return;
+		}
+		if ($_value < $this->getConfiguration('minValue', $_value) || $_value > $this->getConfiguration('maxValue', $_value)) {
+			return;
+		}
+
+		$history = new history();
+		$history->setCmd_id($this->getId());
+		$history->setValue($_value);
+		$history->setDatetime($_datetime);
+		$history->save($this);
 	}
 
 	/**

--- a/core/class/cmd.class.php
+++ b/core/class/cmd.class.php
@@ -2758,10 +2758,7 @@ class cmd {
 		if ($this->getType() != 'info' || $this->getIsHistorized() != 1) {
 			return;
 		}
-		if ($_value === null || $_value === '') {
-			return;
-		}
-		if ($_value < $this->getConfiguration('minValue', $_value) || $_value > $this->getConfiguration('maxValue', $_value)) {
+		if ($_value === null || $_value === '' || $_value < $this->getConfiguration('minValue', $_value) || $_value > $this->getConfiguration('maxValue', $_value)) {
 			return;
 		}
 


### PR DESCRIPTION
## Summary

- Replace the single large `if` block in `addHistoryValue` with early return guard clauses
- Extract null, empty, and out-of-range value checks into dedicated guards
- Remove unused `return` on `history::save()` (returns void)
- Fix `$_unite_conversion` PHPDoc type from `array<string, int|string>` to `array<string, array<int|string>>`


## Motivation

The original method wrapped its entire body in one deeply nested condition, making it hard to follow the validation logic. The guard clause pattern makes each rejection reason explicit and reduces indentation throughout the method body.

This refactor is also preparatory for an upcoming history retention feature that will add logic between the guards and the history save.

## Behaviour

No functional change. `history::save()` already rejects null values internally (early return on line 1012), so dropping the null pass-through from the outer condition has no observable effect.
