### PR TITLE
Modernize Element.prototype.empty using replaceChildren

### DIFF
--- a/core/dom/dom.ui.js
+++ b/core/dom/dom.ui.js
@@ -93,9 +93,7 @@ NodeList.prototype.toggle = function() {
   return this
 }
 Element.prototype.empty = function() {
-  while (this.firstChild) {
-    this.removeChild(this.lastChild)
-  }
+  this.replaceChildren()
   return this
 }
 NodeList.prototype.empty = function() {
@@ -1804,7 +1802,7 @@ var jeeCtxMenu = function(_options) {
       display: null
     })
     _ctxMenu.seen()
-    
+
     //Is there use positionning:
     if (ctxInstance.options.position) {
       ctxInstance.options.position.apply(ctxInstance, [ctxInstance, _event.clientX, _event.clientY])


### PR DESCRIPTION
Replaces the manual `while (this.firstChild) { this.removeChild(this.lastChild) }` loop with the native `replaceChildren()` method.

This clears all children in a single DOM operation instead of one `removeChild` call per node, and is consistent with other modern DOM APIs already used in this file (`closest`, `Array.from`, optional chaining).