### PR TITLE
Avoid config pollution when a plugin lookup fails on a non-existent id

### DIFF
--- a/core/class/plugin.class.php
+++ b/core/class/plugin.class.php
@@ -179,7 +179,9 @@ class plugin {
 	}
 
 	public static function forceDisablePlugin($_id) {
-		config::save('active', 0, $_id);
+		if (config::byKey('active', $_id) == 1) {
+			config::save('active', 0, $_id);
+		}
 		$values = array(
 			'eqType_name' => $_id,
 		);

--- a/core/class/plugin.class.php
+++ b/core/class/plugin.class.php
@@ -179,7 +179,7 @@ class plugin {
 	}
 
 	public static function forceDisablePlugin($_id) {
-		if (config::byKey('active', $_id) == 1) {
+		if (config::byKey('active', $_id, 0) == 1) {
 			config::save('active', 0, $_id);
 		}
 		$values = array(


### PR DESCRIPTION
## Context

Reported on the [Jeedom community forum](https://community.jeedom.com/t/plugin-logmanager-fichier-logmanager-class-php-introuvable-jeedom-4-6-x/149955/25): `plugin::byId()` calls `forceDisablePlugin()` on every failed lookup, even when the id was never a real plugin (e.g. a caller using `byId()` combined with try/catch as an "is this plugin installed" check, which is a legitimate pattern). `forceDisablePlugin()` unconditionally wrote an `active=0` config row for that id, a write side effect in what amounts to a read/existence check.

## Fix

`plugin::forceDisablePlugin()` now only writes the `active=0` row when the id was already marked active. This removes the write side effect for ids that were never real plugins, while still disabling a plugin that was genuinely active and became unresolvable.
