### PR TITLE
Scope clearToasts to the dialog being closed

### DIFF
--- a/core/dom/dom.ui.js
+++ b/core/dom/dom.ui.js
@@ -811,8 +811,12 @@ var jeeDialog = (function() {
     })
     return toast
   }
-  exports.clearToasts = function() {
-    document.querySelectorAll('.jeeToastContainer')?.remove()
+  exports.clearToasts = function(_scope) {
+    document.querySelectorAll('.jeeToastContainer').forEach(function(_container) {
+      if (!_scope || _scope.contains(_container)) {
+        _container.remove()
+      }
+    })
     return true
   }
 
@@ -1604,7 +1608,7 @@ var jeeDialog = (function() {
         close: function() {
           this.dialog._jeeDialog.options.beforeClose()
           this.dialog.querySelector('div.jeeDialogContent').empty()
-          jeeDialog.clearToasts()
+          jeeDialog.clearToasts(this.dialog)
           this.dialog.unseen()
           this.dialog._jeeDialog.options.onClose()
           this.dialog.removeClass('active')
@@ -1804,7 +1808,7 @@ var jeeCtxMenu = function(_options) {
       display: null
     })
     _ctxMenu.seen()
-    
+
     //Is there use positionning:
     if (ctxInstance.options.position) {
       ctxInstance.options.position.apply(ctxInstance, [ctxInstance, _event.clientX, _event.clientY])


### PR DESCRIPTION
## Problem

`jeeDialog`'s `close()` unconditionally calls `clearToasts()`, which removes every toast currently displayed on the page, not just the ones related to the dialog being closed. Since there is a single shared toast container reused across the whole page, any toast shown right before closing a dialog (a common pattern: perform an action, then close the dialog) gets wiped out immediately.

Plugins have been working around this by manually closing the dialog before showing the success toast instead of the more natural order (see [calendar/event.edit.js](https://github.com/jeedom/plugin-calendar/blob/beta/desktop/js/event.edit.js) or [ocpp/authorisations.js](https://github.com/jeedom/plugin-ocpp/blob/beta/desktop/js/authorisations.js) as examples).

## Fix

`clearToasts()` now accepts an optional scope element. When provided, it only removes the toast container if it is currently a descendant of that scope, leaving toasts attached elsewhere (typically `document.body`) untouched. The main dialog's `close()` now passes itself as the scope, so it only cleans up toasts explicitly attached to it via `attachTo`.

All other existing call sites (page navigation, notification center, legacy jQuery shim) keep clearing every toast since they call `clearToasts()` without a scope, so their behavior is unchanged.