### PR TITLE
Sync update notification message after each relevant action

### DIFF
--- a/core/ajax/update.ajax.php
+++ b/core/ajax/update.ajax.php
@@ -65,6 +65,7 @@ try {
 	if (init('action') == 'checkAllUpdate') {
 		unautorizedInDemo();
 		update::checkAllUpdate();
+		update::refreshUpdateMessage();
 		ajax::success();
 	}
 
@@ -81,6 +82,7 @@ try {
 			}
 			$update->doUpdate();
 			if ($update->getType() != 'core') {
+				update::refreshUpdateMessage();
 				log::add('update', 'alert', __("Launch cron dependancy plugins", __FILE__));
 				try {
 					$cron = cron::byClassAndFunction('plugin', 'checkDeamon');
@@ -124,6 +126,7 @@ try {
 			throw new Exception(__('Aucune correspondance pour l\'ID :', __FILE__) . ' ' . init('id'));
 		}
 		$update->checkUpdate();
+		update::refreshUpdateMessage();
 		ajax::success();
 	}
 

--- a/core/class/jeedom.class.php
+++ b/core/class/jeedom.class.php
@@ -1223,21 +1223,7 @@ class jeedom {
 			//Check for updates every 24h according to config
 			if (config::byKey('update::autocheck', 'core', 1) == 1 && (config::byKey('update::lastCheck') == '' || (strtotime('now') - strtotime(config::byKey('update::lastCheck'))) > (23 * 3600) || strtotime('now') < strtotime(config::byKey('update::lastCheck')))) {
 				update::checkAllUpdate();
-				$updates = update::byStatus('update');
-				if (count($updates) > 0) {
-					$toUpdate = '';
-					foreach ($updates as $update) {
-						if ($update->getConfiguration('doNotUpdate', 0) == 0) {
-							$toUpdate .= $update->getLogicalId() . ',';
-						}
-					}
-					if ($toUpdate != '') {
-						//set $_logicalId so update function can remove such messages. Bypassed by message::save to notify different updates instead of new occurence.
-						$msg = __('De nouvelles mises à jour sont disponibles', __FILE__) . ' : ' . trim($toUpdate, ',');
-						$action = '<a href="/index.php?v=d&p=update">' . __('Centre de mise à jour', __FILE__) . '</a>';
-						message::add('update', $msg, $action, 'newUpdate');
-					}
-				}
+				update::refreshUpdateMessage();
 			}
 		} catch (\Throwable $e) {
 			log::add('jeedom', 'error', log::exception($e));

--- a/core/class/update.class.php
+++ b/core/class/update.class.php
@@ -143,6 +143,28 @@ class update {
 		}
 	}
 
+	public static function refreshUpdateMessage() {
+		$updates = self::byStatus('update');
+		$toUpdate = [];
+		foreach ($updates as $update) {
+			if ($update->getConfiguration('doNotUpdate', 0) == 0) {
+				$toUpdate[] = $update->getLogicalId();
+			}
+		}
+		if (!empty($toUpdate)) {
+			$msg = __('De nouvelles mises à jour sont disponibles', __FILE__) . ' : ' . implode(', ', $toUpdate);
+			$action = '<a href="/index.php?v=d&p=update">' . __('Centre de mise à jour', __FILE__) . '</a>';
+			foreach (message::byPlugin(__CLASS__) as $updateMessage) {
+				if ($updateMessage->getMessage() !== $msg) {
+					$updateMessage->remove();
+				}
+			}
+			message::add(__CLASS__, $msg, $action, 'newUpdate');
+		} else {
+			message::removeAll(__CLASS__);
+		}
+	}
+
 	public static function byId($_id) {
 		$values = array(
 			'id' => $_id,

--- a/core/class/update.class.php
+++ b/core/class/update.class.php
@@ -144,9 +144,8 @@ class update {
 	}
 
 	public static function refreshUpdateMessage() {
-		$updates = self::byStatus('update');
 		$toUpdate = [];
-		foreach ($updates as $update) {
+		foreach (self::byStatus('update') as $update) {
 			if ($update->getConfiguration('doNotUpdate', 0) == 0) {
 				$toUpdate[] = $update->getLogicalId();
 			}

--- a/install/update.php
+++ b/install/update.php
@@ -348,9 +348,9 @@ try {
 	}
 	echo "[PROGRESS][90]\n";
 	try {
-		message::removeAll('update', 'newUpdate');
 		echo "Check update\n";
 		update::checkAllUpdate();
+		update::refreshUpdateMessage();
 		echo "OK\n";
 	} catch (Exception $ex) {
 		echo "***ERROR*** " . $ex->getMessage() . "\n";


### PR DESCRIPTION
## Summary

- Fix `message::removeAll('update', 'newUpdate')` in `install/update.php` that never deleted anything: `message::save()` randomizes the logicalId when it equals `'newUpdate'`, so no message ever had that logicalId in the database.
- Add `update::refreshUpdateMessage()` as a central method to manage the update notification message lifecycle: removes stale messages when the pending list changes, leverages `message::save()` native dedup to avoid spurious toasts when the list is unchanged, and cleans up entirely when no updates are pending.
- Call `refreshUpdateMessage()` after every operation that can change update statuses: `jeedom::cronHourly()` and the `update`, `checkUpdate`, `checkAllUpdate` actions in `update.ajax.php`.
