### PR TITLE
Add history retention mode

### DIFF
--- a/core/class/cmd.class.php
+++ b/core/class/cmd.class.php
@@ -2762,6 +2762,36 @@ class cmd {
 			return;
 		}
 
+		$retentionMode = $this->getConfiguration('historyRetentionMode', 'none');
+		if ($retentionMode !== 'none') {
+			$ts = ($_datetime !== '') ? strtotime($_datetime) : time();
+			$dayEnd = date('Y-m-d 23:59:59', $ts);
+
+			switch ($retentionMode) {
+				case 'current_day':
+					history::removes($this->getId(), date('Y-m-d 00:00:00', $ts), $dayEnd);
+					break;
+
+				case 'current_day_keep_first':
+					$histories = $this->getHistory(date('Y-m-d 00:00:00', $ts), $dayEnd);
+					if (count($histories) > 1) {
+						history::removes($this->getId(), date('Y-m-d H:i:s', strtotime($histories[0]->getDatetime()) + 1), $dayEnd);
+					}
+					break;
+
+				case 'current_month':
+					history::removes($this->getId(), date('Y-m-01 00:00:00', $ts), $dayEnd);
+					break;
+
+				case 'current_month_keep_first':
+					$histories = $this->getHistory(date('Y-m-01 00:00:00', $ts), $dayEnd);
+					if (count($histories) > 1) {
+						history::removes($this->getId(), date('Y-m-d H:i:s', strtotime($histories[0]->getDatetime()) + 1), $dayEnd);
+					}
+					break;
+			}
+		}
+
 		$history = new history();
 		$history->setCmd_id($this->getId());
 		$history->setValue($_value);

--- a/desktop/modal/cmd.configure.php
+++ b/desktop/modal/cmd.configure.php
@@ -473,6 +473,20 @@ $configEqDisplayType = jeedom::getConfiguration('eqLogic:displayType');
               </div>
               <?php if ($JEEDOM_INTERNAL_CONFIG['cmd']['type']['info']['subtype'][$cmd->getSubType()]['isHistorized']['canBeSmooth']) { ?>
                 <div class="form-group">
+                  <label class="col-md-3 col-sm-3 control-label">{{Mode de rétention}}
+                    <sup><i class="fas fa-question-circle" title="{{Limite l'historique à la dernière valeur, ou aux première et dernière valeurs, du jour ou du mois}}"></i></sup>
+                  </label>
+                  <div class="col-sm-6">
+                    <select class="form-control cmdAttr" data-l1key="configuration" data-l2key="historyRetentionMode">
+                      <option value="none">{{Aucun}}</option>
+                      <option value="current_day">{{Dernière valeur du jour}}</option>
+                      <option value="current_day_keep_first">{{Première et dernière valeur du jour}}</option>
+                      <option value="current_month">{{Dernière valeur du mois}}</option>
+                      <option value="current_month_keep_first">{{Première et dernière valeur du mois}}</option>
+                    </select>
+                  </div>
+                </div>
+                <div class="form-group">
                   <label class="col-md-3 col-sm-3 control-label">{{Mode de lissage}}
                     <sup><i class="fas fa-question-circle" title="{{Mode de lissage des historiques (défaut : moyenne). Attention : aucun lissage conserve toutes les données en historique au risque de remplir la base}}"></i></sup>
                   </label>
@@ -1459,6 +1473,28 @@ $configEqDisplayType = jeedom::getConfiguration('eqLogic:displayType');
             jeedomUtils.taAutosize()
           })
         })
