### PR TITLE
Fix setTags() reference error in jeeApi & plan3d

### DIFF
--- a/core/api/jeeApi.php
+++ b/core/api/jeeApi.php
@@ -64,10 +64,10 @@ if (init('type') != '') {
 			throw new Exception(__('Vous n\'êtes pas autorisé à effectuer cette action, IP :', __FILE__) . ' ' . getClientIp());
 		}
 
-		if(config::byKey('api::forbidden::method', 'core', '') !== '' && preg_match(config::byKey('api::forbidden::method', 'core', ''), init('type'))){
+		if (config::byKey('api::forbidden::method', 'core', '') !== '' && preg_match(config::byKey('api::forbidden::method', 'core', ''), init('type'))) {
 			throw new Exception(__('Cette demande n\'est pas autorisée', __FILE__) . ' ' . getClientIp());
 		}
-		if(config::byKey('api::allow::method', 'core', '') !== '' && !preg_match(config::byKey('api::allow::method', 'core', ''), init('type'))){
+		if (config::byKey('api::allow::method', 'core', '') !== '' && !preg_match(config::byKey('api::allow::method', 'core', ''), init('type'))) {
 			throw new Exception(__('Cette demande n\'est pas autorisée', __FILE__) . ' ' . getClientIp());
 		}
 		$type = init('type');
@@ -174,8 +174,8 @@ if (init('type') != '') {
 					} else if (is_array(init('tags'))) {
 						$scenario->setTags(init('tags'));
 					}
-					$scenario->addTag('trigger','api');
-					$scenario->addTag('trigger_message',__('Scénario exécuté sur appel API', __FILE__));
+					$scenario->addTag('trigger', 'api');
+					$scenario->addTag('trigger_message', __('Scénario exécuté sur appel API', __FILE__));
 					$scenario_return = $scenario->launch();
 					if (is_string($scenario_return)) {
 						$return = $scenario_return;
@@ -237,7 +237,7 @@ if (init('type') != '') {
 		if ($type == 'fullData') {
 			log::add('api', 'debug', __('Demande API pour les commandes', __FILE__));
 			header('Content-Type: application/json');
-			echo json_encode(jeeObject::fullData(null,$_USER_GLOBAL), JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_UNESCAPED_UNICODE, 1024);
+			echo json_encode(jeeObject::fullData(null, $_USER_GLOBAL), JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_UNESCAPED_UNICODE, 1024);
 			die();
 		}
 		if ($type == 'variable') {
@@ -281,10 +281,10 @@ try {
 		throw new Exception(__('Requête invalide. Version JSON-RPC invalide :', __FILE__) . ' ' . $jsonrpc->getJsonrpc(), -32001);
 	}
 
-	if(config::byKey('api::forbidden::method', 'core', '') !== '' && preg_match(config::byKey('api::forbidden::method', 'core', ''), $jsonrpc->getMethod())){
+	if (config::byKey('api::forbidden::method', 'core', '') !== '' && preg_match(config::byKey('api::forbidden::method', 'core', ''), $jsonrpc->getMethod())) {
 		throw new Exception(__('Cette demande n\'est pas autorisée', __FILE__));
 	}
-	if(config::byKey('api::allow::method', 'core', '') !== '' && !preg_match(config::byKey('api::allow::method', 'core', ''), $jsonrpc->getMethod())){
+	if (config::byKey('api::allow::method', 'core', '') !== '' && !preg_match(config::byKey('api::allow::method', 'core', ''), $jsonrpc->getMethod())) {
 		throw new Exception(__('Cette demande n\'est pas autorisée', __FILE__) . ' ' . getClientIp());
 	}
 
@@ -909,8 +909,8 @@ try {
 			$jsonrpc->makeSuccess($scenario->stop());
 		}
 		if ($params['state'] == 'run') {
-			$scenario->addTag('trigger','api');
-			$scenario->addTag('trigger_message',__('Scénario exécuté sur appel API', __FILE__));
+			$scenario->addTag('trigger', 'api');
+			$scenario->addTag('trigger_message', __('Scénario exécuté sur appel API', __FILE__));
 			$jsonrpc->makeSuccess($scenario->launch());
 		}
 		if ($params['state'] == 'enable') {
@@ -1412,8 +1412,8 @@ try {
 	/*         * *********Catch exeption*************** */
 } catch (Exception $e) {
 	$message = $e->getMessage();
-	if(!isset($jsonrpc) || !is_object($jsonrpc)){
-		if(!isset($request)){
+	if (!isset($jsonrpc) || !is_object($jsonrpc)) {
+		if (!isset($request)) {
 			$request = init('request');
 			if ($request == '') {
 				$request = file_get_contents("php://input");

--- a/core/api/jeeApi.php
+++ b/core/api/jeeApi.php
@@ -168,7 +168,7 @@ if (init('type') != '') {
 						$_tags = array();
 						$args = arg2array(init('tags'));
 						foreach ($args as $key => $value) {
-							$_tags['#' . trim(trim($key), '#') . '#'] = scenarioExpression::setTags(trim($value), $scenario);
+							$_tags['#' . trim(trim($key), '#') . '#'] = scenarioExpression::setTags($value, $scenario);
 						}
 						$scenario->setTags($_tags);
 					} else if (is_array(init('tags'))) {

--- a/core/class/plan3d.class.php
+++ b/core/class/plan3d.class.php
@@ -223,7 +223,8 @@ class plan3d {
 		}
 		if ($this->getLink_type() == 'eqLogic') {
 			if ($this->getConfiguration('3d::widget') == 'text') {
-				$return['text'] = scenarioExpression::setTags($this->getConfiguration('3d::widget::text::text'));
+				$text = $this->getConfiguration('3d::widget::text::text');
+				$return['text'] = scenarioExpression::setTags($text);
 				preg_match_all("/#([0-9]*)#/", $this->getConfiguration('3d::widget::text::text'), $matches);
 				$return['cmds'] = $matches[1];
 			}


### PR DESCRIPTION
## Context

Following PR #3407, two additional calls to `scenarioExpression::setTags()` were found where a function result was passed directly as the first argument, which is declared by reference (`&$_expression`). This triggers a PHP "Only variables can be passed by reference" notice.

## Changes

- `core/api/jeeApi.php`: remove the `trim()` wrapper around `$value` before passing it to `setTags` (the function already trims its argument internally on line 1263)
- `core/class/plan3d.class.php`: store the result of `getConfiguration()` in a local variable before passing it to `setTags`
