### PR TITLE
save update options

### DIFF
--- a/desktop/js/update.js
+++ b/desktop/js/update.js
@@ -537,9 +537,9 @@ if (!jeeFrontEnd.update) {
         height: window.innerHeight > 500 ? 440 : window.innerHeight - 80,
         top: window.innerHeight > 500 ? 120 : 0,
         callback: function() {
-          var contentEl = jeeDialog.get('#md_update', 'content')
+          const contentEl = jeeDialog.get('#md_update', 'content')
           if (contentEl.querySelector('#md_specifyUpdate') == null) {
-            var newContent = document.getElementById('md_specifyUpdate-template').cloneNode(true)
+            const newContent = document.getElementById('md_specifyUpdate-template').cloneNode(true)
             newContent.setAttribute('id', 'md_specifyUpdate')
             contentEl.appendChild(newContent)
             newContent.querySelector('#bt_warnChangelogCore').href = document.getElementById('bt_changelogCore').href
@@ -548,6 +548,35 @@ if (!jeeFrontEnd.update) {
               _tooltip.removeAttribute('data-title')
             })
             jeedomUtils.initTooltips(document.getElementById('md_update'))
+          }
+
+          if (jeephp2js.updateOptions) {
+            try {
+              const options = typeof jeephp2js.updateOptions === 'string' ? JSON.parse(jeephp2js.updateOptions) : jeephp2js.updateOptions
+
+              Object.keys(options).forEach(function(key) {
+                const el = contentEl.querySelector('[data-l1key="' + key + '"], [data-l2key="' + key + '"]')
+                if (el) {
+                  if (el.type === 'checkbox') {
+                    el.checked = options[key] == 1
+                  } else {
+                    el.value = options[key]
+                  }
+                }
+              });
+
+              const forceCheck = contentEl.querySelector('input[data-l1key="force"]')
+              if (forceCheck && forceCheck.checked) {
+                const check_backupBefore = contentEl.querySelector('.updateOption[data-l1key="backup::before"]')
+                if (check_backupBefore) {
+                  check_backupBefore.setAttribute('data-state', check_backupBefore.checked)
+                  check_backupBefore.checked = false;
+                  check_backupBefore.setAttribute('disabled', '')
+                }
+              }
+            } catch (e) {
+              console.error('Erreur lors du traitement des options mémorisées', e)
+            }
           }
 
           contentEl.querySelector('input[data-l1key="force"]').addEventListener('click', function(event) {
@@ -567,12 +596,51 @@ if (!jeeFrontEnd.update) {
           jeeDialog.get('#md_update', 'content').querySelector('#md_specifyUpdate').removeClass('hidden')
         },
         buttons: {
+          saveOptions: {
+            label: '<i class="fas fa-save"></i> {{Sauvegarder les options}}',
+            className: 'btn-default',
+            callback: {
+              click: function(event) {
+                if (event) {
+                  event.preventDefault()
+                  event.stopPropagation()
+                }
+
+                const options = document.getElementById('md_specifyUpdate').getJeeValues('.updateOption')[0]
+                jeephp2js.updateOptions = options
+                jeedom.config.save({
+                  configuration: {
+                    'update::options': JSON.stringify(options)
+                  },
+                  error: function(error) {
+                    jeedomUtils.showAlert({
+                      message: error.message,
+                      level: 'danger'
+                    })
+                  },
+                  success: function(data) {
+                    jeedomUtils.showAlert({
+                      message: '{{Options de mise à jour sauvegardées}}',
+                      level: 'success'
+                    })
+                  }
+                });
+                
+                return false
+              }
+            }
+          },
           confirm: {
             label: '{{Mettre à jour}}',
             className: 'success',
             callback: {
               click: function(event) {
-                var options = document.getElementById('md_specifyUpdate').getJeeValues('.updateOption')[0]
+                if (event) {
+                  event.preventDefault();
+                  event.stopPropagation();
+                }
+
+                const options = document.getElementById('md_specifyUpdate').getJeeValues('.updateOption')[0]
                 jeedomUtils.hideAlert()
                 jeeDialog.get('#md_update').hide()
                 jeeP.progress = 0

--- a/desktop/php/update.php
+++ b/desktop/php/update.php
@@ -38,6 +38,7 @@ if (strpos($logUpdate, 'END UPDATE') || count(system::ps('install/update.php', '
 } else {
 	sendVarToJS('jeephp2js.isUpdating', '1');
 }
+sendVarToJS('jeephp2js.updateOptions', config::byKey('update::options', 'core', []));
 ?>
 
 <div class="row row-overflow">


### PR DESCRIPTION
add possibility to save update options

## Description
After this discussion : https://community.jeedom.com/t/update-core-jeedom-enchaine-lupdate-des-plugins/149733,
all users don't need the same update options and prefer to save them in order not to check them at each update.

I added the possibility to save update options.

SELECT * FROM `config` WHERE `key` = 'update::options'
   plugin | key                     | value
   core    | update::options  | {"preUpdate":"0","backup::before":"1","core":"1","force":"0","plugins":"0","update::reapply":""}

### Suggested changelog entry
add possibility to save update options

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [x] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.
