### PR TITLE
Fix widget size (zoom) breaking grid snap and containment in the design editor

### DIFF
--- a/desktop/js/plan.js
+++ b/desktop/js/plan.js
@@ -290,7 +290,11 @@ if (!jeeFrontEnd.plan) {
       }
       const node = domUtils.DOMparseHTML(_html)
       node.setAttribute('data-plan_id', _plan.id)
-      node.setAttribute('data-zoom', init(_plan.css.zoom, 1))
+      let zoom = parseFloat(_plan.css.zoom)
+      if (isNaN(zoom)) {
+        zoom = 1
+      }
+      node.setAttribute('data-zoom', zoom)
       node.addClass('jeedomAlreadyPosition', 'noResize')
 
       //set widget style:
@@ -299,8 +303,8 @@ if (!jeeFrontEnd.plan) {
       style['position'] = 'absolute'
       style['top'] = init(_plan.position.top, '10') + 'px'
       style['left'] = init(_plan.position.left, '10') + 'px'
-      if (init(_plan.css.zoom, 1) != 1) {
-        style['scale'] = init(_plan.css.zoom, 1)
+      if (zoom != 1) {
+        style['scale'] = zoom
       }
       style['transform-origin'] = '0 0'
 
@@ -565,16 +569,11 @@ if (!jeeFrontEnd.plan) {
           jeeFrontEnd.plan.draggables.push(draggie)
 
           draggie.on('dragStart', function(event, pointer) {
-
             //Is locked:
             if (this.element.hasClass('locked')) this.dragEnd()
 
             //Handle zoom:
-            this.containementBrect = document.querySelector('div.div_displayObject').getBoundingClientRect()
             this.zoomScale = parseFloat(this.element.getAttribute('data-zoom'))
-            if (this.zoomScale != 1) {
-              this.options.containment = false
-            }
 
             //Handle grid snap
             if (jeeFrontEnd.planEditOption.grid == 1) {
@@ -591,52 +590,32 @@ if (!jeeFrontEnd.plan) {
           draggie.on('dragMove', function(event, pointer, moveVector) {
             //Handle zoom move / containement:
             if (this.zoomScale != 1) {
-
               //Fix zoomed move:
               this.dragPoint.x = moveVector.x / this.zoomScale
               this.dragPoint.y = moveVector.y / this.zoomScale
 
-              //Check zoomed containement:
-              /*Doesn't work
-              var eRect = this.element.getBoundingClientRect()
-              console.log('eRect:',eRect)
-
-              console.log('position:', this.position)
-              console.log(this.dragPoint)
-
-              if (eRect.left < this.containementBrect.left) {
-                console.log('>>>>>>> OUT LEFT')
-                this.setPosition(this.position.x + this.dragPoint.x, this.position.y + this.dragPoint.y)
-                this.pointerDone()
-                this.dragEnd()
+              //Keep grid snap working when zoomed:
+              if (this.dragStep) {
+                this.dragPoint.x = getNearestMultiple(this.dragPoint.x, this.dragStep)
+                this.dragPoint.y = getNearestMultiple(this.dragPoint.y, this.dragStep)
               }
-              */
-            }
 
-            /*
-            if (this.zoomScale != 1) {
-              var matrix = window.getComputedStyle(this.element).getPropertyValue('transform')
-              var matrixValues = matrix.match(/matrix.*\((.+)\)/)[1].split(', ')
-              var tx = matrixValues[4]
-              var ty = matrixValues[5]
-              var txFactor = tx * this.zoomScale
-              var tyFactor = ty * this.zoomScale
-              var deltaX = this.element.offsetLeft - (tx * this.zoomScale)
-              if ((this.element.offsetLeft + txFactor) < 0) this.dragEnd()
-              if ((this.element.offsetTop + tyFactor) < 0) this.dragEnd()
-
-              var realWidth = this.element.clientWidth * this.zoomScale
-              var realRight = this.element.getBoundingClientRect().left + realWidth
-
-              console.log('dragMove realRight:', realRight, 'realWidth:', realWidth, this.containementBrect)
-
-              //Test ok, not solution--
-              if (realRight >= this.containementBrect.right) {
-                this.dragEnd()
+              //Keep the widget within the design bounds (containSize/relativeStartPosition ignore the zoom, correct for it here):
+              if (this.containSize) {
+                const overflowX = this.element.offsetWidth * (this.zoomScale - 1)
+                const overflowY = this.element.offsetHeight * (this.zoomScale - 1)
+                const minX = -this.relativeStartPosition.x / this.zoomScale
+                const minY = -this.relativeStartPosition.y / this.zoomScale
+                const maxX = (this.containSize.width - overflowX) / this.zoomScale
+                const maxY = (this.containSize.height - overflowY) / this.zoomScale
+                this.dragPoint.x = Math.max(minX, Math.min(maxX, this.dragPoint.x))
+                this.dragPoint.y = Math.max(minY, Math.min(maxY, this.dragPoint.y))
               }
-            }
-            */
 
+              //Final position must match what was shown during the drag, not Draggabilly's own (zoom-unaware) calculation:
+              this.position.x = this.startPosition.x + this.dragPoint.x * this.zoomScale
+              this.position.y = this.startPosition.y + this.dragPoint.y * this.zoomScale
+            }
           })
 
           draggie.on('dragEnd', function(event, pointer) {
@@ -698,8 +677,33 @@ if (!jeeFrontEnd.plan) {
 
             element.querySelector('.camera')?.triggerEvent('resize')
           },
-          stop: function(event, ui) {
+          stop: function(event, element) {
             jeeFrontEnd.modifyWithoutSave = true
+
+            //Bring the widget back within the design bounds if the resize left it overflowing (zoom is not accounted for during the live resize):
+            if (this.zoomScale != 1) {
+              const containRect = document.querySelector('.div_displayObject').getBoundingClientRect()
+              const elemRect = element.getBoundingClientRect()
+              const overflowLeft = containRect.left - elemRect.left
+              const overflowTop = containRect.top - elemRect.top
+              const overflowRight = elemRect.right - containRect.right
+              const overflowBottom = elemRect.bottom - containRect.bottom
+
+              if (overflowLeft > 0) {
+                element.style.left = element.offsetLeft + overflowLeft + 'px'
+                element.style.width = element.offsetWidth - overflowLeft / this.zoomScale + 'px'
+              }
+              if (overflowTop > 0) {
+                element.style.top = element.offsetTop + overflowTop + 'px'
+                element.style.height = element.offsetHeight - overflowTop / this.zoomScale + 'px'
+              }
+              if (overflowRight > 0) {
+                element.style.width = element.offsetWidth - overflowRight / this.zoomScale + 'px'
+              }
+              if (overflowBottom > 0) {
+                element.style.height = element.offsetHeight - overflowBottom / this.zoomScale + 'px'
+              }
+            }
             //jeeP.savePlan(false, false)
           },
         })

--- a/desktop/js/plan.js
+++ b/desktop/js/plan.js
@@ -168,8 +168,8 @@ if (!jeeFrontEnd.plan) {
         success: function(data) {
           jeedom.cmd.resetUpdateFunction()
           jeeFrontEnd.plan.planContainer.empty().insertAdjacentHTML('beforeend', '<div id="div_grid" class="container-fluid" style="display:none;"></div>')
-          document.querySelectorAll('.style_plan_specific').remove();
-          Object.assign(jeeFrontEnd.plan.planContainer.style, {height:"auto", width:"auto"})
+          document.querySelectorAll('.style_plan_specific').remove()
+          Object.assign(jeeFrontEnd.plan.planContainer.style, { height: "auto", width: "auto" })
           //general design configuration:
           if (isset(data.image)) {
             jeeFrontEnd.plan.planContainer.insertAdjacentHTML('beforeend', data.image)
@@ -250,7 +250,7 @@ if (!jeeFrontEnd.plan) {
               jeeP.initEditOption(jeeFrontEnd.planEditOption.state)
               jeedomUtils.initReportMode()
               jeedomUtils.initTooltips()
-              window.scrollTo({top: 0, behavior: "smooth"})
+              window.scrollTo({ top: 0, behavior: "smooth" })
               jeeFrontEnd.plan.setGraphResizes()
               jeeFrontEnd.modifyWithoutSave = false
             }
@@ -511,19 +511,19 @@ if (!jeeFrontEnd.plan) {
     },
     getElementInfo: function(_element) {
       if (_element.length) _element = _element[0]
-      if (_element.hasClass('eqLogic-widget')) { return {type: 'eqLogic', id: _element.getAttribute('data-eqLogic_id')} }
-      if (_element.hasClass('cmd-widget')) { return {type: 'cmd', id: _element.getAttribute('data-cmd_id')} }
-      if (_element.hasClass('scenario-widget')) { return {type: 'scenario', id: _element.getAttribute('data-scenario_id')} }
-      if (_element.hasClass('plan-link-widget')) { return {type: 'plan', id: _element.getAttribute('data-link_id')} }
-      if (_element.hasClass('view-link-widget')) { return {type: 'view', id: _element.getAttribute('data-link_id')} }
-      if (_element.hasClass('graph-widget')) { return {type: 'graph', id: _element.getAttribute('data-graph_id')} }
-      if (_element.hasClass('text-widget')) { return {type: 'text', id: _element.getAttribute('data-text_id')} }
-      if (_element.hasClass('image-widget')) { return {type: 'image', id: _element.getAttribute('data-image_id')} }
-      if (_element.hasClass('zone-widget')) { return {type: 'zone', id: _element.getAttribute('data-zone_id')} }
-      if (_element.hasClass('summary-widget')) { return {type: 'summary', id: _element.getAttribute('data-summary_id')} }
+      if (_element.hasClass('eqLogic-widget')) { return { type: 'eqLogic', id: _element.getAttribute('data-eqLogic_id') } }
+      if (_element.hasClass('cmd-widget')) { return { type: 'cmd', id: _element.getAttribute('data-cmd_id') } }
+      if (_element.hasClass('scenario-widget')) { return { type: 'scenario', id: _element.getAttribute('data-scenario_id') } }
+      if (_element.hasClass('plan-link-widget')) { return { type: 'plan', id: _element.getAttribute('data-link_id') } }
+      if (_element.hasClass('view-link-widget')) { return { type: 'view', id: _element.getAttribute('data-link_id') } }
+      if (_element.hasClass('graph-widget')) { return { type: 'graph', id: _element.getAttribute('data-graph_id') } }
+      if (_element.hasClass('text-widget')) { return { type: 'text', id: _element.getAttribute('data-text_id') } }
+      if (_element.hasClass('image-widget')) { return { type: 'image', id: _element.getAttribute('data-image_id') } }
+      if (_element.hasClass('zone-widget')) { return { type: 'zone', id: _element.getAttribute('data-zone_id') } }
+      if (_element.hasClass('summary-widget')) { return { type: 'summary', id: _element.getAttribute('data-summary_id') } }
     },
     //Events setter
-    setGraphResizes: function () {
+    setGraphResizes: function() {
       for (const obs of this.resizeObservers) {
         obs.disconnect()
       }
@@ -690,10 +690,10 @@ if (!jeeFrontEnd.plan) {
             }
             //Handle snap:
             if (this.dragStep) {
-              element.style.width = getNearestMultiple(element.offsetWidth,  this.dragStep) + 'px'
-              element.style.height = getNearestMultiple(element.offsetHeight,  this.dragStep) + 'px'
-              element.style.top = getNearestMultiple(element.offsetTop,  this.dragStep) + 'px'
-              element.style.left = getNearestMultiple(element.offsetLeft,  this.dragStep) + 'px'
+              element.style.width = getNearestMultiple(element.offsetWidth, this.dragStep) + 'px'
+              element.style.height = getNearestMultiple(element.offsetHeight, this.dragStep) + 'px'
+              element.style.top = getNearestMultiple(element.offsetTop, this.dragStep) + 'px'
+              element.style.left = getNearestMultiple(element.offsetLeft, this.dragStep) + 'px'
             }
 
             element.querySelector('.camera')?.triggerEvent('resize')
@@ -706,7 +706,7 @@ if (!jeeFrontEnd.plan) {
 
         jeeP.elementContexMenu.enable()
       } else { //Leave Edit mode
-        if(jeeFrontEnd.planEditOption.state === true){
+        if (jeeFrontEnd.planEditOption.state === true) {
           jeeP.savePlan(false, false)
         }
         if (jeeP.elementContexMenu) {
@@ -731,7 +731,7 @@ if (!jeeFrontEnd.plan) {
         jeeFrontEnd.plan.draggables = []
         try {
           jeedomUtils.enableTooltips()
-        } catch (e) {}
+        } catch (e) { }
         document.getElementById('div_grid').unseen()
       }
     },
@@ -827,10 +827,10 @@ if (jeedomUtils.userDevice.type == 'desktop' && user_isAdmin == 1) {
       }
     },
     items: {
-      title : {
+      title: {
         name: '{{Menu}}',
         icon: 'fas fa-bars',
-        disabled:true
+        disabled: true
       },
       parameter: {
         name: '{{Paramètres d\'affichage}}',
@@ -886,7 +886,7 @@ if (jeedomUtils.userDevice.type == 'desktop' && user_isAdmin == 1) {
               },
               contentUrl: 'index.php?v=d&modal=cmd.graph.select',
               callback: function() {
-                document.querySelectorAll('#table_addViewData tbody tr .enable').forEach(_check => { _check.checked = false})
+                document.querySelectorAll('#table_addViewData tbody tr .enable').forEach(_check => { _check.checked = false })
                 const options = json_decode(dom_el.querySelector('.graphOptions').jeeValue())
                 jeeFrontEnd.md_cmdGraphSelect.displayOptions(options)
               }
@@ -975,10 +975,10 @@ if (jeedomUtils.userDevice.type == 'desktop' && user_isAdmin == 1) {
       }
     },
     items: {
-      title : {
+      title: {
         name: '{{Menu}}',
         icon: 'fas fa-bars',
-        disabled:true
+        disabled: true
       },
       fold1: {
         name: "{{Designs}}",
@@ -1307,15 +1307,15 @@ if (jeedomUtils.userDevice.type == 'desktop' && user_isAdmin == 1) {
           return !getBool(this.getAttribute('data-jeeFrontEnd.planEditOption.state'))
         },
         callback: function(key, opt) {
-          let name = "";
-          for(const i in jeephp2js.planHeader){
-            if(jeephp2js.planHeader[i].id == jeephp2js.planHeader_id){
-              name = jeephp2js.planHeader[i].name+ " copie";
+          let name = ""
+          for (const i in jeephp2js.planHeader) {
+            if (jeephp2js.planHeader[i].id == jeephp2js.planHeader_id) {
+              name = jeephp2js.planHeader[i].name + " copie"
             }
           }
           jeeDialog.prompt({
-            title : "{{Nom de la copie du design ?}}",
-            value : name,
+            title: "{{Nom de la copie du design ?}}",
+            value: name,
           }, function(result) {
             if (result !== null) {
               jeeP.savePlan(false, false)
@@ -1368,7 +1368,7 @@ jeedomUI.setEqSignals()
 jeedomUI.setHistoryModalHandler()
 
 //Handle zones:
-document.body.registerEvent('click', function (event) {
+document.body.registerEvent('click', function(event) {
   if (!jeeFrontEnd.planEditOption.state) {
     if ((!event.target.hasClass('.zone-widget.zoneEqLogic') && event.target.closest('.zone-widget.zoneEqLogic') == null) && (!event.target.hasClass('.zone-widget.zoneEqLogicOnFly') && event.target.closest('.zone-widget.zoneEqLogicOnFly') == null)) {
       document.querySelectorAll('.zone-widget.zoneEqLogic').forEach(function(_zone) {
@@ -1461,7 +1461,7 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
     }
   }
 
-}, {buble: true})
+}, { buble: true })
 
 document.querySelector('.div_displayObject').addEventListener('mouseenter', function(event) {
   if (event.target.matches('.zone-widget.zoneEqLogic.zoneEqLogicOnFly')) {
@@ -1487,7 +1487,7 @@ document.querySelector('.div_displayObject').addEventListener('mouseenter', func
     }
     return
   }
-}, {capture: true})
+}, { capture: true })
 
 document.querySelector('.div_displayObject').addEventListener('mouseleave', function(event) {
   if (event.target.matches('.zone-widget.zoneEqLogic.zoneEqLogicOnFly')) {
@@ -1498,13 +1498,13 @@ document.querySelector('.div_displayObject').addEventListener('mouseleave', func
     }
     return
   }
-}, {capture: true})
+}, { capture: true })
 
 //Event for App Mobile:
 document.body.addEventListener('jeeObject::summary::update', function(_event) {
   for (const i in _event.detail) {
-    if(isset(_event.detail[i].force) && _event.detail[i].force == 1) continue
-    if(_event.detail[i].object_id == 'global') {
+    if (isset(_event.detail[i].force) && _event.detail[i].force == 1) continue
+    if (_event.detail[i].object_id == 'global') {
       /* SEND UPDATE SUMMARY TO APP */
       jeedom.appMobile.postToApp('updateSummary', _event.detail[i].keys)
     }
@@ -1513,7 +1513,7 @@ document.body.addEventListener('jeeObject::summary::update', function(_event) {
 
 //back to mobile home with three fingers on mobile:
 if (user_isAdmin == 1 && jeedomUtils.userDevice.type != 'desktop') {
-  document.body.registerEvent('touchstart', function (event) {
+  document.body.registerEvent('touchstart', function(event) {
     if (event.touches.length == 3) {
       event.preventDefault()
       event.stopPropagation()

--- a/desktop/modal/plan.configure.php
+++ b/desktop/modal/plan.configure.php
@@ -71,7 +71,6 @@ sendVarToJS('jeephp2js.md_planConfigure_Id', $plan->getId());
         </label>
         <div class="col-lg-2">
           <input type="text" class="planAttr form-control" data-l1key="css" data-l2key="zoom" placeholder="1.2" />
-          <sup class="danger"><i class="fas fa-exclamation-circle" title="{{Attention : cette option crée des problèmes de placement sur les bords du design et désactive la grille aimantée pour l'équipement en question}}"></i></sup>
         </div>
       </div>
       <legend>{{Spécifique}}</legend>

--- a/desktop/modal/plan.configure.php
+++ b/desktop/modal/plan.configure.php
@@ -95,7 +95,7 @@ sendVarToJS('jeephp2js.md_planConfigure_Id', $plan->getId());
       <div class="form-group link_type link_image display_mode display_mode_image">
         <div class="col-lg-4"></div>
         <div class="col-lg-4 planImg">
-          <img src="core/img/no_image.gif" width="240px" height="auto"/>
+          <img src="core/img/no_image.gif" width="240px" height="auto" />
         </div>
       </div>
       <div class="form-group link_type link_image display_mode display_mode_camera" style="display:none;">
@@ -451,192 +451,16 @@ sendVarToJS('jeephp2js.md_planConfigure_Id', $plan->getId());
 </div>
 
 <script>
-if (!jeeFrontEnd.md_planConfigure) {
-  jeeFrontEnd.md_planConfigure = {
-    plan_configure_plan: null,
-    editor: [],
-    init: function() {
-    },
-    postInit: function() {
-      //load and set settings (call before any change event set):
-      if (isset(jeephp2js.md_planConfigure_Id) && jeephp2js.md_planConfigure_Id != '') {
-        jeedom.plan.byId({
-          id: jeephp2js.md_planConfigure_Id,
-          error: function(error) {
-            jeedomUtils.showAlert({
-              attachTo: jeeDialog.get('#md_planConfigure', 'dialog'),
-              message: error.message,
-              level: 'danger'
-            })
-          },
-          success: function(plan) {
-            jeeFrontEnd.md_planConfigure.plan_configure_plan = plan
-            document.querySelectorAll('.link_type:not(.link_' + plan.plan.link_type + ')').remove()
-            document.getElementById('fd_planConfigure').setJeeValues(plan.plan, '.planAttr')
-            if (isset(plan.plan.configuration.action_on)) {
-              for (var i in plan.plan.configuration.action_on) {
-                jeeFrontEnd.md_planConfigure.addActionPlanConfigure(plan.plan.configuration.action_on[i], 'on')
-              }
-            }
-            if (isset(plan.plan.configuration.action_off)) {
-              for (var i in plan.plan.configuration.action_off) {
-                jeeFrontEnd.md_planConfigure.addActionPlanConfigure(plan.plan.configuration.action_off[i], 'off')
-              }
-            }
-            if (isset(plan.plan.configuration.action_other)) {
-              for (var i in plan.plan.configuration.action_other) {
-                jeeFrontEnd.md_planConfigure.addActionPlanConfigure(plan.plan.configuration.action_other[i], 'other')
-              }
-            }
-            if (plan.plan.link_type == 'image' && plan.plan.display.path != undefined) {
-              document.querySelector('#fd_planConfigure .planImg img').seen().setAttribute('src', plan.plan.display.path)
-            }
-            if (plan.plan.link_type == 'text') {
-              var code = document.querySelector('.planAttr[data-l1key="display"][data-l2key="text"]')
-              if (code.getAttribute('id') == undefined) {
-                code.uniqueId()
-                var id = code.getAttribute('id')
-                setTimeout(function() {
-                  jeeFrontEnd.md_planConfigure.editor[id] = CodeMirror.fromTextArea(document.getElementById(id), {
-                    lineNumbers: true,
-                    mode: 'htmlmixed',
-                    matchBrackets: true
-                  })
-                }, 1)
-              }
-            }
-          }
-        })
-      }
-
-      this.setPlanUI_Events()
-      this.setFileUpload()
-      jeedomUtils.setCheckContextMenu()
-    },
-    setFileUpload: function() {
-      new jeeFileUploader({
-        fileInput: document.getElementById('bt_uploadImagePlan'),
-        replaceFileInput: false,
-        url: 'core/ajax/plan.ajax.php?action=uploadImagePlan&id=' + jeephp2js.md_planConfigure_Id,
-        dataType: 'json',
-        done: function(e, data) {
-          if (data.result.state != 'ok') {
-            jeedomUtils.showAlert({
-              attachTo: jeeDialog.get('#md_planConfigure', 'dialog'),
-              message: data.result.result,
-              level: 'danger'
-            })
-            return
-          }
-          if (isset(data.result.result.filepath)) {
-            var filePath = data.result.result.filepath
-            filePath = '/data/plan/' + filePath.split('/data/plan/')[1]
-            document.querySelector('.planImg img').seen().setAttribute('src', filePath)
-          } else {
-            document.querySelector('.planImg img').unseen()
-          }
-        }
-      })
-    },
-    addActionPlanConfigure: function(_action, _type) {
-      if (!isset(_action)) {
-        _action = {}
-      }
-      if (!isset(_action.options)) {
-        _action.options = {}
-      }
-      var div = '<div class="expression ' + _type + '">'
-      div += '<div class="form-group ">'
-      div += '<label class="col-sm-1 control-label">{{Action}}</label>'
-      div += '<div class="col-sm-4">'
-      div += '<div class="input-group">'
-      div += '<span class="input-group-btn">'
-      div += '<a class="btn btn-default bt_removeAction btn-sm roundedLeft" data-type="' + _type + '"><i class="fas fa-minus-circle"></i></a>'
-      div += '</span>'
-      div += '<input class="expressionAttr form-control input-sm cmdAction" data-l1key="cmd" data-type="' + _type + '" />'
-      div += '<span class="input-group-btn">'
-      div += '<a class="btn btn-default btn-sm bt_selectOtherActionExpression" data-type="' + _type + '" title="{{Sélectionner un mot-clé}}"><i class="fas fa-tasks"></i></a>'
-      div += '<a class="btn btn-default btn-sm listCmdAction roundedRight" data-type="' + _type + '"><i class="fas fa-list-alt"></i></a>'
-      div += '</span>'
-      div += '</div>'
-      div += '</div>'
-      div += '<div class="col-sm-7 actionOptions">'
-      div += jeedom.cmd.displayActionOption(init(_action.cmd, ''), _action.options)
-      div += '</div>'
-      div += '</div>'
-
-      let newDiv = document.createElement('div')
-      newDiv.html(div)
-      newDiv.setJeeValues(_action, '.expressionAttr')
-      document.querySelector('#div_planConfigureAction' + _type).appendChild(newDiv)
-      newDiv.replaceWith(...newDiv.childNodes)
-      jeedomUtils.taAutosize()
-    },
-    setPlanUI_Events: function() {
-      document.getElementById('deferredEvents').addEventListener('change', function(event) {
-        var _target = null
-        //background : not default if transparent:
-        if (_target = event.target.closest('.planAttr[data-l1key="display"][data-l2key="background-transparent"]')) {
-          if (_target.jeeValue() == 1) {
-            document.querySelector('.planAttr[data-l1key="display"][data-l2key="background-defaut"]').checked = false
-          }
-          return
-        }
-        //background: not default/transparent if colored:
-        if (_target = event.target.closest('.planAttr[data-l1key="css"][data-l2key="background-color"]')) {
-          if (_target.jeeValue() != '#000000') {
-            document.querySelector('.planAttr[data-l1key="display"][data-l2key="background-defaut"]').checked = false
-            document.querySelector('.planAttr[data-l1key="display"][data-l2key="background-transparent"]').checked = false
-          }
-          return
-        }
-        //background: not transparent if default:
-        if (_target = event.target.closest('.planAttr[data-l1key="display"][data-l2key="background-defaut"]')) {
-          if (_target.jeeValue() == 1) {
-            document.querySelector('.planAttr[data-l1key="display"][data-l2key="background-transparent"]').checked = false
-          }
-          return
-        }
-        //text: not default if colored:
-        if (_target = event.target.closest('.planAttr[data-l1key="display"][data-l2key="background-defaut"]')) {
-          if (_target.jeeValue() != '#000000') {
-            document.querySelector('.planAttr[data-l1key="display"][data-l2key="color-defaut"]').checked = false
-          }
-          return
-        }
-      })
-    },
-    save: function() {
-      var plans = document.getElementById('fd_planConfigure').getJeeValues('.planAttr')
-      if (plans[0].link_type == 'text') {
-        var id = document.querySelector('.planAttr[data-l1key=display][data-l2key=text]').getAttribute('id')
-        if (id != undefined && isset(jeeFrontEnd.md_planConfigure.editor[id])) {
-          plans[0].display.text = jeeFrontEnd.md_planConfigure.editor[id].getValue()
-        }
-      }
-      if (!isset(plans[0].configuration)) {
-        plans[0].configuration = {}
-      }
-      plans[0].configuration.action_on = document.getElementById('div_planConfigureActionon')?.querySelectorAll('.on').getJeeValues('.expressionAttr')
-      plans[0].configuration.action_off = document.getElementById('div_planConfigureActionoff')?.querySelectorAll('.off').getJeeValues('.expressionAttr')
-      plans[0].configuration.action_other = document.getElementById('div_planConfigureActionother')?.querySelectorAll('.other').getJeeValues('.expressionAttr')
-      jeedom.plan.save({
-        plans: plans,
-        error: function(error) {
-          jeedomUtils.showAlert({
-            attachTo: jeeDialog.get('#md_planConfigure', 'dialog'),
-            message: error.message,
-            level: 'danger'
-          })
-        },
-        success: function() {
-          jeedomUtils.showAlert({
-            attachTo: jeeDialog.get('#md_planConfigure', 'dialog'),
-            message: '{{Design sauvegardé}}',
-            level: 'success'
-          })
+  if (!jeeFrontEnd.md_planConfigure) {
+    jeeFrontEnd.md_planConfigure = {
+      plan_configure_plan: null,
+      editor: [],
+      init: function() {},
+      postInit: function() {
+        //load and set settings (call before any change event set):
+        if (isset(jeephp2js.md_planConfigure_Id) && jeephp2js.md_planConfigure_Id != '') {
           jeedom.plan.byId({
-            id: plans[0].id,
+            id: jeephp2js.md_planConfigure_Id,
             error: function(error) {
               jeedomUtils.showAlert({
                 attachTo: jeeDialog.get('#md_planConfigure', 'dialog'),
@@ -645,139 +469,314 @@ if (!jeeFrontEnd.md_planConfigure) {
               })
             },
             success: function(plan) {
-              if (jeeFrontEnd.md_planConfigure.plan_configure_plan.plan.link_type == 'summary' && jeeFrontEnd.md_planConfigure.plan_configure_plan !== null && jeeFrontEnd.md_planConfigure.plan_configure_plan.plan.link_id) {
-                document.querySelector('.div_displayObject .summary-widget[data-summary_id="' + jeeFrontEnd.md_planConfigure.plan_configure_plan.plan.link_id + '"]').remove()
+              jeeFrontEnd.md_planConfigure.plan_configure_plan = plan
+              document.querySelectorAll('.link_type:not(.link_' + plan.plan.link_type + ')').remove()
+              document.getElementById('fd_planConfigure').setJeeValues(plan.plan, '.planAttr')
+              if (isset(plan.plan.configuration.action_on)) {
+                for (var i in plan.plan.configuration.action_on) {
+                  jeeFrontEnd.md_planConfigure.addActionPlanConfigure(plan.plan.configuration.action_on[i], 'on')
+                }
               }
-              jeeFrontEnd.plan.displayObject(plan.plan, plan.html, false)
+              if (isset(plan.plan.configuration.action_off)) {
+                for (var i in plan.plan.configuration.action_off) {
+                  jeeFrontEnd.md_planConfigure.addActionPlanConfigure(plan.plan.configuration.action_off[i], 'off')
+                }
+              }
+              if (isset(plan.plan.configuration.action_other)) {
+                for (var i in plan.plan.configuration.action_other) {
+                  jeeFrontEnd.md_planConfigure.addActionPlanConfigure(plan.plan.configuration.action_other[i], 'other')
+                }
+              }
+              if (plan.plan.link_type == 'image' && plan.plan.display.path != undefined) {
+                document.querySelector('#fd_planConfigure .planImg img').seen().setAttribute('src', plan.plan.display.path)
+              }
+              if (plan.plan.link_type == 'text') {
+                var code = document.querySelector('.planAttr[data-l1key="display"][data-l2key="text"]')
+                if (code.getAttribute('id') == undefined) {
+                  code.uniqueId()
+                  var id = code.getAttribute('id')
+                  setTimeout(function() {
+                    jeeFrontEnd.md_planConfigure.editor[id] = CodeMirror.fromTextArea(document.getElementById(id), {
+                      lineNumbers: true,
+                      mode: 'htmlmixed',
+                      matchBrackets: true
+                    })
+                  }, 1)
+                }
+              }
             }
           })
         }
-      })
-    },
-  }
-}
-(function() {// Self Isolation!
-  var jeeM = jeeFrontEnd.md_planConfigure
-  jeeM.init()
 
-  /*Events delegations
-  */
-  document.getElementById('md_planConfigure').addEventListener('click', function(event) {
-    var _target = null
-    if (_target = event.target.closest('.bt_planConfigurationAction')) {
-      jeeFrontEnd.md_planConfigure.addActionPlanConfigure({}, _target.getAttribute('data-type'))
-      return
-    }
-
-    if (_target = event.target.closest('.bt_removeAction')) {
-      _target.closest('.' + _target.getAttribute('data-type')).remove()
-      return
-    }
-
-    if (_target = event.target.closest('.listCmdAction')) {
-      var type = _target.getAttribute('data-type')
-      var el = _target.closest('.' + type).querySelector('.expressionAttr[data-l1key="cmd"]')
-      jeedom.cmd.getSelectModal({
-        cmd: {
-          type: 'action'
-        }
-      }, function(result) {
-        el.jeeValue(result.human)
-        jeedom.cmd.displayActionOption(result.human, '', function(html) {
-          el.closest('.' + type).querySelector('.actionOptions').html(html)
-          jeedomUtils.taAutosize()
+        this.setPlanUI_Events()
+        this.setFileUpload()
+        jeedomUtils.setCheckContextMenu()
+      },
+      setFileUpload: function() {
+        new jeeFileUploader({
+          fileInput: document.getElementById('bt_uploadImagePlan'),
+          replaceFileInput: false,
+          url: 'core/ajax/plan.ajax.php?action=uploadImagePlan&id=' + jeephp2js.md_planConfigure_Id,
+          dataType: 'json',
+          done: function(e, data) {
+            if (data.result.state != 'ok') {
+              jeedomUtils.showAlert({
+                attachTo: jeeDialog.get('#md_planConfigure', 'dialog'),
+                message: data.result.result,
+                level: 'danger'
+              })
+              return
+            }
+            if (isset(data.result.result.filepath)) {
+              var filePath = data.result.result.filepath
+              filePath = '/data/plan/' + filePath.split('/data/plan/')[1]
+              document.querySelector('.planImg img').seen().setAttribute('src', filePath)
+            } else {
+              document.querySelector('.planImg img').unseen()
+            }
+          }
         })
-      })
-      return
-    }
-
-    if (_target = event.target.closest('.bt_selectOtherActionExpression')) {
-      var expression = _target.closest('.expression')
-      jeedom.getSelectActionModal({
-        scenario: true
-      }, function(result) {
-        expression.querySelector('.expressionAttr[data-l1key="cmd"]').jeeValue(result.human)
-        jeedom.cmd.displayActionOption(result.human, '', function(html) {
-          expression.querySelector('.actionOptions').html(html)
-          jeedomUtils.taAutosize()
-        })
-      })
-      return
-    }
-
-    if (_target = event.target.closest('#bt_planConfigureAddEqLogic')) {
-      jeedom.eqLogic.getSelectModal({}, function(result) {
-        _target.parentNode.parentNode.querySelector('.planAttr[data-l1key="configuration"][data-l2key="eqLogic"]').jeeValue(result.human)
-      })
-      return
-    }
-
-    if (_target = event.target.closest('#bt_planConfigureSelectCamera')) {
-      jeedom.eqLogic.getSelectModal({
-        eqLogic: {
-          eqType_name: 'camera'
+      },
+      addActionPlanConfigure: function(_action, _type) {
+        if (!isset(_action)) {
+          _action = {}
         }
-      }, function(result) {
-        _target.parentNode.parentNode.querySelector('.planAttr[data-l1key="configuration"][data-l2key="camera"]').jeeValue(result.human)
-      })
-      return
-    }
-
-    if (_target = event.target.closest('#bt_planConfigureSelectBinary')) {
-      jeedom.cmd.getSelectModal({
-        cmd: {
-          type: 'info'
+        if (!isset(_action.options)) {
+          _action.options = {}
         }
-      }, function(result) {
-        _target.parentNode.parentNode.querySelector('.planAttr[data-l1key="configuration"][data-l2key="binary_info"]').jeeValue(result.human)
-      })
-      return
-    }
+        var div = '<div class="expression ' + _type + '">'
+        div += '<div class="form-group ">'
+        div += '<label class="col-sm-1 control-label">{{Action}}</label>'
+        div += '<div class="col-sm-4">'
+        div += '<div class="input-group">'
+        div += '<span class="input-group-btn">'
+        div += '<a class="btn btn-default bt_removeAction btn-sm roundedLeft" data-type="' + _type + '"><i class="fas fa-minus-circle"></i></a>'
+        div += '</span>'
+        div += '<input class="expressionAttr form-control input-sm cmdAction" data-l1key="cmd" data-type="' + _type + '" />'
+        div += '<span class="input-group-btn">'
+        div += '<a class="btn btn-default btn-sm bt_selectOtherActionExpression" data-type="' + _type + '" title="{{Sélectionner un mot-clé}}"><i class="fas fa-tasks"></i></a>'
+        div += '<a class="btn btn-default btn-sm listCmdAction roundedRight" data-type="' + _type + '"><i class="fas fa-list-alt"></i></a>'
+        div += '</span>'
+        div += '</div>'
+        div += '</div>'
+        div += '<div class="col-sm-7 actionOptions">'
+        div += jeedom.cmd.displayActionOption(init(_action.cmd, ''), _action.options)
+        div += '</div>'
+        div += '</div>'
 
-    if (_target = event.target.closest('#bt_chooseIcon')) {
-      jeedomUtils.chooseIcon(function(_icon) {
-        document.querySelector('.planAttr[data-l1key="display"][data-l2key="icon"]').innerHTML = _icon
-      })
-      return
-    }
-
-    if (_target = event.target.closest('#bt_saveConfigurePlan')) {
-      var check = document.querySelector('input[data-l2key="font-size"]')
-      if (check && check.value != '' && !check.value.endsWith('%')) {
-        check.value = check.value + '%'
-      }
-      jeeFrontEnd.md_planConfigure.save()
-      return
-    }
-  })
-
-  document.getElementById('md_planConfigure').addEventListener('focusout', function(event) {
-    var _target = null
-    if (_target = event.target.closest('.expressionAttr[data-l1key="cmd"]')) {
-      var type = _target.getAttribute('data-type')
-      jeedom.cmd.displayActionOption(_target.jeeValue(), '', function(html) {
-        _target.closest('.' + type).querySelector('.actionOptions').html(html)
+        let newDiv = document.createElement('div')
+        newDiv.html(div)
+        newDiv.setJeeValues(_action, '.expressionAttr')
+        document.querySelector('#div_planConfigureAction' + _type).appendChild(newDiv)
+        newDiv.replaceWith(...newDiv.childNodes)
         jeedomUtils.taAutosize()
-      })
-      return
+      },
+      setPlanUI_Events: function() {
+        document.getElementById('deferredEvents').addEventListener('change', function(event) {
+          var _target = null
+          //background : not default if transparent:
+          if (_target = event.target.closest('.planAttr[data-l1key="display"][data-l2key="background-transparent"]')) {
+            if (_target.jeeValue() == 1) {
+              document.querySelector('.planAttr[data-l1key="display"][data-l2key="background-defaut"]').checked = false
+            }
+            return
+          }
+          //background: not default/transparent if colored:
+          if (_target = event.target.closest('.planAttr[data-l1key="css"][data-l2key="background-color"]')) {
+            if (_target.jeeValue() != '#000000') {
+              document.querySelector('.planAttr[data-l1key="display"][data-l2key="background-defaut"]').checked = false
+              document.querySelector('.planAttr[data-l1key="display"][data-l2key="background-transparent"]').checked = false
+            }
+            return
+          }
+          //background: not transparent if default:
+          if (_target = event.target.closest('.planAttr[data-l1key="display"][data-l2key="background-defaut"]')) {
+            if (_target.jeeValue() == 1) {
+              document.querySelector('.planAttr[data-l1key="display"][data-l2key="background-transparent"]').checked = false
+            }
+            return
+          }
+          //text: not default if colored:
+          if (_target = event.target.closest('.planAttr[data-l1key="display"][data-l2key="background-defaut"]')) {
+            if (_target.jeeValue() != '#000000') {
+              document.querySelector('.planAttr[data-l1key="display"][data-l2key="color-defaut"]').checked = false
+            }
+            return
+          }
+        })
+      },
+      save: function() {
+        var plans = document.getElementById('fd_planConfigure').getJeeValues('.planAttr')
+        if (plans[0].link_type == 'text') {
+          var id = document.querySelector('.planAttr[data-l1key=display][data-l2key=text]').getAttribute('id')
+          if (id != undefined && isset(jeeFrontEnd.md_planConfigure.editor[id])) {
+            plans[0].display.text = jeeFrontEnd.md_planConfigure.editor[id].getValue()
+          }
+        }
+        if (!isset(plans[0].configuration)) {
+          plans[0].configuration = {}
+        }
+        plans[0].configuration.action_on = document.getElementById('div_planConfigureActionon')?.querySelectorAll('.on').getJeeValues('.expressionAttr')
+        plans[0].configuration.action_off = document.getElementById('div_planConfigureActionoff')?.querySelectorAll('.off').getJeeValues('.expressionAttr')
+        plans[0].configuration.action_other = document.getElementById('div_planConfigureActionother')?.querySelectorAll('.other').getJeeValues('.expressionAttr')
+        jeedom.plan.save({
+          plans: plans,
+          error: function(error) {
+            jeedomUtils.showAlert({
+              attachTo: jeeDialog.get('#md_planConfigure', 'dialog'),
+              message: error.message,
+              level: 'danger'
+            })
+          },
+          success: function() {
+            jeedomUtils.showAlert({
+              attachTo: jeeDialog.get('#md_planConfigure', 'dialog'),
+              message: '{{Design sauvegardé}}',
+              level: 'success'
+            })
+            jeedom.plan.byId({
+              id: plans[0].id,
+              error: function(error) {
+                jeedomUtils.showAlert({
+                  attachTo: jeeDialog.get('#md_planConfigure', 'dialog'),
+                  message: error.message,
+                  level: 'danger'
+                })
+              },
+              success: function(plan) {
+                if (jeeFrontEnd.md_planConfigure.plan_configure_plan.plan.link_type == 'summary' && jeeFrontEnd.md_planConfigure.plan_configure_plan !== null && jeeFrontEnd.md_planConfigure.plan_configure_plan.plan.link_id) {
+                  document.querySelector('.div_displayObject .summary-widget[data-summary_id="' + jeeFrontEnd.md_planConfigure.plan_configure_plan.plan.link_id + '"]').remove()
+                }
+                jeeFrontEnd.plan.displayObject(plan.plan, plan.html, false)
+              }
+            })
+          }
+        })
+      },
     }
-  })
+  }
+  (function() { // Self Isolation!
+    var jeeM = jeeFrontEnd.md_planConfigure
+    jeeM.init()
 
-  document.getElementById('md_planConfigure').addEventListener('change', function(event) {
-    var _target = null
-    if (_target = event.target.closest('.planAttr[data-l1key="configuration"][data-l2key="zone_mode"]')) {
-      document.querySelectorAll('.zone_mode').unseen()
-      document.querySelectorAll('.zone_mode.zone_' + _target.jeeValue()).seen()
-      return
-    }
+    /*Events delegations
+     */
+    document.getElementById('md_planConfigure').addEventListener('click', function(event) {
+      var _target = null
+      if (_target = event.target.closest('.bt_planConfigurationAction')) {
+        jeeFrontEnd.md_planConfigure.addActionPlanConfigure({}, _target.getAttribute('data-type'))
+        return
+      }
 
-    if (_target = event.target.closest('.planAttr[data-l1key="configuration"][data-l2key="display_mode"]')) {
-      document.querySelectorAll('.display_mode').unseen()
-      document.querySelectorAll('.display_mode.display_mode_' + _target.jeeValue()).seen()
-      return
-    }
-  })
+      if (_target = event.target.closest('.bt_removeAction')) {
+        _target.closest('.' + _target.getAttribute('data-type')).remove()
+        return
+      }
 
-  jeeM.postInit()
-})()
+      if (_target = event.target.closest('.listCmdAction')) {
+        var type = _target.getAttribute('data-type')
+        var el = _target.closest('.' + type).querySelector('.expressionAttr[data-l1key="cmd"]')
+        jeedom.cmd.getSelectModal({
+          cmd: {
+            type: 'action'
+          }
+        }, function(result) {
+          el.jeeValue(result.human)
+          jeedom.cmd.displayActionOption(result.human, '', function(html) {
+            el.closest('.' + type).querySelector('.actionOptions').html(html)
+            jeedomUtils.taAutosize()
+          })
+        })
+        return
+      }
+
+      if (_target = event.target.closest('.bt_selectOtherActionExpression')) {
+        var expression = _target.closest('.expression')
+        jeedom.getSelectActionModal({
+          scenario: true
+        }, function(result) {
+          expression.querySelector('.expressionAttr[data-l1key="cmd"]').jeeValue(result.human)
+          jeedom.cmd.displayActionOption(result.human, '', function(html) {
+            expression.querySelector('.actionOptions').html(html)
+            jeedomUtils.taAutosize()
+          })
+        })
+        return
+      }
+
+      if (_target = event.target.closest('#bt_planConfigureAddEqLogic')) {
+        jeedom.eqLogic.getSelectModal({}, function(result) {
+          _target.parentNode.parentNode.querySelector('.planAttr[data-l1key="configuration"][data-l2key="eqLogic"]').jeeValue(result.human)
+        })
+        return
+      }
+
+      if (_target = event.target.closest('#bt_planConfigureSelectCamera')) {
+        jeedom.eqLogic.getSelectModal({
+          eqLogic: {
+            eqType_name: 'camera'
+          }
+        }, function(result) {
+          _target.parentNode.parentNode.querySelector('.planAttr[data-l1key="configuration"][data-l2key="camera"]').jeeValue(result.human)
+        })
+        return
+      }
+
+      if (_target = event.target.closest('#bt_planConfigureSelectBinary')) {
+        jeedom.cmd.getSelectModal({
+          cmd: {
+            type: 'info'
+          }
+        }, function(result) {
+          _target.parentNode.parentNode.querySelector('.planAttr[data-l1key="configuration"][data-l2key="binary_info"]').jeeValue(result.human)
+        })
+        return
+      }
+
+      if (_target = event.target.closest('#bt_chooseIcon')) {
+        jeedomUtils.chooseIcon(function(_icon) {
+          document.querySelector('.planAttr[data-l1key="display"][data-l2key="icon"]').innerHTML = _icon
+        })
+        return
+      }
+
+      if (_target = event.target.closest('#bt_saveConfigurePlan')) {
+        var check = document.querySelector('input[data-l2key="font-size"]')
+        if (check && check.value != '' && !check.value.endsWith('%')) {
+          check.value = check.value + '%'
+        }
+        jeeFrontEnd.md_planConfigure.save()
+        return
+      }
+    })
+
+    document.getElementById('md_planConfigure').addEventListener('focusout', function(event) {
+      var _target = null
+      if (_target = event.target.closest('.expressionAttr[data-l1key="cmd"]')) {
+        var type = _target.getAttribute('data-type')
+        jeedom.cmd.displayActionOption(_target.jeeValue(), '', function(html) {
+          _target.closest('.' + type).querySelector('.actionOptions').html(html)
+          jeedomUtils.taAutosize()
+        })
+        return
+      }
+    })
+
+    document.getElementById('md_planConfigure').addEventListener('change', function(event) {
+      var _target = null
+      if (_target = event.target.closest('.planAttr[data-l1key="configuration"][data-l2key="zone_mode"]')) {
+        document.querySelectorAll('.zone_mode').unseen()
+        document.querySelectorAll('.zone_mode.zone_' + _target.jeeValue()).seen()
+        return
+      }
+
+      if (_target = event.target.closest('.planAttr[data-l1key="configuration"][data-l2key="display_mode"]')) {
+        document.querySelectorAll('.display_mode').unseen()
+        document.querySelectorAll('.display_mode.display_mode_' + _target.jeeValue()).seen()
+        return
+      }
+    })
+
+    jeeM.postInit()
+  })()
 </script>


### PR DESCRIPTION
- `_plan.css.zoom` could be stored as an empty string when the "Taille du widget" field was saved while left blank. `init(value, default)` only treats `undefined`/`null` as unset, not `''`, so `zoomScale` ended up `NaN` for these widgets, breaking both grid snap and containment entirely. Now explicitly falls back to `1` when the parsed value is `NaN`.
- Reworked the zoom-compensated drag handling so grid snap keeps working correctly for widgets with an explicit size other than 1, and so dragging one now keeps it within the design bounds (previously fully disabled as soon as the size differed from 1).
- Added the same kind of correction to resizing: a zoomed widget resized past the design's edge is now brought back within bounds once the resize ends, instead of being left overflowing.
- Removed the now-outdated tooltip warning on "Taille du widget", since the placement/grid-snap issues it warned about are fixed.

Closes #3438