### PR TITLE
Fix setTags() reference error in interactQuery

### DIFF
--- a/core/class/interactQuery.class.php
+++ b/core/class/interactQuery.class.php
@@ -830,7 +830,8 @@ class interactQuery {
 			$cron->setSchedule(cron::convertDateToCron($executeDate));
 			$cron->save();
 			$replace['#valeur#'] = date('Y-m-d H:i:s', $executeDate);
-			$result = scenarioExpression::setTags(str_replace(array_keys($replace), $replace, $reply));
+			$tmpReply = str_replace(array_keys($replace), $replace, $reply);
+			$result = scenarioExpression::setTags($tmpReply);
 			return $result;
 		}
 		$replace['#valeur#'] = '';
@@ -869,7 +870,8 @@ class interactQuery {
 					if (isset($options['tags'])) {
 						$options['tags'] = arg2array($options['tags']);
 						foreach ($options['tags'] as $key => $value) {
-							$tags['#' . trim(trim($key), '#') . '#'] = scenarioExpression::setTags(trim($value));
+							$tmpValue = trim($value);
+							$tags['#' . trim(trim($key), '#') . '#'] = scenarioExpression::setTags($tmpValue);
 						}
 					}
 					$options['tags'] = array_merge($replace, $tags);

--- a/core/class/interactQuery.class.php
+++ b/core/class/interactQuery.class.php
@@ -870,8 +870,7 @@ class interactQuery {
 					if (isset($options['tags'])) {
 						$options['tags'] = arg2array($options['tags']);
 						foreach ($options['tags'] as $key => $value) {
-							$tmpValue = trim($value);
-							$tags['#' . trim(trim($key), '#') . '#'] = scenarioExpression::setTags($tmpValue);
+							$tags['#' . trim(trim($key), '#') . '#'] = scenarioExpression::setTags($value);
 						}
 					}
 					$options['tags'] = array_merge($replace, $tags);


### PR DESCRIPTION
Correction du bogue affectant les tags passés en arguments à un scénario

<!-- Provide a general summary of your changes in the title above. -->

<!--
Please target the `beta` branch when submitting your pull request on plugins and `develop` branch on core.
-->

## Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
-->
Les tags passés en argument aux scénarios, depuis les interactions, provoquent une erreur de type: "Erreur lors de l'exécution de scenario. Détails : scenarioExpression::setTags(): Argument #1 ($_expression) could not be passed by reference" qui empêche l'exécution du scénario. 

Correction de deux appels à setTags() dans interactQuery::executeAndReply().

### Suggested changelog entry
<!-- Please provide a short description of the change for the changelog. -->

Fix erreur fatale setTags(): Argument #1 could not be passed by reference empêchant l'exécution des interactions avec tags

### Related issues/external references

Fixes # 
Correction de deux appels à setTags() dans interactQuery::executeAndReply(). . Testé localement

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have checked there is no other PR open for the same change.
- [X] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [X] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [ ] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
