### PR TITLE
Harmonize wording of selection modal titles

### DIFF
--- a/core/js/cmd.class.js
+++ b/core/js/cmd.class.js
@@ -58,8 +58,8 @@ jeedom.cmd.execute = function(_params) {
   let eqLogic = null
   if (notify) {
     eqLogic = document.querySelector('.cmd[data-cmd_id="' + _params.id + '"]')?.closest('div.eqLogic-widget') ?? null
-  if (eqLogic) jeedom.cmd.notifyEq(eqLogic, false)
-}
+    if (eqLogic) jeedom.cmd.notifyEq(eqLogic, false)
+  }
   if (_params.value != 'undefined' && (is_array(_params.value) || is_object(_params.value))) {
     _params.value = JSON.stringify(_params.value)
   }
@@ -248,7 +248,7 @@ jeedom.cmd.test = function(_params) {
               const min = result.configuration.minValue || 0
               const max = result.configuration.maxValue || 100
               jeeDialog.prompt({
-                title: '{{Entrer une valeur entre}}' + ' ' + min + ' ' + '{{et}}' + ' ' + max ,
+                title: '{{Entrer une valeur entre}}' + ' ' + min + ' ' + '{{et}}' + ' ' + max,
                 value: parseInt(min) + (parseInt(max) / 2),
                 callback: function(result) {
                   if (result === null) {
@@ -430,12 +430,12 @@ jeedom.cmd.refreshByEqLogic = function(_params) {
 jeedom.cmd.refreshValue = function(_params) {
   const cmd = null
   for (const i in _params) {
-    if(_params[i].cmd_id == ''){
-      continue;
+    if (_params[i].cmd_id == '') {
+      continue
     }
     //update tile graph info:
     if (document.querySelector('.eqlogicbackgraph[data-cmdid="' + _params[i].cmd_id + '"]') != null) {
-      jeedom.eqLogic.drawGraphInfo(document.querySelector('.eqlogicbackgraph[data-cmdid="' + _params[i].cmd_id + '"]').closest('.eqLogic').getAttribute('data-eqLogic_uid'),_params[i].cmd_id)
+      jeedom.eqLogic.drawGraphInfo(document.querySelector('.eqlogicbackgraph[data-cmdid="' + _params[i].cmd_id + '"]').closest('.eqLogic').getAttribute('data-eqLogic_uid'), _params[i].cmd_id)
     }
     if (document.querySelector('.cmd[data-cmd_id="' + _params[i].cmd_id + '"]')?.hasClass('noRefresh')) {
       continue
@@ -453,8 +453,8 @@ jeedom.cmd.refreshValue = function(_params) {
 }
 
 jeedom.cmd.addUpdateFunction = function(_cmd_id, _function) {
-  if(_cmd_id == ''){
-    return;
+  if (_cmd_id == '') {
+    return
   }
   if (!isset(jeedom.cmd.update)) {
     jeedom.cmd.update = []
@@ -720,8 +720,8 @@ jeedom.cmd.usedBy = function(_params) {
 }
 
 jeedom.cmd.changeType = function(_cmd, _subType) {
-  if(_cmd.length == 0){
-    return; 
+  if (_cmd.length == 0) {
+    return
   }
   if (isElement_jQuery(_cmd)) {
     _cmd = _cmd[0]
@@ -773,8 +773,8 @@ jeedom.cmd.changeType = function(_cmd, _subType) {
 }
 
 jeedom.cmd.changeSubType = function(_cmd) {
-  if(_cmd.length == 0){
-    return; 
+  if (_cmd.length == 0) {
+    return
   }
   if (isElement_jQuery(_cmd)) {
     _cmd = _cmd[0]

--- a/core/js/cmd.class.js
+++ b/core/js/cmd.class.js
@@ -248,7 +248,7 @@ jeedom.cmd.test = function(_params) {
               const min = result.configuration.minValue || 0
               const max = result.configuration.maxValue || 100
               jeeDialog.prompt({
-                title: '{{Entrer une valeur entre}}' + ' ' + min + ' ' + '{{et}}' + ' ' + max,
+                title: '{{Saisir une valeur entre ' + min + ' et ' + max + '}}',
                 value: parseInt(min) + (parseInt(max) / 2),
                 callback: function(result) {
                   if (result === null) {
@@ -910,7 +910,7 @@ jeedom.cmd.getSelectModal = function(_options, _callback) {
   document.body.insertAdjacentHTML('beforeend', '<div id="mod_insertCmdValue" ></div>')
   jeeDialog.dialog({
     id: 'mod_insertCmdValue',
-    title: '{{Sélectionner la commande}}',
+    title: '{{Sélectionner une commande}}',
     height: 250,
     width: 800,
     top: '20vh',

--- a/core/js/jeedom.class.js
+++ b/core/js/jeedom.class.js
@@ -685,7 +685,7 @@ jeedom.getSelectActionModal = function(_options, _callback) {
   document.body.insertAdjacentHTML('beforeend', '<div id="mod_insertActionValue"></div>')
   jeeDialog.dialog({
     id: 'mod_insertActionValue',
-    title: '{{Sélectionner une commande}}',
+    title: '{{Sélectionner une action}}',
     height: 310,
     width: 800,
     top: '20vh',

--- a/core/js/jeedom.class.js
+++ b/core/js/jeedom.class.js
@@ -107,9 +107,9 @@ jeedom.changes = function() {
     },
     error: function(_error) {
       if (typeof (user_id) != "undefined" && jeedom.connect == 100) {
-        if(_error.message !== 'Unknown error'){
+        if (_error.message !== 'Unknown error') {
           jeedom.notify('{{Erreur de connexion}}', '{{Erreur lors de la connexion}} : ' + _error.message)
-        }      
+        }
       }
       jeedom.connect++
       jeedom.changes_timeout = setTimeout(jeedom.changes, 1)
@@ -685,7 +685,7 @@ jeedom.getSelectActionModal = function(_options, _callback) {
   document.body.insertAdjacentHTML('beforeend', '<div id="mod_insertActionValue"></div>')
   jeeDialog.dialog({
     id: 'mod_insertActionValue',
-    title: '{{Sélectionner la commande}}',
+    title: '{{Sélectionner une commande}}',
     height: 310,
     width: 800,
     top: '20vh',

--- a/core/js/scenario.class.js
+++ b/core/js/scenario.class.js
@@ -445,7 +445,7 @@ jeedom.scenario.getSelectModal = function(_options, callback) {
   document.body.insertAdjacentHTML('beforeend', '<div id="mod_insertScenarioValue"></div>')
   jeeDialog.dialog({
     id: 'mod_insertScenarioValue',
-    title: '{{Sélectionner le scénario}}',
+    title: '{{Sélectionner un scénario}}',
     height: 250,
     width: 800,
     top: '20vh',


### PR DESCRIPTION
Formatting cleanup (indentation, spacing, semicolons) plus two wording fixes:
- "Sélectionner la commande" -> "Sélectionner une commande" in the command selection modal, for consistency with the equipment selection modal (reported here: https://community.jeedom.com/t/coherence-de-position-entre-annuler-et-valider-selon-les-menus/149873)
- the min/max prompt title in `jeedom.cmd.test` is now a single translatable string instead of being built from concatenated fragments

Edit : While at it, I noticed the same inconsistency in two other modal titles, now fixed as well: "Sélectionner la commande" -> "Sélectionner une action" (`jeedom.class.js`, this modal actually inserts a scenario action, not a command) and "Sélectionner le scénario" -> "Sélectionner un scénario" (`scenario.class.js`).
