### PR TITLE
Unify plugin install prompts and revamp the add plugin modal

### DIFF
--- a/core/ajax/repo.ajax.php
+++ b/core/ajax/repo.ajax.php
@@ -59,8 +59,10 @@ try {
 			throw new Exception(__('Impossible de trouver l\'objet associé :', __FILE__) . ' ' . init('id'));
 		}
 		$update = update::byTypeAndLogicalId($repo->getType(), $repo->getLogicalId());
+		$new = false;
 		if (!is_object($update)) {
 			$update = new update();
+			$new = true;
 		}
 		if ($update->getConfiguration('doNotUpdate') == 1) {
 			throw new Exception(__('Mise à jour et réinstallation désactivées sur ', __FILE__) . ' ' . $repo->getLogicalId());
@@ -71,7 +73,14 @@ try {
 		$update->setLocalVersion($repo->getDatetime(init('version', 'stable')));
 		$update->setConfiguration('version', init('version', 'stable'));
 		$update->save();
-		$update->doUpdate();
+		try {
+			$update->doUpdate();
+		} catch (Exception $e) {
+			if ($new) {
+				$update->deleteObjet();
+			}
+			throw $e;
+		}
 		ajax::success();
 	}
 

--- a/core/ajax/update.ajax.php
+++ b/core/ajax/update.ajax.php
@@ -154,6 +154,7 @@ try {
 			$update->doUpdate();
 		} catch (Exception $e) {
 			if ($new) {
+				$update->deleteObjet();
 				throw $e;
 			} else {
 				$update = $old_update;

--- a/core/class/update.class.php
+++ b/core/class/update.class.php
@@ -535,7 +535,7 @@ class update {
 
 	public function preSave() {
 		if ($this->getLogicalId() == '') {
-			throw new Exception(__('Le logical ID ne peut pas être vide', __FILE__));
+			throw new Exception(__("L'identifiant du plugin ne peut pas être vide", __FILE__));
 		}
 		if ($this->getName() == '') {
 			$this->setName($this->getLogicalId());

--- a/core/repo/file.repo.php
+++ b/core/repo/file.repo.php
@@ -33,20 +33,20 @@ class repo_file {
 
 	/*     * ***********************Méthodes statiques*************************** */
 
-	public static function getConfigurationOption(){
+	public static function getConfigurationOption() {
 		return array(
-          	'translate_name' => __('Fichier',__FILE__),
+			'translate_name' => __('Fichier', __FILE__),
 			'parameters_for_add' => array(
 				'path' => array(
-					'name' =>  __('Chemin',__FILE__),
+					'name' =>  __('Fichier ZIP', __FILE__),
 					'type' => 'file',
+					'tooltip' => __("Téléverser le plugin compressé", __FILE__) . ' (*.zip)'
 				),
 			),
 		);
 	}
 
 	public static function checkUpdate($_update) {
-
 	}
 
 	public static function downloadObject($_update) {
@@ -54,7 +54,6 @@ class repo_file {
 	}
 
 	public static function deleteObjet($_update) {
-
 	}
 
 	public static function objectInfo($_update) {
@@ -67,5 +66,4 @@ class repo_file {
 	/*     * *********************Methode d'instance************************* */
 
 	/*     * **********************Getteur Setteur*************************** */
-
 }

--- a/core/repo/github.repo.php
+++ b/core/repo/github.repo.php
@@ -39,42 +39,48 @@ class repo_github {
 		return array(
 			'parameters_for_add' => array(
 				'user' => array(
-					'name' =>  __('Utilisateur ou organisation du dépôt', __FILE__),
+					'name' =>  __('Propriétaire du dépôt', __FILE__),
 					'type' => 'input',
+					'tooltip' => __("Renseigner le nom de l'utilisateur ou de l'organisation propriétaire du dépôt Github", __FILE__),
+					'placeholder' => 'jeedom'
 				),
 				'repository' => array(
 					'name' =>  __('Nom du dépôt', __FILE__),
 					'type' => 'input',
+					'tooltip' => __("Renseigner le nom du dépôt Github", __FILE__),
+					'placeholder' => 'plugin-PLUGIN_ID'
 				),
 				'token' => array(
 					'name' =>  __('Token (facultatif)', __FILE__),
-					'type' => 'input'
+					'type' => 'input',
+					'tooltip' => __("Si nécessaire, renseigner votre token d'accès au dépôt privé", __FILE__)
 				),
 				'version' => array(
-					'name' =>  __('Branche', __FILE__),
+					'name' =>  __('Branche/Version', __FILE__),
 					'type' => 'input',
-					'default' => 'master',
+					'tooltip' => __("Renseigner la version plugin à installer (master, beta ou autre)", __FILE__),
+					'placeholder' => 'master'
 				),
 			),
 			'configuration' => array(
 				'token' => array(
 					'name' =>  __('Token (facultatif)', __FILE__),
-					'type' => 'input',
+					'type' => 'input'
 				),
 				'core::user' => array(
 					'name' =>  __('Utilisateur ou organisation du dépôt pour le core Jeedom', __FILE__),
 					'type' => 'input',
-					'default' => 'jeedom',
+					'default' => 'jeedom'
 				),
 				'core::repository' => array(
 					'name' =>  __('Nom du dépôt pour le core Jeedom', __FILE__),
 					'type' => 'input',
-					'default' => 'core',
+					'default' => 'core'
 				),
 				'core::branch' => array(
 					'name' =>  __('Branche pour le core Jeedom', __FILE__),
 					'type' => 'input',
-					'default' => 'stable',
+					'default' => 'stable'
 				),
 			),
 		);
@@ -126,9 +132,9 @@ class repo_github {
 
 	public static function downloadObject($_update) {
 		$token = $_update->getConfiguration('token', config::byKey('github::token', 'core', ''));
-		$branch = self::getBranchInfo($_update);
+		$pluginId = $_update->getLogicalId();
 		$tmp_dir = jeedom::getTmpFolder('github');
-		$tmp = $tmp_dir . '/' . $_update->getLogicalId() . '.zip';
+		$tmp = $tmp_dir . '/' . $pluginId . '.zip';
 		if (file_exists($tmp)) {
 			unlink($tmp);
 		}
@@ -138,8 +144,18 @@ class repo_github {
 		if (!is_writable($tmp_dir)) {
 			throw new Exception(__('Impossible d\'écrire dans le répertoire :', __FILE__) . ' ' . $tmp . __('. Exécuter la commande suivante en SSH : sudo chmod 777 -R', __FILE__) . ' ' . $tmp_dir);
 		}
+		$user = $_update->getConfiguration('user');
+		$repository = $_update->getConfiguration('repository');
+		$version = $_update->getConfiguration('version');
+		if (empty($user) || empty($repository) || empty($version)) {
+			$_update->setConfiguration('user', empty($user) ? 'jeedom' : $user)
+				->setConfiguration('repository', empty($repository) ? 'plugin-' . $pluginId : $repository)
+				->setConfiguration('version', empty($version) ? 'master' : $version)
+				->save();
+		}
+		$branch = self::getBranchInfo($_update);
 		$url = 'https://api.github.com/repos/' . $_update->getConfiguration('user') . '/' . $_update->getConfiguration('repository') . '/zipball/' . $_update->getConfiguration('version', 'master');
-		log::add('update', 'alert', __('Téléchargement de', __FILE__) . ' ' . $_update->getLogicalId() . '...');
+		log::add('update', 'alert', __('Téléchargement de', __FILE__) . ' ' . $pluginId . '...');
 		if ($token == '') {
 			exec('curl -s -f -L -o ' . escapeshellarg($tmp) . ' ' . escapeshellarg($url) . ' 2>&1', $output, $return_code);
 		} else {

--- a/core/repo/github.repo.php
+++ b/core/repo/github.repo.php
@@ -35,44 +35,44 @@ class repo_github {
 
 	/*     * ***********************Méthodes statiques*************************** */
 
-	public static function getConfigurationOption(){
+	public static function getConfigurationOption() {
 		return array(
 			'parameters_for_add' => array(
 				'user' => array(
-					'name' =>  __('Utilisateur ou organisation du dépôt',__FILE__),
+					'name' =>  __('Utilisateur ou organisation du dépôt', __FILE__),
 					'type' => 'input',
 				),
 				'repository' => array(
-					'name' =>  __('Nom du dépôt',__FILE__),
+					'name' =>  __('Nom du dépôt', __FILE__),
 					'type' => 'input',
 				),
 				'token' => array(
-					'name' =>  __('Token (facultatif)',__FILE__),
+					'name' =>  __('Token (facultatif)', __FILE__),
 					'type' => 'input'
 				),
 				'version' => array(
-					'name' =>  __('Branche',__FILE__),
+					'name' =>  __('Branche', __FILE__),
 					'type' => 'input',
 					'default' => 'master',
 				),
 			),
 			'configuration' => array(
 				'token' => array(
-					'name' =>  __('Token (facultatif)',__FILE__),
+					'name' =>  __('Token (facultatif)', __FILE__),
 					'type' => 'input',
 				),
 				'core::user' => array(
-					'name' =>  __('Utilisateur ou organisation du dépôt pour le core Jeedom',__FILE__),
+					'name' =>  __('Utilisateur ou organisation du dépôt pour le core Jeedom', __FILE__),
 					'type' => 'input',
 					'default' => 'jeedom',
 				),
 				'core::repository' => array(
-					'name' =>  __('Nom du dépôt pour le core Jeedom',__FILE__),
+					'name' =>  __('Nom du dépôt pour le core Jeedom', __FILE__),
 					'type' => 'input',
 					'default' => 'core',
 				),
 				'core::branch' => array(
-					'name' =>  __('Branche pour le core Jeedom',__FILE__),
+					'name' =>  __('Branche pour le core Jeedom', __FILE__),
 					'type' => 'input',
 					'default' => 'stable',
 				),
@@ -113,19 +113,19 @@ class repo_github {
 		$_update->save();
 	}
 
-	public static function getBranchInfo($_update){
+	public static function getBranchInfo($_update) {
 		$headers = array('User-agent: jeedom');
-		$token = $_update->getConfiguration('token',config::byKey('github::token','core',''));
-		if($token != ''){
-			$headers[] = 'Authorization: Bearer '.$token;
+		$token = $_update->getConfiguration('token', config::byKey('github::token', 'core', ''));
+		if ($token != '') {
+			$headers[] = 'Authorization: Bearer ' . $token;
 		}
-		$request_http = new com_http('https://api.github.com/repos/'.$_update->getConfiguration('user').'/'.$_update->getConfiguration('repository').'/branches/'.$_update->getConfiguration('version', 'master'));
+		$request_http = new com_http('https://api.github.com/repos/' . $_update->getConfiguration('user') . '/' . $_update->getConfiguration('repository') . '/branches/' . $_update->getConfiguration('version', 'master'));
 		$request_http->setHeader($headers);
 		return json_decode($request_http->exec(10, 1), true);
 	}
 
 	public static function downloadObject($_update) {
-		$token = $_update->getConfiguration('token',config::byKey('github::token','core',''));
+		$token = $_update->getConfiguration('token', config::byKey('github::token', 'core', ''));
 		$branch = self::getBranchInfo($_update);
 		$tmp_dir = jeedom::getTmpFolder('github');
 		$tmp = $tmp_dir . '/' . $_update->getLogicalId() . '.zip';
@@ -188,7 +188,7 @@ class repo_github {
 	}
 
 	public static function versionCore() {
-		$url = 'https://raw.githubusercontent.com/'.config::byKey('github::core::user', 'core', 'jeedom').'/'.config::byKey('github::core::repository', 'core', 'core').'/' . config::byKey('github::core::branch', 'core', 'stable') . '/core/config/version';
+		$url = 'https://raw.githubusercontent.com/' . config::byKey('github::core::user', 'core', 'jeedom') . '/' . config::byKey('github::core::repository', 'core', 'core') . '/' . config::byKey('github::core::branch', 'core', 'stable') . '/core/config/version';
 		$request_http = new com_http($url);
 		return trim($request_http->exec(30));
 	}

--- a/core/repo/market.display.repo.php
+++ b/core/repo/market.display.repo.php
@@ -26,18 +26,6 @@ sendVarToJS('market_display_info', $market_array);
     <div class='col-sm-3'>
       <center>
         <?php
-        $default_image = 'core/img/no_image.gif';
-        switch ($market->getType()) {
-          case 'widget':
-            $default_image = 'core/img/no-image-widget.png';
-            break;
-          case 'plugin':
-            $default_image = 'core/img/no-image-plugin.png';
-            break;
-          case 'script':
-            $default_image = 'core/img/no-image-script.png';
-            break;
-        }
         $urlPath = config::byKey('market::address') . '/' . $market->getImg('icon');
         echo '<img src="' . $urlPath . '" class="img-responsive" style="height : 200px;" onerror="this.onerror=null;this.src=&quot;core/img/no-image-plugin.png&quot;;"/>';
         ?>
@@ -346,10 +334,8 @@ sendVarToJS('market_display_info', $market_array);
       }
 
       if (_target = event.target.closest('.bt_installFromMarket')) {
-        var id = _target.getAttribute('data-market_id')
-        var logicalId = _target.getAttribute('data-market_logicalId')
         jeedom.repo.install({
-          id: id,
+          id: _target.getAttribute('data-market_id'),
           repo: 'market',
           version: _target.getAttribute('data-version'),
           error: function(error) {
@@ -359,20 +345,7 @@ sendVarToJS('market_display_info', $market_array);
             })
           },
           success: function(data) {
-            if (market_display_info.type == 'plugin') {
-              jeeDialog.confirm('{{Voulez-vous aller sur la page de configuration de votre nouveau plugin ?}}', function(result) {
-                if (result) {
-                  jeedomUtils.loadPage('index.php?v=d&p=plugin&id=' + logicalId)
-                }
-              })
-            }
-            if (typeof refreshListAfterMarketObjectInstall == 'function') {
-              refreshListAfterMarketObjectInstall()
-            }
-            jeedomUtils.showAlert({
-              message: '{{Plugin installé avec succès}}',
-              level: 'success'
-            })
+            jeeFrontEnd.plugin.installSuccess(_target.getAttribute('data-market_logicalId'))
           }
         })
         return

--- a/core/repo/market.display.repo.php
+++ b/core/repo/market.display.repo.php
@@ -116,23 +116,23 @@ sendVarToJS('market_display_info', $market_array);
       <?php
       $purchase_info = null;
       if (config::byKey('market::apikey') != '' || (config::byKey('market::username') != '' && config::byKey('market::password') != '')) {
-          $purchase_info = repo_market::getPurchaseInfo();
+        $purchase_info = repo_market::getPurchaseInfo();
       }
       if ($market->getCertification() == 'Premium') {
-          echo '<span data-l1key="rating" style="font-size: 1.5em;">{{Nous Contacter}}</span>';
+        echo '<span data-l1key="rating" style="font-size: 1.5em;">{{Nous Contacter}}</span>';
       } else {
-          if (isset($purchase_info['user_id']) && is_numeric($purchase_info['user_id']) && $market->getPurchase() == 1) {
-              echo '<span data-l1key="rating" style="font-size: 1.5em;">{{Plugin deja acheté et/ou inclus dans votre service Pack}}</span>';
+        if (isset($purchase_info['user_id']) && is_numeric($purchase_info['user_id']) && $market->getPurchase() == 1) {
+          echo '<span data-l1key="rating" style="font-size: 1.5em;">{{Plugin deja acheté et/ou inclus dans votre service Pack}}</span>';
+        } else {
+          if ($market->getCost() > 0) {
+            if ($market->getCost() != $market->getRealCost()) {
+              echo '<span data-l1key="rating" style="font-size: 1em;text-decoration:line-through;">' . number_format($market->getRealCost(), 2) . ' €</span> ';
+            }
+            echo '<span data-l1key="rating" style="font-size: 1.5em;">' . number_format($market->getCost(), 2) . ' € TTC</span>';
           } else {
-              if ($market->getCost() > 0) {
-                  if ($market->getCost() != $market->getRealCost()) {
-                      echo '<span data-l1key="rating" style="font-size: 1em;text-decoration:line-through;">' . number_format($market->getRealCost(), 2) . ' €</span> ';
-                  }
-                  echo '<span data-l1key="rating" style="font-size: 1.5em;">' . number_format($market->getCost(), 2) . ' € TTC</span>';
-              } else {
-                  echo '<span data-l1key="rating" style="font-size: 1.5em;">{{Gratuit}}</span>';
-              }
+            echo '<span data-l1key="rating" style="font-size: 1.5em;">{{Gratuit}}</span>';
           }
+        }
       }
       ?>
     </div>
@@ -283,38 +283,38 @@ sendVarToJS('market_display_info', $market_array);
   (function() { // Self Isolation!
 
     function compareVersionsCore(v1, v2) {
-        const v1Parts = v1.split('.').map(Number);
-        const v2Parts = v2.split('.').map(Number);
+      const v1Parts = v1.split('.').map(Number);
+      const v2Parts = v2.split('.').map(Number);
 
-        for (let i = 0; i < Math.max(v1Parts.length, v2Parts.length); i++) {
-            const v1Part = v1Parts[i] || 0;
-            const v2Part = v2Parts[i] || 0;
+      for (let i = 0; i < Math.max(v1Parts.length, v2Parts.length); i++) {
+        const v1Part = v1Parts[i] || 0;
+        const v2Part = v2Parts[i] || 0;
 
-            if (v1Part > v2Part) return 1;
-            if (v1Part < v2Part) return -1;
-        }
+        if (v1Part > v2Part) return 1;
+        if (v1Part < v2Part) return -1;
+      }
 
-        return 0;
+      return 0;
     }
 
     jeedom.version({
-        success: function(version) {
-            if(compareVersionsCore(market_display_info.parameters.minJeedomVersion, version) > 0) {
-                var installButtons = document.querySelectorAll('.bt_installFromMarket');
-                installButtons.forEach(function(installButton) {
-                    installButton.style.display = 'none';
-                });
-              var buyButtons = document.querySelectorAll('.buyButtons');
-                     buyButtons.forEach(function(buyButton) {
-                          buyButton.style.display = 'none';
-                      });
-     
-              var warningDiv = document.getElementById('warningVersion'); 
-              if (warningDiv) {
-                  warningDiv.style.display = 'block';
-              }
-            }
+      success: function(version) {
+        if (compareVersionsCore(market_display_info.parameters.minJeedomVersion, version) > 0) {
+          var installButtons = document.querySelectorAll('.bt_installFromMarket');
+          installButtons.forEach(function(installButton) {
+            installButton.style.display = 'none';
+          });
+          var buyButtons = document.querySelectorAll('.buyButtons');
+          buyButtons.forEach(function(buyButton) {
+            buyButton.style.display = 'none';
+          });
+
+          var warningDiv = document.getElementById('warningVersion');
+          if (warningDiv) {
+            warningDiv.style.display = 'block';
+          }
         }
+      }
     });
 
 

--- a/core/repo/market.repo.php
+++ b/core/repo/market.repo.php
@@ -73,41 +73,46 @@ class repo_market {
 			'configuration' => array(
 				'address' => array(
 					'name' => __('Adresse', __FILE__),
-					'type' => 'input',
+					'type' => 'input'
 				),
 				'username' => array(
 					'name' => __('Nom d\'utilisateur', __FILE__),
-					'type' => 'input',
+					'type' => 'input'
 				),
 				'password' => array(
 					'name' => __('Mot de passe', __FILE__),
-					'type' => 'password_noshow',
+					'type' => 'password_noshow'
 				),
 				'no_ssl_verify' => array(
 					'name' => __('Pas de validation SSL (non recommandé)', __FILE__),
-					'type' => 'checkbox',
+					'type' => 'checkbox'
 				),
 				'cloud::backup::name' => array(
 					'name' => __('[Backup cloud] Nom du dossier de backup', __FILE__),
-					'type' => 'input',
+					'type' => 'input'
 				),
 				'cloud::backup::password' => array(
 					'name' => __('[Backup cloud] Mot de passe', __FILE__),
-					'type' => 'password',
+					'type' => 'password'
 				),
 				'cloud::backup::password_confirmation' => array(
 					'name' => __('[Backup cloud] Mot de passe (confirmation)', __FILE__),
-					'type' => 'password',
+					'type' => 'password'
 				),
 				'cloud::monitoring::disable' => array(
 					'name' => __('[Monitoring cloud] Désactiver', __FILE__),
-					'type' => 'checkbox',
+					'type' => 'checkbox'
 				)
 			),
 			'parameters_for_add' => array(
 				'version' => array(
-					'name' => __('Version : beta, stable', __FILE__),
-					'type' => 'input',
+					'name' => __('Version à installer', __FILE__),
+					'type' => 'select',
+					'options' => array(
+						'stable' => __('Stable', __FILE__),
+						'beta' => __('Beta', __FILE__),
+					),
+					'tooltip' => __("Sélectionner la version du plugin à installer", __FILE__)
 				),
 			),
 		);

--- a/core/repo/samba.repo.php
+++ b/core/repo/samba.repo.php
@@ -40,30 +40,31 @@ class repo_samba {
 		return array(
 			'parameters_for_add' => array(
 				'path' => array(
-					'name' => __('Chemin', __FILE__),
+					'name' => __('Chemin du fichier ZIP', __FILE__),
 					'type' => 'input',
+					'tooltip' => __("Renseigner le chemin du plugin compressé", __FILE__) . ' (*.zip)'
 				),
 			),
 			'configuration' => array(
 				'backup::ip' => array(
 					'name' => __('[Backup] IP', __FILE__),
-					'type' => 'input',
+					'type' => 'input'
 				),
 				'backup::username' => array(
 					'name' => __('[Backup] Utilisateur', __FILE__),
-					'type' => 'input',
+					'type' => 'input'
 				),
 				'backup::password' => array(
 					'name' => __('[Backup] Mot de passe', __FILE__),
-					'type' => 'password',
+					'type' => 'password'
 				),
 				'backup::share' => array(
 					'name' => __('[Backup] Partage', __FILE__),
-					'type' => 'input',
+					'type' => 'input'
 				),
 				'backup::folder' => array(
 					'name' => __('[Backup] Chemin', __FILE__),
-					'type' => 'input',
+					'type' => 'input'
 				),
 			),
 		);

--- a/core/repo/url.repo.php
+++ b/core/repo/url.repo.php
@@ -38,18 +38,19 @@ class repo_url {
 		return array(
 			'parameters_for_add' => array(
 				'url' => array(
-					'name' => __('URL du fichier ZIP', __FILE__),
+					'name' => __('Adresse du fichier ZIP', __FILE__),
 					'type' => 'input',
+					'tooltip' => __("Renseigner l'adresse du plugin compressé", __FILE__) . ' (*.zip)'
 				),
 			),
 			'configuration' => array(
 				'core::url' => array(
 					'name' => __('URL core Jeedom', __FILE__),
-					'type' => 'input',
+					'type' => 'input'
 				),
 				'core::version' => array(
 					'name' => __('URL version core Jeedom', __FILE__),
-					'type' => 'input',
+					'type' => 'input'
 				),
 			),
 		);

--- a/desktop/js/plugin.js
+++ b/desktop/js/plugin.js
@@ -585,7 +585,7 @@ document.getElementById('div_resumePluginList')?.addEventListener('click', funct
 
   if (_target = event.target.closest('#bt_addPluginFromOtherSource')) {
     jeeDialog.dialog({
-      id: 'jee_modal',
+      id: 'jee_modal3',
       title: "{{Installer un plugin}}",
       contentUrl: 'index.php?v=d&modal=update.add'
     })

--- a/desktop/js/plugin.js
+++ b/desktop/js/plugin.js
@@ -22,8 +22,6 @@ Can also be called in modale, triggering plugin button click for direct access t
 
 "use strict"
 
-
-
 if (!jeeFrontEnd.plugin) {
   jeeFrontEnd.plugin = {
     init: function() {
@@ -112,17 +110,17 @@ if (!jeeFrontEnd.plugin) {
           } else {
             self.dom_container.querySelector('#span_plugin_usedSpace').innerHTML = ''
           }
-          
+
           if (isset(data.category) && isset(jeephp2js.pluginCategories[data.category])) {
             self.dom_container.querySelector('#span_plugin_category').innerHTML = jeephp2js.pluginCategories[data.category].name
           } else {
             self.dom_container.querySelector('#span_plugin_category').innerHTML = ''
           }
           if (isset(data.source)) {
-            if (isset(data.update) && isset(data.update.configuration) && isset(data.update.configuration.user)){
-                self.dom_container.querySelector('#span_plugin_source').innerHTML = data.source +' - '+data.update.configuration.user
+            if (isset(data.update) && isset(data.update.configuration) && isset(data.update.configuration.user)) {
+              self.dom_container.querySelector('#span_plugin_source').innerHTML = data.source + ' - ' + data.update.configuration.user
             } else {
-                self.dom_container.querySelector('#span_plugin_source').innerHTML = data.source
+              self.dom_container.querySelector('#span_plugin_source').innerHTML = data.source
             }
           } else {
             self.dom_container.querySelector('#span_plugin_source').innerHTML = ''

--- a/desktop/js/plugin.js
+++ b/desktop/js/plugin.js
@@ -47,6 +47,28 @@ if (!jeeFrontEnd.plugin) {
         }
       }
     },
+    installSuccess: function(_logicalId) {
+      jeedomUtils.showAlert({
+        message: '{{Plugin installé avec succès}}',
+        level: 'success'
+      })
+      jeeDialog.confirm({
+        message: '{{Voulez-vous aller sur la page de configuration de votre nouveau plugin ?}}',
+        buttons: {
+          cancel: {
+            label: '<i class="fa fa-times"></i> {{Non}}',
+          },
+          confirm: {
+            label: '<i class="fa fa-check"></i> {{Oui}}',
+          }
+        },
+        callback: function(result) {
+          if (result) {
+            jeedomUtils.loadPage('index.php?v=d&p=plugin&id=' + _logicalId)
+          }
+        }
+      })
+    },
     displayPlugin: function(_pluginId) {
       jeedomUtils.hideAlert()
       let self = this
@@ -564,7 +586,7 @@ document.getElementById('div_resumePluginList')?.addEventListener('click', funct
   if (_target = event.target.closest('#bt_addPluginFromOtherSource')) {
     jeeDialog.dialog({
       id: 'jee_modal',
-      title: "{{Ajouter un plugin}}",
+      title: "{{Installer un plugin}}",
       contentUrl: 'index.php?v=d&modal=update.add'
     })
     return

--- a/desktop/modal/update.add.php
+++ b/desktop/modal/update.add.php
@@ -22,13 +22,16 @@ $repos = update::listRepo();
 ?>
 
 <div id="md_updateAdd" data-modalType="md_updateAdd">
-  <legend>{{Source}}</legend>
-  <div class="alert alert-danger">{{Attention, il n’y a pas d’assistance de l’équipe}} <?php echo config::byKey('product_name'); ?> {{sur les plugins installés depuis une autre source que le Market}} <?php echo config::byKey('product_name'); ?>. {{De plus, l’installation d’un plugin depuis une autre source que le Market}} <?php echo config::byKey('product_name'); ?> {{entraine la perte globale d’assistance par l’équipe}} <?php echo config::byKey('product_name'); ?>.</div>
+  <div class="alert alert-danger text-center">{{Attention : l'installation d'un plugin depuis une autre source que le Market entraîne la perte globale du support officiel}} (core & plugins)</div>
+
   <form class="form-horizontal">
     <fieldset>
+      <legend><i class="fas fa-search-location"></i> {{Source}}</legend>
       <div class="form-group">
-        <label class="col-lg-4 control-label">{{Type de source}}</label>
-        <div class="col-lg-8">
+        <label class="col-sm-3 control-label">{{Type de source}}
+          <sup><i class="fas fa-question-circle tooltips" title="{{Sélectionner la source d'installation du plugin}}"></i></sup>
+        </label>
+        <div class="col-sm-7">
           <select class="updateAttr form-control" data-l1key="source">
             <option value="nothing">{{Aucun}}</option>
             <?php
@@ -52,11 +55,8 @@ $repos = update::listRepo();
           </select>
         </div>
       </div>
-    </fieldset>
-  </form>
-  <legend>{{Configuration}}</legend>
-  <form class="form-horizontal">
-    <fieldset>
+
+      <legend><i class="fas fa-wrench"></i> {{Configuration}}</legend>
       <?php
       foreach ($repos as $key => $value) {
         if ($value['configuration'] === false) {
@@ -70,31 +70,37 @@ $repos = update::listRepo();
         }
         $div = '<div class="repoSource repo_' . $key . '" style="display:none;">';
         $div .= '<div class="form-group">';
-        $div .= '<label class="col-lg-4 control-label">';
-        $div .= '{{ID logique du plugin}}';
+        $div .= '<label class="col-sm-3 control-label">';
+        $div .= '{{Identifiant du plugin}}';
+        $div .= ' <sup><i class="fas fa-question-circle tooltips" title="{{Renseigner l\'identifiant du plugin}} (info.json > id)"></i></sup>';
         $div .= '</label>';
-        $div .= '<div class="col-lg-8">';
-        $div .= '<input class="updateAttr form-control" data-l1key="logicalId" />';
+        $div .= '<div class="col-sm-7">';
+        $div .= '<input class="updateAttr form-control" data-l1key="logicalId" placeholder="PLUGIN_ID" />';
         $div .= '</div>';
         $div .= '</div>';
         foreach ($value['configuration']['parameters_for_add'] as $pKey => $parameter) {
           $div .= '<div class="form-group">';
-          $div .= '<label class="col-lg-4 control-label">';
+          $div .= '<label class="col-sm-3 control-label">';
           $div .= $parameter['name'];
+          $div .= ' <sup><i class="fas fa-question-circle tooltips" title="' . $parameter['tooltip'] . '"></i></sup>';
           $div .= '</label>';
-          $div .= '<div class="col-lg-8">';
-          $default = (isset($parameter['default'])) ? $parameter['default'] : '';
+          $div .= '<div class="col-sm-7">';
           switch ($parameter['type']) {
             case 'input':
-              $div .= '<input class="updateAttr form-control" data-l1key="configuration" data-l2key="' . $pKey . '" value="' . $default . '" />';
+              $placeholder = (isset($parameter['placeholder'])) ? $parameter['placeholder'] : '';
+              $div .= '<input class="updateAttr form-control" data-l1key="configuration" data-l2key="' . $pKey . '" placeholder="' . $placeholder . '"/>';
               break;
-            case 'number':
-              $div .= '<input type="number" class="updateAttr form-control" data-l1key="configuration" data-l2key="' . $pKey . '" value="' . $default . '" />';
+            case 'select':
+              $div .= '<select class="updateAttr form-control" data-l1key="configuration" data-l2key="' . $pKey . '">';
+              foreach ($parameter['options'] as $optValue => $optLabel) {
+                $div .= '<option value="' . $optValue . '">' . $optLabel . '</option>';
+              }
+              $div .= '</select>';
               break;
             case 'file':
               $div .= '<input class="updateAttr form-control" data-l1key="configuration" data-l2key="' . $pKey . '" style="display:none;" />';
               $div .= '<span class="btn btn-default btn-file">';
-              $div .= '<i class="fas fa-cloud-upload-alt"></i> {{Envoyer un plugin}}<input id="bt_uploadPlugin" data-key="' . $pKey . '" type="file" name="file" style="display : inline-block;">';
+              $div .= '<i class="fas fa-cloud-upload-alt"></i> {{Envoyer un plugin}}<input id="bt_uploadPlugin" data-key="' . $pKey . '" type="file" name="file" accept=".zip" style="display:inline-block;">';
               $div .= '</span>';
               break;
           }
@@ -106,7 +112,7 @@ $repos = update::listRepo();
         echo $div;
       }
       ?>
-      <a class="btn btn-success pull-right" id="bt_repoAddSaveUpdate"><i class="fas fa-check-circle"></i> {{Sauvegarder}}</a>
+      <a class="btn btn-success pull-right" id="bt_repoAddSaveUpdate"><i class="fas fa-check-circle"></i> {{Installer le plugin}}</a>
     </fieldset>
   </form>
 </div>
@@ -125,11 +131,8 @@ $repos = update::listRepo();
           level: 'danger'
         })
       },
-      success: function() {
-        jeedomUtils.showAlert({
-          message: '{{Sauvegarde réussie}}',
-          level: 'success'
-        })
+      success: function(data) {
+        jeeFrontEnd.plugin.installSuccess(data.logicalId)
       }
     })
   })


### PR DESCRIPTION
Fixes #3418, and while at it, unifies plugin install feedback regardless of source.

- Replace the Cancel/OK buttons shown after installing a plugin from the Market with Yes/No, and reuse the same prompt for plugins installed from any other source (file, GitHub, URL, Samba), which previously just showed a toast and left the user with a stale plugin list.
- Rework the "Add a plugin from another source" modal: tooltips, placeholders instead of prefilled values, a Stable/Beta dropdown for Market installs, and restrict the manual file upload to `.zip`.
- Harden the GitHub source: surface curl failures instead of silently producing an empty archive, fall back to sensible defaults when user/repository/version are left blank, and fix an ordering issue so the installed commit SHA is captured on the very first install.
- Remove dead code found along the way (an unused image-type switch and a call to a function that was never defined).
- Fix an orphaned database row left behind when adding a new plugin from another source fails partway through.
- Apply the same orphaned-row cleanup to the Market's visual "Install" button (`repo.ajax.php`), which had the identical gap.
- `jee_modal` was oversized for the content of this modal. Switch to `jee_modal3` (60vw) instead
