### PR TITLE
Remove dead widget plugin template lookup

### DIFF
--- a/core/class/cmd.class.php
+++ b/core/class/cmd.class.php
@@ -1967,9 +1967,6 @@ class cmd {
 		if (!isset(self::$_templateArray[$_version . '::' . $template_name])) {
 			$template = getTemplate('core', $_version, $template_name);
 			if ($template == '') {
-				if (config::byKey('active', 'widget') == 1) {
-					$template = getTemplate('core', $_version, $template_name, 'widget');
-				}
 				$template = getTemplate('core', $_version, $template_name, $this->getEqType());
 				if ($template == '') {
 					foreach (plugin::listPlugin(true) as $plugin) {


### PR DESCRIPTION
The dedicated template lookup for the (deprecated, obsolete on the market) `widget` plugin in `cmd::getWidgetTemplateCode()` was dead code.

Its result was always immediately discarded by the following unconditional `getTemplate(..., $this->getEqType())` call added in a 2023 commit, which overwrites `$template` regardless of what the `widget` block found. Even without that, the check was already redundant: the generic `plugin::listPlugin(true)` fallback loop right after tests every active plugin's own template folder using the same `active` condition, so an active `widget` plugin would already be picked up there.
