### PR TITLE
Always place the cancel button before confirm in jeeDialog footers

### DIFF
--- a/core/dom/dom.ui.js
+++ b/core/dom/dom.ui.js
@@ -971,7 +971,11 @@ var jeeDialog = (function() {
         })
       }
     }
-    _footer.appendChild(button)
+    if (_button[0] === 'cancel') {
+      _footer.prepend(button)
+    } else {
+      _footer.appendChild(button)
+    }
     return button
   }
 
@@ -1804,7 +1808,7 @@ var jeeCtxMenu = function(_options) {
       display: null
     })
     _ctxMenu.seen()
-    
+
     //Is there use positionning:
     if (ctxInstance.options.position) {
       ctxInstance.options.position.apply(ctxInstance, [ctxInstance, _event.clientX, _event.clientY])


### PR DESCRIPTION
The position of the "Cancel" and "Confirm" buttons in jeeDialog footers used to depend on the key order declared in each caller's `buttons` object, which led to inconsistent positioning across the different menus, as reported here: https://community.jeedom.com/t/coherence-de-position-entre-annuler-et-valider-selon-les-menus/149873

The cancel button is now always prepended to the dialog footer instead of appended, so it is guaranteed to appear before the confirm button regardless of the order declared by the caller.