### PR TITLE
Harmonize buttons and icons on the update page

### DIFF
--- a/desktop/css/desktop.main.css
+++ b/desktop/css/desktop.main.css
@@ -5021,7 +5021,7 @@ div.eqLogic-widget.editingMode .panelLink {
     }
     table.ui-table-reflow.table-condensed tbody tr {
       display: table;
-      flex: 0 1 150px;
+      flex: 150px;
       margin: 2px;
       margin-bottom: 22px !important;
     }

--- a/desktop/js/update.js
+++ b/desktop/js/update.js
@@ -97,7 +97,7 @@ if (!jeeFrontEnd.update) {
                   clearTimeout(jeeP.alertTimeout)
                 }
                 jeedomUtils.showAlert({
-                  message: '{{L\'opération a échoué. Veuillez aller sur l\'onglet informations et consulter la log pour savoir pourquoi.}}',
+                  message: "{{L'opération a échoué. Veuillez aller sur l'onglet informations et consulter la log pour plus de détails.}}",
                   level: 'danger'
                 })
                 _autoUpdate = 0
@@ -183,7 +183,7 @@ if (!jeeFrontEnd.update) {
         },
         success: function(data) {
           let span = document.getElementById('span_lastUpdateCheck')
-          span.title = '{{Dernière verification des mises à jour}}'
+          span.title = '{{Dernière vérification des mises à jour}}'
           span.jeeValue(data['update::lastCheck'])
         }
       })
