### PR TITLE
Sanitize dynamic tooltip content before rendering it as HTML

### DIFF
--- a/desktop/common/js/utils.js
+++ b/desktop/common/js/utils.js
@@ -1016,6 +1016,18 @@ jeedomUtils.initDisplayAsTable = function() {
   }
 }
 
+jeedomUtils.sanitizeHTML = function(_html) {
+  const doc = new DOMParser().parseFromString(_html, 'text/html')
+  doc.querySelectorAll('script, style, iframe, object, embed, link, meta, form, base').forEach(el => el.remove())
+  doc.body.querySelectorAll('*').forEach(el => {
+    for (const attr of [...el.attributes]) {
+      if (attr.name.toLowerCase().startsWith('on')) {
+        el.removeAttribute(attr.name)
+      }
+    }
+  })
+  return doc.body.innerHTML
+}
 
 jeedomUtils.TOOLTIPSOPTIONS = {
   onTrigger: (instance, event) => {
@@ -1023,8 +1035,10 @@ jeedomUtils.TOOLTIPSOPTIONS = {
       instance.reference.setAttribute('data-title', instance.reference.getAttribute('title'))
       instance.reference.removeAttribute('title')
     }
-    if (instance.reference.getAttribute('data-title') == '') return false
-    instance.setContent(instance.reference.getAttribute('data-title'))
+    if (instance.reference.getAttribute('data-title') == '') {
+      return false
+    }
+    instance.setContent(jeedomUtils.sanitizeHTML(instance.reference.getAttribute('data-title')))
     return true
   },
   lazy: false,


### PR DESCRIPTION
Tooltips read the `title`/`data-title` attribute and render it with `allowHTML: true`. Since `getAttribute` decodes HTML entities before the string reaches Tippy's `setContent()`, a plugin displaying externally sourced data (a device name, an MQTT topic, a third-party API response) in a tooltip could not fully protect itself against XSS by escaping the value beforehand, the escaped entities get decoded back into live HTML at that point regardless. This closes #3188 without disabling `allowHTML`, which many existing tooltips across the core and plugins rely on for legitimate formatting (`<br>`, `<i>`, icons).

A `jeedomUtils.sanitizeHTML()` helper strips script-capable tags (`<script>`, `<iframe>`, `<object>`, `<embed>`, etc.) and any `on*` event handler attribute from the tooltip content right before it is displayed, while leaving normal formatting tags and attributes untouched. It is exposed on `jeedomUtils` rather than kept private so it can be reused for other sinks that render externally sourced HTML, if a similar need comes up later.