### PR TITLE
fix filter reset on scenarios after save and add scenario group filter

### DIFF
--- a/core/template/scenario/scenario.default.html
+++ b/core/template/scenario/scenario.default.html
@@ -57,20 +57,22 @@
 
       const input = document.querySelector('.expressionAttr[data-uid="#uid#"][data-l1key="options"][data-l2key="filter"]')
       const allOptions = Array.from(select.options)
+      const optgroups = select.querySelectorAll('optgroup')
 
       function filterOptions() {
         const text = input.value.trim().toLowerCase().stripAccents()
 
-        select.innerHTML = ''
-
-        allOptions
-          .filter(option => {
-            const optionText = option.textContent.toLowerCase().stripAccents()
-            return text === '' || optionText.includes(text)
-          })
-          .forEach(option => {
-            select.add(option.cloneNode(true))
-          })
+        const selectElement = document.querySelector('.expressionAttr[data-l2key="scenario_id"]')
+        if (!selectElement) return
+        allOptions.forEach(option => {
+          const optionText = option.textContent.toLowerCase().stripAccents()
+          option.hidden = text !== '' && !optionText.includes(text)
+        })
+        optgroups.forEach(group => {
+          const childOptions = Array.from(group.querySelectorAll('option'))
+          const hasVisibleOption = childOptions.some(option => !option.hidden)
+          group.hidden = text !== '' && !hasVisibleOption
+        })
       }      
 
       input.addEventListener('input', filterOptions)

--- a/desktop/modal/cmd.configure.php
+++ b/desktop/modal/cmd.configure.php
@@ -1160,7 +1160,15 @@ $configEqDisplayType = jeedom::getConfiguration('eqLogic:displayType');
 
         //Get pre/post exec actions:
         cmd.configuration.actionCheckCmd = {}
-        cmd.configuration.actionCheckCmd = document.querySelectorAll('#div_actionCheckCmd .actionCheckCmd').getJeeValues('.expressionAttr')
+		    const actionCheckCmd = document.querySelectorAll('#div_actionCheckCmd .actionCheckCmd').getJeeValues('.expressionAttr')
+        if (Array.isArray(actionCheckCmd)) {
+            actionCheckCmd.forEach(action => {
+                if (action.options) {
+                    delete action.options.filter
+                }
+            });
+        }
+        cmd.configuration.actionCheckCmd = actionCheckCmd
         cmd.configuration.jeedomPreExecCmd = document.querySelectorAll('#div_actionPreExecCmd .actionPreExecCmd').getJeeValues('.expressionAttr')
         cmd.configuration.jeedomPostExecCmd = document.querySelectorAll('#div_actionPostExecCmd .actionPostExecCmd').getJeeValues('.expressionAttr')
         jeedom.cmd.save({


### PR DESCRIPTION
[<!-- Provide a general summary of your changes in the title above. -->
](https://community.jeedom.com/t/probleme-daffichage-avec-le-filtrage-de-scenario-dans-action-sur-valeur/149972/5?u=noodom)

## Description
- fix filter reset on scenarios after save 
- add scenarios group filter

### Suggested changelog entry
fix scenarios filter

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [x] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.