+        return
+      }
+    })
+
+    document.getElementById('cmd_configuration')?.addEventListener('change', function(event) {
+      let _target = null
+      if (_target = event.target.closest('.cmdAttr[data-l2key="historyRetentionMode"]')) {
+        const historizeMode = document.querySelector('.cmdAttr[data-l2key="historizeMode"]')
+        const historizeSmooth = document.querySelector('.cmdAttr[data-l2key="history::smooth"]')
+        if (_target.jeeValue() == 'none') {
+          const previousMode = jeephp2js.md_cmdConfigure_cmdInfo.configuration.historizeMode
+          historizeMode.jeeValue(previousMode && previousMode !== 'none' ? previousMode : 'avg')
+          historizeMode.closest('.form-group').seen()
+          const previousSmooth = jeephp2js.md_cmdConfigure_cmdInfo.configuration['history::smooth']
+          historizeSmooth.jeeValue(previousSmooth !== '-1' ? previousSmooth : '')
+          historizeSmooth.closest('.form-group').seen()
+        } else {
+          historizeMode.closest('.form-group').unseen()
+          historizeMode.jeeValue('none')
+          historizeSmooth.closest('.form-group').unseen()
+          historizeSmooth.jeeValue('-1')
+        }
         return
       }
     })

--- a/desktop/modal/cmd.configure.php
+++ b/desktop/modal/cmd.configure.php
@@ -478,7 +478,7 @@ $configEqDisplayType = jeedom::getConfiguration('eqLogic:displayType');
                   </label>
                   <div class="col-sm-6">
                     <select class="form-control cmdAttr" data-l1key="configuration" data-l2key="historyRetentionMode">
-                      <option value="none">{{Aucun}}</option>
+                      <option value="none">{{Normal}}</option>
                       <option value="current_day">{{Dernière valeur du jour}}</option>
                       <option value="current_day_keep_first">{{Première et dernière valeur du jour}}</option>
                       <option value="current_month">{{Dernière valeur du mois}}</option>

--- a/desktop/modal/cmd.configure.php
+++ b/desktop/modal/cmd.configure.php
@@ -473,7 +473,9 @@ $configEqDisplayType = jeedom::getConfiguration('eqLogic:displayType');
               </div>
               <?php if ($JEEDOM_INTERNAL_CONFIG['cmd']['type']['info']['subtype'][$cmd->getSubType()]['isHistorized']['canBeSmooth']) { ?>
                 <div class="form-group">
-                  <label class="col-md-3 col-sm-3 control-label">{{Mode de lissage}}</label>
+                  <label class="col-md-3 col-sm-3 control-label">{{Mode de lissage}}
+                    <sup><i class="fas fa-question-circle" title="{{Mode de lissage des historiques (défaut : moyenne). Attention : aucun lissage conserve toutes les données en historique au risque de remplir la base}}"></i></sup>
+                  </label>
                   <div class="col-sm-6">
                     <select class="form-control cmdAttr" data-l1key="configuration" data-l2key="historizeMode">
                       <option value="avg">{{Moyenne}}</option>
@@ -485,7 +487,7 @@ $configEqDisplayType = jeedom::getConfiguration('eqLogic:displayType');
                 </div>
                 <div class="form-group">
                   <label class="col-md-3 col-sm-3 control-label">{{Limiter à une valeur toute les}}
-                    <sup><i class="fas fa-question-circle" title="{{Limiter le nombre de valeurs historisées par la commande en temps réel (avant le lissage de la nuit). Attention un mode de lissage doit absolument être défini.}}"></i></sup>
+                    <sup><i class="fas fa-question-circle" title="{{Regroupe les valeurs reçues dans une même fenêtre de temps en une seule. Nécessite un mode de lissage pour fonctionner}}"></i></sup>
                   </label>
                   <div class="col-sm-6">
                     <select class="form-control cmdAttr" data-l1key="configuration" data-l2key="history::smooth">
@@ -501,7 +503,7 @@ $configEqDisplayType = jeedom::getConfiguration('eqLogic:displayType');
               ?>
               <div class="form-group">
                 <label class="col-md-3 col-sm-3 control-label">{{Purger historique}}
-                  <sup><i class="fas fa-question-circle" title="{{si plus vieux que}}"></i></sup>
+                  <sup><i class="fas fa-question-circle" title="{{Purge les historiques si plus anciens que}}"></i></sup>
                 </label>
                 <div class="col-sm-6">
                   <select class="form-control cmdAttr" data-l1key="configuration" data-l2key="historyPurge">
@@ -988,7 +990,7 @@ $configEqDisplayType = jeedom::getConfiguration('eqLogic:displayType');
             version: 'dashboard',
             widgetName: _widgetName,
             error: function(error) {
-              document.getElementById('optionalParamHelp').empty().textContent = '{{Pas de description des paramètres optionnels sur ce Widget.}}'
+              document.getElementById('optionalParamHelp').empty().textContent = '{{Pas de description des paramètres optionnels sur ce widget}}'
             },
             success: function(data) {
               document.getElementById('optionalParamHelp').empty().innerHTML = data.html
@@ -1393,7 +1395,6 @@ $configEqDisplayType = jeedom::getConfiguration('eqLogic:displayType');
         }
         return
       }
