### PR TITLE
Centralize eqLogic remove confirmation and post-delete redirect

### DIFF
--- a/core/js/eqLogic.class.js
+++ b/core/js/eqLogic.class.js
@@ -34,7 +34,7 @@ if (!isset(jeedom.eqLogic.cache.byId)) {
   jeedom.eqLogic.cache.byId = Array()
 }
 
-if(!isset(jeedom.eqLogic.cache.byLogical)){
+if (!isset(jeedom.eqLogic.cache.byLogical)) {
   jeedom.eqLogic.cache.byLogical = Array()
 
 }
@@ -270,7 +270,7 @@ jeedom.eqLogic.toHtml = function(_params) {
     action: 'toHtml',
     id: _params.id,
     version: _params.version,
-    global : _params.global || false
+    global: _params.global || false
   }
   domUtils.ajax(paramsAJAX)
 }
@@ -299,7 +299,7 @@ jeedom.eqLogic.getCmd = function(_params) {
   paramsAJAX.data = {
     action: 'byEqLogic',
     eqLogic_id: _params.id,
-    ...(_params.typeCmd ? { typeCmd: _params.typeCmd } : {}) 
+    ...(_params.typeCmd ? { typeCmd: _params.typeCmd } : {})
   }
   domUtils.ajax(paramsAJAX)
 }
@@ -333,22 +333,22 @@ jeedom.eqLogic.byId = function(_params) {
 }
 
 jeedom.eqLogic.removeImage = function(_params) {
-  const paramsRequired = ['id'];
-  const paramsSpecifics = {};
+  const paramsRequired = ['id']
+  const paramsSpecifics = {}
   try {
-    jeedom.private.checkParamsRequired(_params || {}, paramsRequired);
+    jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
-    (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e);
-    return;
+    (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
+    return
   }
-  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {});
-  const paramsAJAX = jeedom.private.getParamsAJAX(params);
-  paramsAJAX.url = 'core/ajax/eqLogic.ajax.php';
+  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+  const paramsAJAX = jeedom.private.getParamsAJAX(params)
+  paramsAJAX.url = 'core/ajax/eqLogic.ajax.php'
   paramsAJAX.data = {
     action: 'removeImage',
     id: _params.id
-  };
-  domUtils.ajax(paramsAJAX);
+  }
+  domUtils.ajax(paramsAJAX)
 }
 
 jeedom.eqLogic.byLogical = function(_params) {
@@ -425,7 +425,7 @@ jeedom.eqLogic.getSelectModal = function(_options, callback) {
             args.human = mod_insertEqLogic.getValue()
             args.id = mod_insertEqLogic.getId()
             if (args.human.trim() != '') {
-                callback(args)
+              callback(args)
             }
             document.getElementById('mod_insertEqLogicValue')._jeeDialog.destroy()
           }
@@ -512,7 +512,7 @@ jeedom.eqLogic.refreshValue = function(_params) {
               jeedomUtils.positionEqLogic(result[i].id)
               const packer = Packery.data(object_div)
               if (packer != undefined) packer.destroy()
-              new Packery(object_div, {isLayoutInstant: true, transitionDuration: 0})
+              new Packery(object_div, { isLayoutInstant: true, transitionDuration: 0 })
 
               document.querySelectorAll('div.eqLogic-widget').forEach(function(element, idx) {
                 element.setAttribute('data-order', idx + 1)
@@ -548,7 +548,7 @@ jeedom.eqLogic.refreshValue = function(_params) {
                           jeeFrontEnd.plan.cssStyleString = ''
                         }
                       }
-                      break;
+                      break
                     }
                   }
                 } catch (e) { console.error(e) }
@@ -592,7 +592,7 @@ jeedom.eqLogic.refreshValue = function(_params) {
           eqLogic.triggerEvent('create')
           jeedomUtils.setTileSize('.eqLogic')
         } else if (typeof jeedomUI !== 'undefined' && typeof jeeFrontEnd?.dashboard?.editWidgetMode == 'function' && document.getElementById('bt_editDashboardWidgetOrder') != null) {
-          jeeFrontEnd.dashboard.editWidgetMode(jeedomUI?.isEditing,false)
+          jeeFrontEnd.dashboard.editWidgetMode(jeedomUI?.isEditing, false)
         }
       }
     }

