### PR TITLE
Fix autoload always loading a plugin's main class file instead of a dedicated one

### DIFF
--- a/core/php/core.inc.php
+++ b/core/php/core.inc.php
@@ -64,7 +64,7 @@ function jeedomAutoload(string $_classname): void {
 		}
 		if ($plugin_active == 1) {
 			try {
-				if (file_exists(__DIR__ . "/../../plugins/$classname/core/class/$_classname.class.php")) {
+				if ($classname !== $_classname && file_exists(__DIR__ . "/../../plugins/$classname/core/class/$_classname.class.php")) {
 					include_file('core', $_classname, 'class', $classname);
 				} else {
 					include_file('core', $classname, 'class', $classname);

--- a/core/php/core.inc.php
+++ b/core/php/core.inc.php
@@ -64,7 +64,11 @@ function jeedomAutoload(string $_classname): void {
 		}
 		if ($plugin_active == 1) {
 			try {
-				include_file('core', $classname, 'class', $classname);
+				if (file_exists(__DIR__ . "/../../plugins/$classname/core/class/$_classname.class.php")) {
+					include_file('core', $_classname, 'class', $classname);
+				} else {
+					include_file('core', $classname, 'class', $classname);
+				}
 			} catch (Throwable $e) {
 				log::add('plugin', 'error', $e->getMessage());
 			}

--- a/core/php/core.inc.php
+++ b/core/php/core.inc.php
@@ -44,10 +44,9 @@ try {
 } catch (\Throwable $e) {
 }
 
-function jeedomAutoload($_classname) {
-	/* core class always in /core/class : */
-	$path = __DIR__ . "/../../core/class/$_classname.class.php";
-	if (file_exists($path)) {
+function jeedomAutoload(string $_classname): void {
+	if (file_exists(__DIR__ . "/../../core/class/$_classname.class.php")) {
+		/* core class always in /core/class : */
 		include_file('core', $_classname, 'class');
 	} else if (substr($_classname, 0, 4) === 'com_') {
 		/* class com_$1 in /core/com/$1.com.php */


### PR DESCRIPTION
`jeedomAutoload` truncates an unresolved plugin class name (e.g. `xxx_yyy`) down to its plugin prefix (`xxx`) to check if the plugin is active, then reuses that truncated name as both the plugin folder and the file to load. This means it always loads the plugin's main class file, even when a dedicated file matching the exact class name exists in the plugin's `core/class` folder.

The fix checks for a file matching the exact class name first, and only falls back to the plugin's main class file if it doesn't exist. Fully backward compatible: plugins that never split a secondary class out keep the exact same behavior.

This also applies to the `Cmd`/`Real` suffix stripping done earlier in the function, so a plugin's `xxxCmd` class can now be extracted into its own dedicated file too, not just underscore-suffixed classes.

Also added type hints to `jeedomAutoload` and simplified it slightly (inlined single-use path variables) while working on it.