-
     })
 
 

--- a/desktop/modal/cmd.configure.php
+++ b/desktop/modal/cmd.configure.php
@@ -1214,7 +1214,7 @@ $configEqDisplayType = jeedom::getConfiguration('eqLogic:displayType');
     })
 
     document.getElementById('cmd_configuration')?.addEventListener('click', function(event) {
-      var _target = null
+      let _target = null
       if (_target = event.target.closest('#bt_cmdConfigureCopyHistory')) {
         jeedom.cmd.getSelectModal({
           cmd: {
@@ -1255,7 +1255,7 @@ $configEqDisplayType = jeedom::getConfiguration('eqLogic:displayType');
      */
     //cmd information tab
     document.getElementById('cmd_information')?.addEventListener('click', function(event) {
-      var _target = null
+      let _target = null
       if (_target = event.target.closest('#bt_cmdConfigureChooseIcon')) {
         let displayIconParent = _target.closest('.displayIconParent')
         let icon = displayIconParent.querySelector('[data-l2key="icon"] > i')
@@ -1376,7 +1376,7 @@ $configEqDisplayType = jeedom::getConfiguration('eqLogic:displayType');
     })
 
     document.getElementById('cmd_information')?.addEventListener('dblclick', function(event) {
-      var _target = null
+      let _target = null
       if (_target = event.target.closest('.cmdAttr[data-l1key="display"][data-l2key="icon"]')) {
         _target.innerHTML = ''
         return
@@ -1384,12 +1384,12 @@ $configEqDisplayType = jeedom::getConfiguration('eqLogic:displayType');
     })
 
     document.getElementById('cmd_information')?.addEventListener('change', function(event) {
-      var _target = null
+      let _target = null
       if (_target = event.target.closest('.cmdAttr[data-l2key="timeline::enable"]')) {
         if (_target.jeeValue() == 1) {
-          document.querySelectorAll('.cmdAttr[data-l2key="timeline::folder"]').seen()
+          document.querySelector('.cmdAttr[data-l2key="timeline::folder"]').seen()
         } else {
-          document.querySelectorAll('.cmdAttr[data-l2key="timeline::folder"]').unseen()
+          document.querySelector('.cmdAttr[data-l2key="timeline::folder"]').unseen()
         }
         return
       }
@@ -1399,7 +1399,7 @@ $configEqDisplayType = jeedom::getConfiguration('eqLogic:displayType');
 
     //cmd configuration tab
     document.getElementById('cmd_configuration')?.addEventListener('click', function(event) {
-      var _target = null
+      let _target = null
 
       if (_target = event.target.closest('#bt_searchInfoCmdCalculValue')) {
         jeedom.cmd.getSelectModal({
@@ -1407,7 +1407,7 @@ $configEqDisplayType = jeedom::getConfiguration('eqLogic:displayType');
             type: 'info'
           }
         }, function(result) {
-          document.querySelectorAll('.cmdAttr[data-l1key=configuration][data-l2key=calculValueOffset]')[0].insertAtCursor(result.human)
+          document.querySelector('.cmdAttr[data-l1key=configuration][data-l2key=calculValueOffset]').insertAtCursor(result.human)
         })
       }
 
@@ -1463,7 +1463,7 @@ $configEqDisplayType = jeedom::getConfiguration('eqLogic:displayType');
     })
 
     document.getElementById('cmd_configuration')?.addEventListener('focusout', function(event) {
-      var _target = null
+      let _target = null
       if (_target = event.target.closest('.cmdAction.expressionAttr[data-l1key="cmd"]')) {
         var type = _target.getAttribute('data-type')
         var expression = _target.closest('.' + type).getJeeValues('.expressionAttr')
@@ -1480,7 +1480,7 @@ $configEqDisplayType = jeedom::getConfiguration('eqLogic:displayType');
 
     //cmd display tab
     document.getElementById('cmd_display')?.addEventListener('click', function(event) {
-      var _target = null
+      let _target = null
 
       if (_target = event.target.closest('#bt_addWidgetParametersCmd')) {
         var tr = '<tr>'
@@ -1510,7 +1510,7 @@ $configEqDisplayType = jeedom::getConfiguration('eqLogic:displayType');
     })
 
     document.getElementById('cmd_display')?.addEventListener('change', function(event) {
-      var _target = null
+      let _target = null
       if (_target = event.target.closest('select[data-l1key="template"][data-l2key="dashboard"]')) {
         jeeFrontEnd.md_displayCmdConfigure.displayWidgetHelp(_target.value)
         return

--- a/desktop/modal/cmd.configure.php
+++ b/desktop/modal/cmd.configure.php
@@ -1487,7 +1487,7 @@ $configEqDisplayType = jeedom::getConfiguration('eqLogic:displayType');
           historizeMode.jeeValue(previousMode && previousMode !== 'none' ? previousMode : 'avg')
           historizeMode.closest('.form-group').seen()
           const previousSmooth = jeephp2js.md_cmdConfigure_cmdInfo.configuration['history::smooth']
-          historizeSmooth.jeeValue(previousSmooth !== '-1' ? previousSmooth : '')
+          historizeSmooth.jeeValue(previousSmooth && previousSmooth !== '-1' ? previousSmooth : '')
           historizeSmooth.closest('.form-group').seen()
         } else {
           historizeMode.closest('.form-group').unseen()


### PR DESCRIPTION
## Summary

- Add a new `historyRetentionMode` configuration per **numeric info command** (the only subtype for which smoothing options are available)
- When active, forces `historizeMode` to `none` and `history::smooth` to disabled to prevent conflicts with real-time smoothing
- The corresponding fields are hidden in the UI when a retention mode is selected

<img  height="300" alt="image" src="https://github.com/user-attachments/assets/398ffd4b-dd19-49c0-a99b-f3856316f973" />

## Retention options

| Option | Use case |
|--------|----------|
| **Last value of the day** | Commands updated frequently where only the end-of-day value matters: daily energy index, gas or water meter, daily rainfall accumulation, real-time price or tariff |
| **First and last value of the day** | Cumulative counters where the daily delta matters (last - first): electricity, gas or water index to calculate daily consumption |
| **Last value of the month** | Commands representing a consolidated monthly state: peak power demand, monthly usage total, subscription consumption counter |
| **First and last value of the month** | Same as above but where the monthly delta is needed, typically for billing-period index readings |


## Notes

- Retention is applied in real time on each call to `addHistoryValue`, before the value is saved
- When retention is set back to none, `historizeMode` and `history::smooth` are restored to their last saved values if they were not previously overridden by a retention save. Otherwise they reset to their defaults (`avg` and empty)
- Documentation update required in `docs/fr_FR/display.md`: add `historyRetentionMode` field description under the history section of the info command configuration tab


