### PR TITLE
Speed up plugin::isInstalled and use it instead of byId for existence checks

### DIFF
--- a/core/class/cache.class.php
+++ b/core/class/cache.class.php
@@ -200,15 +200,8 @@ class cache {
 				continue;
 			}
 			preg_match_all('/dependancy(.*)/', $cache->getKey(), $matches);
-			if (isset($matches[1][0])) {
-				try {
-					$plugin = plugin::byId($matches[1][0]);
-					if (!is_object($plugin)) {
-						cache::delete($cache->getKey());
-					}
-				} catch (Exception $e) {
-					cache::delete($cache->getKey());
-				}
+			if (isset($matches[1][0]) && !plugin::isInstalled($matches[1][0])) {
+				cache::delete($cache->getKey());
 			}
 		}
 	}

--- a/core/class/jeedom.class.php
+++ b/core/class/jeedom.class.php
@@ -562,9 +562,7 @@ class jeedom {
 			return config::byKey('apimarket');
 		}
 		if (config::byKey('api', $_plugin) == '') {
-			try {
-				plugin::byId($_plugin);
-			} catch (\Throwable $th) {
+			if (!plugin::isInstalled($_plugin)) {
 				return '';
 			}
 			config::save('api', config::genKey(), $_plugin);

--- a/core/class/plugin.class.php
+++ b/core/class/plugin.class.php
@@ -57,16 +57,12 @@ class plugin {
 
 	/*     * ***********************Méthodes statiques*************************** */
 
-	public static function byId($_id, $_full = false) {
+	public static function byId(string $_id, bool $_full = false): plugin {
 		global $JEEDOM_INTERNAL_CONFIG;
-		if (is_string($_id) && isset(self::$_cache[$_id . '::' . $_full])) {
+		if (isset(self::$_cache[$_id . '::' . $_full])) {
 			return self::$_cache[$_id . '::' . $_full];
 		}
-		if (!file_exists($_id) || strpos($_id, '/') === false) {
-			$path = self::getPathById($_id);
-		} else {
-			$path = $_id;
-		}
+		$path = self::resolvePath($_id);
 		if (!file_exists($path)) {
 			self::forceDisablePlugin($_id);
 			throw new Exception('Plugin introuvable : ' . $_id);

--- a/core/class/plugin.class.php
+++ b/core/class/plugin.class.php
@@ -199,6 +199,13 @@ class plugin {
 		return __DIR__ . '/../../plugins/' . $_id . '/plugin_info/info.json';
 	}
 
+	private static function resolvePath(string $_id): string {
+		if (!file_exists($_id) || strpos($_id, '/') === false) {
+			return self::getPathById($_id);
+		}
+		return $_id;
+	}
+
 	public function getPathToConfigurationById() {
 		if (file_exists(__DIR__ . '/../../plugins/' . $this->id . '/plugin_info/configuration.php')) {
 			return 'plugins/' . $this->id . '/plugin_info/configuration.php';
@@ -599,13 +606,15 @@ class plugin {
 		}
 	}
 
-	public static function isInstalled($_pluginId): bool {
-		try {
-			plugin::byId($_pluginId);
+	public static function isInstalled(string $_pluginId): bool {
+		if (isset(self::$_cache[$_pluginId . '::'])) {
 			return true;
-		} catch (Exception $e) {
+		}
+		$path = self::resolvePath($_pluginId);
+		if (!file_exists($path)) {
 			return false;
 		}
+		return is_array(json_decode(file_get_contents($path), true));
 	}
 
 	/*     * *********************Méthodes d'instance************************* */

--- a/desktop/modal/first.use.php
+++ b/desktop/modal/first.use.php
@@ -20,14 +20,7 @@ if (!isConnect()) {
 	throw new Exception('{{401 - Accès non autorisé}}');
 }
 
-$pluginJeeEasy = false;
-try {
-	if(is_object(plugin::byId('jeeasy'))) {
-		$pluginJeeEasy = true;
-	}
-} catch (\Throwable $th) {
-	
-}
+$pluginJeeEasy = plugin::isInstalled('jeeasy');
 
 
 $showDoc = false;


### PR DESCRIPTION
- `plugin::isInstalled()` no longer goes through `plugin::byId()` (full JSON decode, object hydration, `method_exists` checks, category resolution) just to answer a yes/no question. It now resolves the plugin path and validates the JSON directly, without building a `plugin` object.
- `plugin::byId()` arguments and return type are now typed (`string $_id, bool $_full = false): plugin`), and both methods share a new private `resolvePath()` helper instead of duplicating the path resolution logic.
- Replaced three `plugin::byId()` calls in `core` that were only used to check plugin existence, never using the returned object, with `plugin::isInstalled()`: `cache::clean()`, `jeedom::getApiKey()`, and the `jeeasy` detection in the first-use modal.