--- a/core/js/eqLogic.class.js
+++ b/core/js/eqLogic.class.js
@@ -173,29 +173,67 @@ jeedom.eqLogic.usedBy = function(_params) {
 
 jeedom.eqLogic.remove = function(_params) {
   const paramsRequired = ['id', 'type']
-  const paramsSpecifics = {
-    pre_success: function(data) {
-      if (isset(jeedom.eqLogic.cache.byId[_params.id])) {
-        delete jeedom.eqLogic.cache.byId[_params.id]
-      }
-      return data
-    }
-  }
   try {
     jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
   } catch (e) {
-    (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
+    (_params.error || jeedom.private.default_params.error)(e)
     return
   }
-  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  const paramsAJAX = jeedom.private.getParamsAJAX(params)
-  paramsAJAX.url = 'core/ajax/eqLogic.ajax.php'
-  paramsAJAX.data = {
-    action: 'remove',
-    type: _params.type,
-    id: _params.id
-  }
-  domUtils.ajax(paramsAJAX)
+  jeedom.eqLogic.getUseBeforeRemove({
+    id: _params.id,
+    error: function(error) {
+      jeedomUtils.showAlert({ message: error.message, level: 'danger' })
+    },
+    success: function(data) {
+      let text = "{{Êtes-vous sûr de vouloir supprimer l'équipement}} " + _params.type
+      if (_params.name) {
+        text += ' <b>' + _params.name + '</b>'
+      }
+      text += ' ?'
+      if (Object.keys(data).length > 0) {
+        text += ' </br> {{Il est utilisé par:}}</br>'
+        let complement = null
+        for (const i in data) {
+          complement = ('sourceName' in data[i]) ? ' (' + data[i].sourceName + ')' : ''
+          text += '- <a href="' + data[i].url + '" target="_blank">' + data[i].type + '</a> : <b>' + data[i].name + '</b>' + complement + ' <sup><a href="' + data[i].url + '" target="_blank"><i class="fas fa-external-link-alt"></i></a></sup></br>'
+        }
+      }
+      jeeDialog.confirm(text, function(result) {
+        if (!result) return
+
+        // Fires only once the actual removal succeeds server-side:
+        const paramsSpecifics = {
+          pre_success: function(data) {
+            if (isset(jeedom.eqLogic.cache.byId[_params.id])) {
+              delete jeedom.eqLogic.cache.byId[_params.id]
+            }
+            return data
+          },
+          success: function() {
+            jeeFrontEnd.modifyWithoutSave = false
+            modifyWithoutSave = false
+            const vars = getUrlVars()
+            let url = 'index.php?'
+            for (const i in vars) {
+              if (i != 'id' && i != 'removeSuccessFull' && i != 'saveSuccessFull') {
+                url += i + '=' + vars[i].replace('#', '') + '&'
+              }
+            }
+            jeedomUtils.loadPage(url + 'removeSuccessFull=1')
+          }
+        }
+        const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
+        const paramsAJAX = jeedom.private.getParamsAJAX(params)
+        paramsAJAX.url = 'core/ajax/eqLogic.ajax.php'
+        paramsAJAX.data = {
+          action: 'remove',
+          type: _params.type,
+          id: _params.id
+        }
+        domUtils.ajax(paramsAJAX)
+      })
+    }
+  })
 }
 
 jeedom.eqLogic.copy = function(_params) {

--- a/core/js/plugin.template.js
+++ b/core/js/plugin.template.js
@@ -98,8 +98,8 @@ if (!jeeFrontEnd.pluginTemplate) {
           if (isset(data) && isset(data.timeout) && data.timeout == 0) {
             data.timeout = ''
           }
-          if(document.getElementById('img_device') != null && document.querySelector('.eqLogicDisplayCard.active img').getAttribute('src') != ''){
-            document.getElementById('img_device').setAttribute("src",document.querySelector('.eqLogicDisplayCard.active img').getAttribute('src'));
+          if (document.getElementById('img_device') != null && document.querySelector('.eqLogicDisplayCard.active img').getAttribute('src') != '') {
+            document.getElementById('img_device').setAttribute("src", document.querySelector('.eqLogicDisplayCard.active img').getAttribute('src'))
           }
           document.getElementById('div_mainContainer').setJeeValues(data, '.eqLogicAttr')
           if (!isset(data.category.opening)) try { document.querySelector('input[data-l2key="opening"]').checked = false } catch (e) { }
@@ -398,62 +398,21 @@ if (!jeeFrontEnd.pluginTemplate) {
     removeEqLogic: function() {
       const eqLogicId = document.querySelector('.eqLogicAttr[data-l1key="id"]').jeeValue()
       if (eqLogicId != undefined) {
-        const thisEqType = document.querySelector('.eqLogicDisplayCard[data-eqlogic_id="' + eqLogicId + '"]')?.getAttribute('data-eqLogic_type')
-        const textEqtype = thisEqType || eqType
-        jeedom.eqLogic.getUseBeforeRemove({
+        const thisEqType = document.querySelector('.eqLogicDisplayCard[data-eqlogic_id="' + eqLogicId + '"]')?.getAttribute('data-eqLogic_type') || eqType
+        jeedom.eqLogic.remove({
           id: eqLogicId,
+          type: thisEqType,
+          name: document.querySelector('.eqLogicAttr[data-l1key="name"]').jeeValue(),
           error: function(error) {
             jeedomUtils.showAlert({
               message: error.message,
               level: 'danger'
             })
-          },
-          success: function(data) {
-            let text = '{{Êtes-vous sûr de vouloir supprimer l\'équipement}} ' + textEqtype + ' <b>' + document.querySelector('.eqLogicAttr[data-l1key="name"]').jeeValue() + '</b> ?'
-            if (Object.keys(data).length > 0) {
-              text += ' </br> {{Il est utilisé par:}}</br>'
-              let complement = null
-              for (const i in data) {
-                complement = ''
-                if ('sourceName' in data[i]) {
-                  complement = ' (' + data[i].sourceName + ')'
-                }
-                text += '- ' + '<a href="' + data[i].url + '" target="_blank">' + data[i].type + '</a> : <b>' + data[i].name + '</b>' + complement + ' <sup><a href="' + data[i].url + '" target="_blank"><i class="fas fa-external-link-alt"></i></a></sup></br>'
-              }
-            }
-            text = text.substring(0, text.length - 2)
-            jeeDialog.confirm(text, function(result) {
-              if (result) {
-                jeedom.eqLogic.remove({
-                  type: thisEqType || eqType,
-                  id: eqLogicId,
-                  error: function(error) {
-                    jeedomUtils.showAlert({
-                      message: error.message,
-                      level: 'danger'
-                    })
-                  },
-                  success: function() {
-                    const vars = getUrlVars()
-                    let url = 'index.php?'
-                    for (const i in vars) {
-                      if (i != 'id' && i != 'removeSuccessFull' && i != 'saveSuccessFull') {
-                        url += i + '=' + vars[i].replace('#', '') + '&'
-                      }
-                    }
-                    jeeFrontEnd.modifyWithoutSave = false
-                    modifyWithoutSave = false
-                    url += 'removeSuccessFull=1'
-                    jeedomUtils.loadPage(url)
-                  }
-                })
-              }
-            })
           }
         })
       } else {
         jeedomUtils.showAlert({
-          message: '{{Veuillez d\'abord sélectionner un}} ' + textEqtype,
+          message: '{{Veuillez d\'abord sélectionner un}} ' + eqType,
           level: 'danger'
         })
       }

--- a/desktop/modal/eqLogic.configure.php
+++ b/desktop/modal/eqLogic.configure.php
@@ -843,25 +843,15 @@ sendVarToJS([
       jeeFrontEnd.md_eqLogicConfigure.eqlogicSave(event)
     })
     document.getElementById('bt_eqLogicConfigureRemove')?.addEventListener('click', function(event) {
-      jeeDialog.confirm('{{Êtes-vous sûr de vouloir supprimer cet équipement ?}}', function(result) {
-        if (result) {
-          jeedom.eqLogic.remove({
-            id: jeephp2js.md_eqLogicConfigure_Info.id,
-            type: jeephp2js.md_eqLogicConfigure_Info.eqType_name,
-            error: function(error) {
-              jeedomUtils.showAlert({
-                attachTo: jeeDialog.get('#md_eqLogicConfigure', 'dialog'),
-                message: error.message,
-                level: 'danger'
-              })
-            },
-            success: function(data) {
-              jeedomUtils.showAlert({
-                attachTo: jeeDialog.get('#md_eqLogicConfigure', 'dialog'),
-                message: '{{Equipement supprimé avec succès}}',
-                level: 'success'
-              })
-            }
+      jeedom.eqLogic.remove({
+        id: jeephp2js.md_eqLogicConfigure_Info.id,
+        type: jeephp2js.md_eqLogicConfigure_Info.eqType_name,
+        name: jeephp2js.md_eqLogicConfigure_Info.name,
+        error: function(error) {
+          jeedomUtils.showAlert({
+            attachTo: jeeDialog.get('#md_eqLogicConfigure', 'dialog'),
+            message: error.message,
+            level: 'danger'
           })
         }
       })

--- a/desktop/modal/eqLogic.configure.php
+++ b/desktop/modal/eqLogic.configure.php
@@ -56,17 +56,17 @@ sendVarToJS([
     <div class="tab-content" id="div_displayEqLogicConfigure">
       <div role="tabpanel" class="tab-pane active" id="eqLogic_information">
         <form class="form-horizontal">
-          
-		  <div class="row">
-        	<div class="col-sm-6">
-        	  <legend><i class="fas fa-clipboard-list"></i> {{Général}}</legend>
+
+          <div class="row">
+            <div class="col-sm-6">
+              <legend><i class="fas fa-clipboard-list"></i> {{Général}}</legend>
               <div class="form-group">
                 <label class="col-sm-4 control-label">{{Nom}}</label>
                 <div class="col-sm-8">
                   <input type="text" class="eqLogicAttr form-control input-sm" data-l1key="name">
                 </div>
-            </div>
-             <div class="form-group">
+              </div>
+              <div class="form-group">
                 <label class="col-sm-4 control-label">{{ID unique}}</label>
                 <div class="col-sm-8">
                   <span class="eqLogicAttr label label-sm label-primary" data-l1key="id"></span>
@@ -87,8 +87,8 @@ sendVarToJS([
                   }
                   ?>
                 </div>
-             </div>
-             <div class="form-group">
+              </div>
+              <div class="form-group">
                 <label class="col-sm-4 control-label">{{ID logique}}</label>
                 <div class="col-sm-8">
                   <span class="eqLogicAttr label label-sm label-primary" data-l1key="logicalId"></span>
@@ -102,8 +102,8 @@ sendVarToJS([
                   <span class="eqLogicAttr label label-sm label-info" data-l1key="configuration" data-l2key="createtime"></span> -
                   <span class="eqLogicAttr label label-sm label-info" data-l1key="configuration" data-l2key="updatetime"></span>
                 </div>
-             </div>
-             <div class="form-group">
+              </div>
+              <div class="form-group">
                 <label class="col-sm-4 control-label">{{Tentative échouée}}</label>
                 <div class="col-sm-8">
                   <span class="label label-sm label-primary"><?php echo $eqLogic->getStatus('numberTryWithoutSuccess', 0) ?></span>
@@ -115,8 +115,8 @@ sendVarToJS([
                 <div class="col-sm-8">
                   <span class="label label-sm label-info"><?php echo $eqLogic->getStatus('lastCommunication') ?></span>
                 </div>
-            </div>
-             <div class="form-group">
+              </div>
+              <div class="form-group">
                 <label class="col-sm-4 control-label">{{Tag(s)}}</label>
                 <div class="col-sm-8">
                   <input class="eqLogicAttr form-control input-sm" data-l1key="tags">
@@ -131,22 +131,22 @@ sendVarToJS([
               </div>
             </div>
             <div class="col-sm-6">
-                    <legend>{{Image}}</legend>
-                    <div class="form-group">
-                    	<div class="col-sm-7 col-sm-offset-3">
-                    		<span class="btn btn-default btn-file">
-                    			<i class="fas fa-cloud-upload-alt"></i> {{Envoyer}}<input id="bt_uploadImageEqLogic" type="file" name="file" accept="image/*">
-                    		</span>
-                    		<a class="btn btn-danger" id="bt_removeEqLogicImage"><i class="fas fa-trash"></i> {{Enlever l'image}}</a>
-                   		</div>
-					</div>
-					<div class="form-group">
-						<div class="col-sm-7 col-sm-offset-3 eqLogicImg">
-							<img class="img-responsive" src="<?php echo $eqLogic->getImage(); ?>" width="240px" style="min-height : 50px" />
-                        </div>
-					</div>
-                    
-            </div>	        
+              <legend>{{Image}}</legend>
+              <div class="form-group">
+                <div class="col-sm-7 col-sm-offset-3">
+                  <span class="btn btn-default btn-file">
+                    <i class="fas fa-cloud-upload-alt"></i> {{Envoyer}}<input id="bt_uploadImageEqLogic" type="file" name="file" accept="image/*">
+                  </span>
+                  <a class="btn btn-danger" id="bt_removeEqLogicImage"><i class="fas fa-trash"></i> {{Enlever l'image}}</a>
+                </div>
+              </div>
+              <div class="form-group">
+                <div class="col-sm-7 col-sm-offset-3 eqLogicImg">
+                  <img class="img-responsive" src="<?php echo $eqLogic->getImage(); ?>" width="240px" style="min-height : 50px" />
+                </div>
+              </div>
+
+            </div>
           </div>
           <legend><i class="fas fa-list-alt"></i> {{Commandes}}</legend>
           <table class="table table-condensed">
@@ -503,48 +503,48 @@ sendVarToJS([
 
       <div role="tabpanel" class="tab-pane" id="eqLogic_specialAttributesPlugin">
         <form class="form-horizontal">
-        <br/>
+          <br />
           <div class="alert alert-info">{{Vous pouvez trouver ici toute informations complementaires demandées par un plugin sur les équipements Jeedom}}</div>
           <?php
-            try {
-              $plugins = plugin::listPlugin(true);
-              foreach ($plugins as $plugin) {
-                $specialAttributes = $plugin->getSpecialAttributes();
-                if (!isset($specialAttributes['eqLogic']) || !is_array($specialAttributes['eqLogic']) || count($specialAttributes['eqLogic']) == 0) {
-                  continue;
-                }
-                $spAttr = '<legend><i class="fas fa-users-cog"></i> {{Informations complémentaires demandées par}} ' . $plugin->getName() . '</legend>';
-                foreach ($specialAttributes['eqLogic'] as $key => $config) {
-                  $spAttr .= '<div class="form-group">';
-                  $spAttr .= '<label class="col-sm-3 control-label">' . $config['name'][translate::getLanguage()] . '</label>';
-                  $spAttr .= '<div class="col-sm-7">';
-                  switch ($config['type']) {
-                    case 'input':
-                      $spAttr .= '<input class="form-control eqLogicAttr" data-l1key="configuration" data-l2key="plugin::' . $plugin->getId() . '::' . $key . '"/>';
-                      break;
-                    case 'checkbox':
-                        $spAttr .= '<input type="checkbox" class="form-control eqLogicAttr" data-l1key="configuration" data-l2key="plugin::' . $plugin->getId() . '::' . $key . '"/>';
-                        break;
-                    case 'number':
-                      $spAttr .= '<input type="number" class="form-control eqLogicAttr" data-l1key="configuration" data-l2key="plugin::' . $plugin->getId() . '::' . $key . '" min="' . (isset($config['min']) ? $config['min'] : '') . '" max="' . (isset($config['max']) ? $config['max'] : '') . '" />';
-                      break;
-                    case 'select':
-                      $spAttr .= '<select class="form-control eqLogicAttr" data-l1key="configuration" data-l2key="plugin::' . $plugin->getId() . '::' . $key . '">';
-                      foreach ($config['values'] as $value) {
-                        $spAttr .= '<option value="' . $value['value'] . '">' . $value['name'] . '</option>';
-                      }
-                      $spAttr .= '</select>';
-                      break;
-                  }
-                  $spAttr .= '</div>';
-                  $spAttr .= '</div>';
-                }
-                echo $spAttr;
+          try {
+            $plugins = plugin::listPlugin(true);
+            foreach ($plugins as $plugin) {
+              $specialAttributes = $plugin->getSpecialAttributes();
+              if (!isset($specialAttributes['eqLogic']) || !is_array($specialAttributes['eqLogic']) || count($specialAttributes['eqLogic']) == 0) {
+                continue;
               }
-            } catch (\Exception $e) {
+              $spAttr = '<legend><i class="fas fa-users-cog"></i> {{Informations complémentaires demandées par}} ' . $plugin->getName() . '</legend>';
+              foreach ($specialAttributes['eqLogic'] as $key => $config) {
+                $spAttr .= '<div class="form-group">';
+                $spAttr .= '<label class="col-sm-3 control-label">' . $config['name'][translate::getLanguage()] . '</label>';
+                $spAttr .= '<div class="col-sm-7">';
+                switch ($config['type']) {
+                  case 'input':
+                    $spAttr .= '<input class="form-control eqLogicAttr" data-l1key="configuration" data-l2key="plugin::' . $plugin->getId() . '::' . $key . '"/>';
+                    break;
+                  case 'checkbox':
+                    $spAttr .= '<input type="checkbox" class="form-control eqLogicAttr" data-l1key="configuration" data-l2key="plugin::' . $plugin->getId() . '::' . $key . '"/>';
+                    break;
+                  case 'number':
+                    $spAttr .= '<input type="number" class="form-control eqLogicAttr" data-l1key="configuration" data-l2key="plugin::' . $plugin->getId() . '::' . $key . '" min="' . (isset($config['min']) ? $config['min'] : '') . '" max="' . (isset($config['max']) ? $config['max'] : '') . '" />';
+                    break;
+                  case 'select':
+                    $spAttr .= '<select class="form-control eqLogicAttr" data-l1key="configuration" data-l2key="plugin::' . $plugin->getId() . '::' . $key . '">';
+                    foreach ($config['values'] as $value) {
+                      $spAttr .= '<option value="' . $value['value'] . '">' . $value['name'] . '</option>';
+                    }
+                    $spAttr .= '</select>';
+                    break;
+                }
+                $spAttr .= '</div>';
+                $spAttr .= '</div>';
+              }
+              echo $spAttr;
             }
-            ?>
-          </form>
+          } catch (\Exception $e) {
+          }
+          ?>
+        </form>
       </div>
 
 
@@ -580,10 +580,10 @@ sendVarToJS([
         document.querySelectorAll('#md_eqLogicConfigure .advanceWidgetParameterColorTransparent').forEach(_transparent => {
           _transparent?.triggerEvent('change')
         })
-          
-       try {
-        	jeeFrontEnd.md_eqLogicConfigure.bckUploader.destroy()
-       } catch (error) {}
+
+        try {
+          jeeFrontEnd.md_eqLogicConfigure.bckUploader.destroy()
+        } catch (error) {}
         jeeFrontEnd.md_eqLogicConfigure.bckUploader = new jeeFileUploader({
           fileInput: document.getElementById('bt_uploadImageEqLogic'),
           replaceFileInput: false,
@@ -594,19 +594,19 @@ sendVarToJS([
               jeedomUtils.showAlert({
                 message: data.result.result,
                 level: 'danger'
-                })
-                return
-              }
-              if (isset(data.result.result.filepath)) {
-                document.querySelector('#md_eqLogicConfigure .eqLogicImg').seen().querySelector('img').src = data.result.result.filepath
-              } else {
-              	document.querySelector('#md_eqLogicConfigure .eqLogicImg').unseen()
-              }
-              jeedomUtils.showAlert({
-                message: '{{Image ajoutée avec succès}}',
-                level: 'success'
-                })
-              }
+              })
+              return
+            }
+            if (isset(data.result.result.filepath)) {
+              document.querySelector('#md_eqLogicConfigure .eqLogicImg').seen().querySelector('img').src = data.result.result.filepath
+            } else {
+              document.querySelector('#md_eqLogicConfigure .eqLogicImg').unseen()
+            }
+            jeedomUtils.showAlert({
+              message: '{{Image ajoutée avec succès}}',
+              level: 'success'
+            })
+          }
         })
 
         //Dynamic values:
@@ -648,13 +648,13 @@ sendVarToJS([
         }
       },
       synchModalToEq: function() {
-        if(document.querySelector('#div_pageContainer input.eqLogicAttr[data-l1key="name"]')){
+        if (document.querySelector('#div_pageContainer input.eqLogicAttr[data-l1key="name"]')) {
           document.querySelector('#div_pageContainer input.eqLogicAttr[data-l1key="name"]').value = document.querySelector('#eqLogic_information input.eqLogicAttr[data-l1key="name"').value
         }
-        if(document.querySelector('#div_pageContainer input.eqLogicAttr[data-l1key="isEnable"]')){
+        if (document.querySelector('#div_pageContainer input.eqLogicAttr[data-l1key="isEnable"]')) {
           document.querySelector('#div_pageContainer input.eqLogicAttr[data-l1key="isEnable"]').checked = document.querySelector('#eqLogic_information input.eqLogicAttr[data-l1key="isEnable"').checked
         }
-        if(document.querySelector('#div_pageContainer input.eqLogicAttr[data-l1key="isVisible"]')){
+        if (document.querySelector('#div_pageContainer input.eqLogicAttr[data-l1key="isVisible"]')) {
           document.querySelector('#div_pageContainer input.eqLogicAttr[data-l1key="isVisible"]').checked = document.querySelector('#eqLogic_information input.eqLogicAttr[data-l1key="isVisible"').checked
         }
       },
@@ -880,10 +880,10 @@ sendVarToJS([
         })
         return
       }
-      
+
       if (_target = event.target.closest('#bt_removeEqLogicImage')) {
-         jeeDialog.confirm('{{Êtes-vous sûr de vouloir enlever l\'image cet équipement ?}}', function(result) {
-         if (result) {
+        jeeDialog.confirm('{{Êtes-vous sûr de vouloir enlever l\'image cet équipement ?}}', function(result) {
+          if (result) {
             jeedom.eqLogic.removeImage({
               id: jeephp2js.md_eqLogicConfigure_Info.id,
               error: function(error) {
@@ -908,7 +908,7 @@ sendVarToJS([
         })
         return
       }
-      
+
     })
 
     document.getElementById('eqLogic_information')?.addEventListener('dblclick', function(event) {
@@ -992,9 +992,9 @@ sendVarToJS([
       var _target = null
 
       if (_target = event.target.closest('.eqLogicAttr[data-l1key="configuration"][data-l2key="battery::disable"]')) {
-        if(document.querySelector('.eqLogicAttr[data-l1key="configuration"][data-l2key="battery::disable"]').jeeValue() == 1){
+        if (document.querySelector('.eqLogicAttr[data-l1key="configuration"][data-l2key="battery::disable"]').jeeValue() == 1) {
           document.querySelectorAll('.eqLogicHideNoBattery').unseen();
-        }else{
+        } else {
           document.querySelectorAll('.eqLogicHideNoBattery').seen();
         }
       }


### PR DESCRIPTION
## Problem

Deleting an equipment from `eqLogic.configure.php`'s configuration dialog left the dialog open afterwards, showing a stale form for an equipment that no longer existed. The underlying list (plugin equipment list, analysis view, or dashboard) never refreshed either, since nothing told those pages the equipment was gone.

Meanwhile, `plugin.template.js`'s `removeEqLogic()` already had the correct behavior (usage check, confirmation, redirect back to the list) but that logic lived only there, duplicated per caller and unavailable to the modal.

## Fix

`jeedom.eqLogic.remove()` now handles the usage check, confirmation dialog, and redirect to the current page internally, instead of each caller reimplementing it. `plugin.template.js`'s `removeEqLogic()` now delegates to it, which also fixes a pre-existing bug where it referenced an out-of-scope `textEqtype` variable in its own error path. `eqLogic.configure.php`'s delete button calls the same centralized function, so the dialog correctly closes and the underlying page refreshes on success.

## Breaking change

`jeedom.eqLogic.remove()` now shows its own confirmation dialog before deleting. Callers that already confirm before calling it (some plugins do, e.g. jMQTT and coolAutomation) will see a redundant second confirmation until they drop their own.