@@ -257,51 +257,44 @@ if (!jeeFrontEnd.update) {
       tr += '<td style="width:160px;" data-order="' + Date.parse(_update.updateDate) + '"><span class="label label-primary" data-l1key="updateDate">' + _update.updateDate + '</span></td>'
       tr += '<td>'
       if (_update.type != 'core') {
-        tr += '<i class="fas fa-pencil-ruler" title="{{Ne pas mettre à jour}}"></i> <input id="' + _update.name + '" type="checkbox" class="updateAttr checkContext warning" data-l1key="configuration" data-l2key="doNotUpdate" title="{{Sauvegarder pour conserver les modifications}}">'
-        tr += '<label class="cursor fontweightnormal hidden-1280" for="' + _update.name + '"></label>'
+        tr += '<label title="{{Ne pas mettre à jour ce plugin (sauvegarder pour enregistrer)}}" for="' + _update.name + '">'
+        tr += '<i class="fas fa-lock cursor"></i> <input id="' + _update.name + '" type="checkbox" class="updateAttr checkContext warning" data-l1key="configuration" data-l2key="doNotUpdate">'
+        tr += '</label>'
       }
       tr += '</td>'
-      tr += '<td>'
+      tr += '<td class="input-group">'
       if (_update.type != 'core') {
-        if (_update.configuration && _update.configuration.version == 'beta') {
-          if (isset(_update.plugin) && isset(_update.plugin.changelog_beta) && _update.plugin.changelog_beta != '') {
-            tr += '<a class="btn btn-xs cursor" target="_blank" href="' + _update.plugin.changelog_beta + '"><i class="fas fa-book"></i><span class="hidden-1280"> {{Changelog}}</span></a> '
-          } else if (isset(_update.plugin) && isset(_update.plugin.changelog) && _update.plugin.changelog != '') {
-            tr += '<a class="btn btn-xs cursor" target="_blank" href="' + _update.plugin.changelog + '"><i class="fas fa-book"></i><span class="hidden-1280"> {{Changelog}}</span></a> '
-          } else {
-            tr += '<a class="btn btn-xs disabled"><i class="fas fa-book"></i><span class="hidden-1280"> {{Changelog}}</span></a> '
-          }
-        } else {
-          if (isset(_update.plugin) && isset(_update.plugin.changelog) && _update.plugin.changelog != '') {
-            tr += '<a class="btn btn-xs cursor" target="_blank" href="' + _update.plugin.changelog + '"><i class="fas fa-book"></i><span class="hidden-1280"> {{Changelog}}</span></a> '
-          } else {
-            tr += '<a class="btn btn-xs disabled"><i class="fas fa-book"></i><span class="hidden-1280"> {{Changelog}}</span></a> '
-          }
+        let pluginChangelog = false
+        if (_update.configuration && _update.configuration.version == 'beta' && isset(_update.plugin) && isset(_update.plugin.changelog_beta) && _update.plugin.changelog_beta != '') {
+          pluginChangelog = _update.plugin.changelog_beta
+        } else if (isset(_update.plugin) && isset(_update.plugin.changelog) && _update.plugin.changelog != '') {
+          pluginChangelog = _update.plugin.changelog
         }
-      } else {
-        tr += '<a class="btn btn-xs" target="_blank" href="' + _update.changelog_url + '" id="bt_changelogCore"><i class="fas fa-book"></i><span class="hidden-1280"> {{Changelog}}</span></a> '
-      }
-      if (_update.type != 'core') {
+        if (pluginChangelog) {
+          tr += '<a class="btn btn-xs roundedLeft" target="_blank" href="' + pluginChangelog + '"><i class="fas fa-file-code"></i><span class="hidden-1280"> {{Changelog}}</span></a> '
+        } else {
+          tr += '<a class="btn btn-xs roundedLeft disabled"><i class="fas fa-file-code"></i><span class="hidden-1280"> {{Changelog}}</span></a> '
+        }
+
+        tr += '<a class="btn btn-info btn-xs checkUpdate"><i class="fas fa-check"></i><span class="hidden-1280"> {{Vérifier}}</span></a>'
+
+        const canUpdate = !_update.configuration.hasOwnProperty('doNotUpdate') || _update.configuration.doNotUpdate == '0'
         if (_update.status == 'update') {
-          if (!_update.configuration.hasOwnProperty('doNotUpdate') || _update.configuration.doNotUpdate == '0') {
-            tr += '<a class="btn btn-warning btn-xs update"><i class="fas fa-sync"></i><span class="hidden-1280"> {{Mettre à jour}}</span></a> '
-          } else {
-            tr += '<a class="btn btn-warning btn-xs update disabled"><i class="fas fa-sync"></i><span class="hidden-1280"> {{Mettre à jour}}</span></a> '
-          }
+          tr += '<a class="btn btn-warning btn-xs update' + (!canUpdate ? ' disabled' : '') + '"><i class="fas fa-sync-alt"></i><span class="hidden-1280"> {{Mettre à jour}}</span></a> '
         } else {
-          if (!_update.configuration.hasOwnProperty('doNotUpdate') || _update.configuration.doNotUpdate == '0') {
-            tr += '<a class="btn btn-warning btn-xs update"><i class="fas fa-sync"></i><span class="hidden-1280"> {{Réinstaller}}</span></a> '
-          } else {
-            tr += '<a class="btn btn-warning btn-xs update disabled"><i class="fas fa-sync"></i><span class="hidden-1280"> {{Réinstaller}}</span></a> '
-          }
+          tr += '<a class="btn btn-warning btn-xs update' + (!canUpdate ? ' disabled' : '') + '"><i class="fas fa-redo-alt"></i><span class="hidden-1280"> {{Réinstaller}}</span></a> '
         }
-      } else if (_update.status == 'update' && jeephp2js.showUpdate == '1') {
-        tr += '<a class="btn btn-warning btn-xs updateJeedom"><i class="fas fa-sync"></i><span class="hidden-1280"> {{Mettre à jour}}</span></a> '
+
+        tr += '<a class="btn btn-danger btn-xs roundedRight remove"><i class="far fa-trash-alt"></i><span class="hidden-1280"> {{Supprimer}}</span></a> '
+      } else {
+        tr += '<a class="btn btn-xs roundedLeft" target="_blank" href="' + _update.changelog_url + '" id="bt_changelogCore"><i class="fas fa-file-code"></i><span class="hidden-1280"> {{Changelog}}</span></a> '
+        if (_update.status == 'update' && jeephp2js.showUpdate == '1') {
+          tr += '<a class="btn btn-info btn-xs checkUpdate"><i class="fas fa-check"></i><span class="hidden-1280"> {{Vérifier}}</span></a>'
+          tr += '<a class="btn btn-warning btn-xs roundedRight updateJeedom"><i class="fas fa-sync-alt"></i><span class="hidden-1280"> {{Mettre à jour}}</span></a> '
+        } else {
+          tr += '<a class="btn btn-info btn-xs roundedRight checkUpdate"><i class="fas fa-check"></i><span class="hidden-1280"> {{Vérifier}}</span></a>'
+        }
       }
-      if (_update.type != 'core') {
-        tr += '<a class="btn btn-danger btn-xs remove"><i class="far fa-trash-alt"></i><span class="hidden-1280"> {{Supprimer}}</span></a> '
-      }
-      tr += '<a class="btn btn-info btn-xs checkUpdate"><i class="fas fa-check"></i><span class="hidden-1280"> {{Vérifier}}</span></a>'
       tr += '</td>'
       tr += '</tr>'
       let newRow = document.createElement('tr')
@@ -567,7 +560,7 @@ if (!jeeFrontEnd.update) {
         },
         buttons: {
           confirm: {
-            label: '{{Mettre à jour}}',
+            label: '<i class="fas fa-sync-alt"></i> {{Mettre à jour}}',
             className: 'success',
             callback: {
               click: function(event) {
@@ -629,8 +622,10 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
   }
 
   if (_target = event.target.closest('#table_update input[data-l2key="doNotUpdate"]')) {
-    _target._tippy.show()
-    setTimeout(() => { _target._tippy.hide() }, 1500)
+    if (event.isTrusted) {
+      _target.closest('label')._tippy.show()
+      setTimeout(() => { _target.closest('label')._tippy.hide() }, 1500)
+    }
     if (_target.checked) {
       _target.closest('tr').querySelector('a.btn.update').addClass('disabled')
     } else {
@@ -654,9 +649,9 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
       },
       success: function(data) {
         var isActivated = (data.activate !== undefined && data.activate !== null) ? data.activate : 1
-        var confirmationMessage = '{{Êtes-vous sûr de vouloir mettre à jour le plugin :}} ' + logicalId + ' ?'
+        var confirmationMessage = '{{Êtes-vous sûr de vouloir mettre à jour le plugin ' + logicalId + ' ?}}'
         if (isActivated != 1) {
-          confirmationMessage = '{{Attention : Le plugin ' + logicalId + ' n\'est pas activé. Êtes-vous sûr de vouloir le mettre à jour ?}}'
+          confirmationMessage = "{{Attention : Le plugin " + logicalId + " n'est pas activé. Êtes-vous sûr de vouloir le mettre à jour ?}}"
         }
 
         jeeDialog.confirm(confirmationMessage, function(result) {
@@ -688,7 +683,7 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
   if (_target = event.target.closest('#table_update .remove')) {
     var id = _target.closest('tr').getAttribute('data-id')
     var logicalId = _target.closest('tr').getAttribute('data-logicalid')
-    jeeDialog.confirm('{{Êtes-vous sûr de vouloir supprimer :}}' + ' ' + logicalId + ' ?', function(result) {
+    jeeDialog.confirm('{{Êtes-vous sûr de vouloir supprimer le plugin ' + logicalId + ' ?}}', function(result) {
       if (result) {
         jeedomUtils.hideAlert()
         jeedom.update.remove({
@@ -754,7 +749,7 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
       return
     }
     let type = _target.getAttribute('data-type')
-    jeeDialog.confirm('{{Êtes-vous sûr de vouloir mettre à jour les packages de type}}' + ' : ' + type + ' ? {{Attention cette opération est toujours risquée et peut prendre plusieurs dizaines de minutes}}.', function(result) {
+    jeeDialog.confirm('{{Êtes-vous sûr de vouloir mettre à jour les packages de type ' + type + ' ? Attention cette opération est toujours risquée et peut prendre plusieurs dizaines de minutes}}.', function(result) {
       if (!result) {
         return
       }

--- a/desktop/php/update.php
+++ b/desktop/php/update.php
@@ -46,9 +46,9 @@ if (strpos($logUpdate, 'END UPDATE') || count(system::ps('install/update.php', '
 		<span class="label label-info" id="span_lastUpdateCheck"></span>
 		<div class="input-group pull-right" style="display:inline-flex">
 			<span class="input-group-btn">
-				<a class="btn btn-info btn-sm roundedLeft" id="bt_checkAllUpdate"><i class="fas fa-sync"></i> {{Vérifier les mises à jour}}
+				<a class="btn btn-info btn-sm roundedLeft" id="bt_checkAllUpdate"><i class="fas fa-check"></i> {{Vérifier les mises à jour}}
 				</a><a class="btn btn-success btn-sm" id="bt_saveUpdate"><i class="fas fa-check-circle"></i> {{Sauvegarder}}
-				</a><?php if ($showUpdate == true) { ?><a href="#" class="btn btn-sm btn-warning roundedRight updateJeedom"><i class="fas fa-check"></i> {{Mettre à jour}}
+				</a><?php if ($showUpdate == true) { ?><a href="#" class="btn btn-sm btn-warning roundedRight updateJeedom"><i class="fas fa-sync-alt"></i> {{Mettre à jour}}
 					</a><?php } ?>
 			</span>
 		</div>
@@ -128,7 +128,7 @@ if (strpos($logUpdate, 'END UPDATE') || count(system::ps('install/update.php', '
 				<fieldset>
 					<div class="alert alert-warning">
 						{{En cas de mise à jour du core, veuillez prendre connaissance du}}
-						<a class="btn btn-xs" id="bt_warnChangelogCore" target="_blank"><i class="fas fa-book"></i>
+						<a class="btn btn-xs" id="bt_warnChangelogCore" target="_blank"><i class="fas fa-file-code"></i>
 							{{Changelog}}
 						</a>
 						{{au préalable}}.


### PR DESCRIPTION
- Groups changelog / check / update / reinstall / remove buttons into a single rounded button group in each update table row.
- Replaces inconsistent icons with a coherent set: `fa-check` for verify, `fa-sync-alt` for update, `fa-redo-alt` for reinstall, `fa-file-code` for changelog, `fa-lock` for the "don't update this plugin" toggle.
- Simplifies the changelog link logic (single `pluginChangelog` variable instead of duplicated beta/stable branches).
- Wraps the "don't update" checkbox and its icon in a single `<label>` with one unified tooltip, instead of two separate tooltips and an empty, unused label.
- Adjusts the update table row layout (`flex`) so rows fit evenly on the page instead of leaving uneven gaps, especially in mobile/reflow view.
- Guards the "don't update" checkbox tooltip flash behind `event.isTrusted`, so a future fix to the checkbox context menu (bulk select/deselect) won't flash every row's tooltip at once.
- Fixes minor wording issues in confirmation and alert messages (accents, phrasing).

Based on a community suggestion: https://community.jeedom.com/t/suggestion-de-presentation-sur-la-page-mise-a-jour/149869