### PR TITLE
Fire a change event on ispin spinners and guard against double init

### DIFF
--- a/desktop/common/js/utils.js
+++ b/desktop/common/js/utils.js
@@ -1299,7 +1299,7 @@ jeedomUtils.initSpinners = function() {
       wrapOverflow: true,
       parse: Number,
       onChange: function() {
-        _spin.triggerEvent('change', { bubbles: true })
+        _spin.triggerEvent('change')
       }
     }
     new ISpin(_spin, options)

--- a/desktop/common/js/utils.js
+++ b/desktop/common/js/utils.js
@@ -1287,19 +1287,23 @@ jeedomUtils.initSpinners = function() {
     })
   }
 
-  document.querySelectorAll('input[type="number"].ispin').forEach(_spin => {
-    var options = {
+  document.querySelectorAll('input[type="number"].ispin:not(.ispinned)').forEach(_spin => {
+    const options = {
       wrapperClass: 'ispin-wrapper',
       buttonsClass: 'ispin-button',
       step: _spin.getAttribute('step') != undefined ? parseFloat(_spin.getAttribute('step')) : 1,
       min: _spin.getAttribute('min') != undefined ? parseFloat(_spin.getAttribute('min')) : 1,
+      max: _spin.getAttribute('max') != undefined ? parseFloat(_spin.getAttribute('max')) : undefined,
       disabled: false,
       repeatInterval: 200,
       wrapOverflow: true,
-      parse: Number
+      parse: Number,
+      onChange: function() {
+        _spin.triggerEvent('change', { bubbles: true })
+      }
     }
-    if (_spin.getAttribute('max') != undefined) options.max = parseFloat(_spin.getAttribute('max'))
     new ISpin(_spin, options)
+    _spin.addClass('ispinned')
     if (_spin.hasClass('roundedLeft')) {
       _spin.closest('.ispin-wrapper').addClass('roundedLeft')
     }


### PR DESCRIPTION
- ISpin's own `spin()` method (triggered by the +/- buttons, arrow keys, and mouse wheel) updates the input's value via JS without ever firing a native `change` event, so listeners relying on `change` (e.g. an unsaved-parameter indicator) never fired for those interactions. `onChange` now dispatches a `change` event to cover this gap.
- `initSpinners()` could be called multiple times on the same page (e.g. reopened modals), and the underlying ISpin library rewraps the input and rebinds its listeners unconditionally on every call, stacking duplicate wrappers/buttons and duplicate keydown/wheel listeners. Elements are now marked with an `ispinned` class (same pattern as `tippied` for tooltips) so they're skipped on subsequent calls.