### PR TITLE
Fix real-time graph updates: skip inconsistent cases and rescale the Y axis

### DIFF
--- a/core/js/history.class.js
+++ b/core/js/history.class.js
@@ -182,11 +182,9 @@ jeedom.history.graphUpdate = function(_params) {
       if (cmd?.option?.invertData) {
         value = -value
       }
-      for (const serie in jeedom.history.chart[chart].chart.series) {
-        if (jeedom.history.chart[chart].chart.series[serie]?.options.id == cmd_id) {
-          jeedom.history.chart[chart].chart.series[serie].addPoint([Date.now() + (-new Date().getTimezoneOffset() * 60 * 1000), value])
-          break
-        }
+      const serie = jeedom.history.chart[chart].chart.series.find(s => s?.options.id == cmd_id)
+      if (serie) {
+        serie.addPoint([Date.now() + (-new Date().getTimezoneOffset() * 60 * 1000), value])
       }
     }
   }

--- a/core/js/history.class.js
+++ b/core/js/history.class.js
@@ -161,7 +161,13 @@ jeedom.history.graphUpdate = function(_params) {
       continue
     }
     for (const chart in jeedom.history.chart) {
+      if (jeedom.history.chart[chart].comparing) {
+        continue
+      }
       const cmd = jeedom.history.chart[chart].cmd[cmd_id]
+      if (cmd?.option?.groupingType || cmd?.option?.graphDerive) {
+        continue
+      }
       let value = _params[i].value
       if (typeof cmd?.calcul === 'function') {
         value = cmd.calcul(value)
@@ -179,6 +185,7 @@ jeedom.history.graphUpdate = function(_params) {
       for (const serie in jeedom.history.chart[chart].chart.series) {
         if (jeedom.history.chart[chart].chart.series[serie]?.options.id == cmd_id) {
           jeedom.history.chart[chart].chart.series[serie].addPoint([Date.now() + (-new Date().getTimezoneOffset() * 60 * 1000), value])
+          break
         }
       }
     }

--- a/core/js/history.class.js
+++ b/core/js/history.class.js
@@ -185,6 +185,7 @@ jeedom.history.graphUpdate = function(_params) {
       const serie = jeedom.history.chart[chart].chart.series.find(s => s?.options.id == cmd_id)
       if (serie) {
         serie.addPoint([Date.now() + (-new Date().getTimezoneOffset() * 60 * 1000), value])
+        jeedom.history.setAxisScales(chart, { redraw: true })
       }
     }
   }

--- a/core/js/jeedom.class.js
+++ b/core/js/jeedom.class.js
@@ -172,9 +172,6 @@ jeedom.init = function() {
 
   document.body.addEventListener('cmd::update', function(_event) {
     jeedom.cmd.refreshValue(_event.detail)
-  })
-
-  document.body.addEventListener('cmd::update', function(_event) {
     jeedom.history.graphUpdate(_event.detail)
   })
 


### PR DESCRIPTION
`graphUpdate` was adding real-time command values to charts unconditionally, without checking whether the chart was in a state where a raw value would actually make sense.

Three cases where this breaks the display:

- **Comparison mode**: the reference and comparison series share the same command id. A real-time update was applied to both, even though the comparison series represents a fixed past period and should never receive a "now" value.
- **Grouped charts** (`groupingType`, e.g. sum/average per hour or day): the historical series only contains already-aggregated points (computed server-side via SQL `GROUP BY`). A real-time update inserted a raw instantaneous value in the middle of these aggregates, creating an artificial spike or drop.
- **Derived/variation charts** (`derive`): the historical series shows the difference between consecutive values, also computed server-side. A real-time update inserted the raw absolute value instead of a variation, for the same kind of visual break.

This change skips the real-time update entirely for a chart/command combination in any of these three cases, instead of silently corrupting the display. It also means the matching series can safely be found with `.find()` and stop at the first match, now that a chart in comparison mode is excluded upfront (previously up to two series could share the same command id, so every series had to be checked).

Also merged the two separate `cmd::update` event listeners (`jeedom.cmd.refreshValue` and `jeedom.history.graphUpdate`) into one, found while investigating this.

Separately, `graphUpdate` never re-triggers the Y axis scale calculation after adding a real-time point. The axis min/max are computed once, when the chart is first drawn (`setAxisScales`), and stay fixed after that unless the user manually zooms or resets the view. A new value exceeding the original range was simply invisible, off the top or bottom of the chart. This only affects charts using the default axis scaling mode (`yAxisScaling`/`yAxisByUnit` both enabled, or either one alone); the remaining combination already uses soft bounds that auto-expand. The fix calls `setAxisScales` again after a successful real-time update.

**Known related issues, not addressed here:**

- **Past date range**: a real-time update still gets appended at the current instant even when the chart displays a fixed past window (outside comparison mode), visually breaking the axis. No reliable client-side signal was found to detect this without risking false positives on genuinely live charts.
- **Relative periods never refresh**: a chart drawn with a relative period (day/week/month) only fetches data once, on page load. Left open for a long time (e.g. a wall-mounted dashboard), it never re-queries a rolling window and keeps growing indefinitely via real-time pushes instead of showing a proper "last week" view. Affects both `desktop/js/view.js` and `desktop/js/plan.js`, and isn't specific to `graphUpdate`.
