### PR TITLE
Fix shared cmd::update value mutation breaking live chart updates

### DIFF
--- a/core/js/plugin.template.js
+++ b/core/js/plugin.template.js
@@ -98,8 +98,8 @@ if (!jeeFrontEnd.pluginTemplate) {
           if (isset(data) && isset(data.timeout) && data.timeout == 0) {
             data.timeout = ''
           }
-          if(document.getElementById('img_device') != null && document.querySelector('.eqLogicDisplayCard.active img').getAttribute('src') != ''){
-            document.getElementById('img_device').setAttribute("src",document.querySelector('.eqLogicDisplayCard.active img').getAttribute('src'));
+          if (document.getElementById('img_device') != null && document.querySelector('.eqLogicDisplayCard.active img').getAttribute('src') != '') {
+            document.getElementById('img_device').setAttribute("src", document.querySelector('.eqLogicDisplayCard.active img').getAttribute('src'))
           }
           document.getElementById('div_mainContainer').setJeeValues(data, '.eqLogicAttr')
           if (!isset(data.category.opening)) try { document.querySelector('input[data-l2key="opening"]').checked = false } catch (e) { }
@@ -113,7 +113,7 @@ if (!jeeFrontEnd.pluginTemplate) {
               data.cmd[i].state = String(data.cmd[i].state).replace(/<[^>]*>?/gm, '')
               data.cmd[i]['htmlstate'] = '<span class="cmdTableState"'
               data.cmd[i]['htmlstate'] += 'data-cmd_id="' + data.cmd[i].id + '"'
-              data.cmd[i]['htmlstate'] += 'title="{{Date de valeur}} : ' + data.cmd[i].valueDate + '<br/>{{Date de collecte}} : ' + data.cmd[i].collectDate
+              data.cmd[i]['htmlstate'] += 'title="{{Date de valeur}}: ' + data.cmd[i].valueDate + '<br/>{{Date de collecte}}: ' + data.cmd[i].collectDate
               if (data.cmd[i].state.length > 50) {
                 data.cmd[i]['htmlstate'] += '<br/>' + data.cmd[i].state.replaceAll('"', '&quot;')
               }
@@ -132,17 +132,17 @@ if (!jeeFrontEnd.pluginTemplate) {
           }
           document.querySelectorAll('.cmdTableState').forEach(_cmdState => {
             jeedom.cmd.addUpdateFunction(_cmdState.getAttribute('data-cmd_id'), function(_options) {
-              _options.value = String(_options.value).replace(/<[^>]*>?/gm, '')
+              let displayValue = String(_options.value).replace(/<[^>]*>?/gm, '')
               const cmd = document.querySelector('.cmdTableState[data-cmd_id="' + _options.cmd_id + '"]')
               if (cmd === null) {
                 return
               }
-              let title = '{{Date de collecte}} : ' + _options.collectDate + '<br/>{{Date de valeur}} ' + _options.valueDate
-              if (_options.value.length > 50) {
-                title += ' - ' + _options.value
+              let title = '{{Date de valeur}}: ' + _options.valueDate + '<br>{{Date de collecte}}: ' + _options.collectDate
+              if (displayValue.length > 50) {
+                title += ' - ' + displayValue
               }
               cmd.setAttribute('title', title)
-              cmd.empty().innerHTML = _options.value.substring(0, 50) + ' ' + _options.raw_unit
+              cmd.empty().innerHTML = displayValue.substring(0, 50) + ' ' + _options.raw_unit
               cmd.style.color = 'var(--logo-primary-color)'
               setTimeout(function() {
                 cmd.style.color = null

--- a/core/template/dashboard/cmd.action.slider.shutter.html
+++ b/core/template/dashboard/cmd.action.slider.shutter.html
@@ -40,7 +40,7 @@
 
     jeedom.cmd.addUpdateFunction('#id#', function(_options) {
       if (is_object(cmd = document.querySelector('.cmd[data-cmd_uid="#uid#"]'))) {
-        cmd.setAttribute('title', '{{Date de valeur}} : ' + _options.valueDate + '<br>{{Date de collecte}} : ' + _options.collectDate)
+        cmd.setAttribute('title', '{{Date de valeur}}: ' + _options.valueDate + '<br>{{Date de collecte}}: ' + _options.collectDate)
         if ('#time#' == 'duration' || '#time#' == 'date') {
           jeedom.cmd.displayDuration(_options.valueDate, cmd.querySelector('.timeCmd'), '#time#')
         }

--- a/core/template/mobile/cmd.info.numeric.rain.html
+++ b/core/template/mobile/cmd.info.numeric.rain.html
@@ -23,7 +23,7 @@
     cmd#id#.find('.widget-rain-water').css('background', "url('data:image/svg+xml;base64," + waterSvg64#id# + "')")
 
     jeedom.cmd.addUpdateFunction('#id#',function(_options) {
-      cmd#id#.attr('title','{{Date de valeur}} : '+_options.valueDate+'<br/>{{Date de collecte}} : '+_options.collectDate+'<br/>{{Valeur}} : '+_options.display_value+_options.unit)
+      cmd#id#.attr('title','{{Date de valeur}}: '+_options.valueDate+'<br/>{{Date de collecte}}: '+_options.collectDate+'<br/>{{Valeur}}: '+_options.display_value+_options.unit)
       cmd#id#.find('.unit').empty().append(_options.unit);
 
       var value_#id# = parseFloat(_options.value)

--- a/core/template/mobile/cmd.info.string.multiline.html
+++ b/core/template/mobile/cmd.info.string.multiline.html
@@ -5,7 +5,7 @@
   <script>
      jeedom.cmd.addUpdateFunction('#id#',function(_options) {
       cmd = $('.cmd[data-cmd_id=#id#]')
-      cmd.attr('title','Date de valeur : '+_options.valueDate+'<br/>Date de collecte : '+_options.collectDate)
+      cmd.attr('title','{{Date de valeur}}: '+_options.valueDate+'<br/>{{Date de collecte}}: '+_options.collectDate)
       cmd.find('.state').empty().append(_options.display_value+' #unite#')
       
       if (_options.alertLevel) {

--- a/desktop/modal/eqLogic.configure.php
+++ b/desktop/modal/eqLogic.configure.php
@@ -56,17 +56,16 @@ sendVarToJS([
     <div class="tab-content" id="div_displayEqLogicConfigure">
       <div role="tabpanel" class="tab-pane active" id="eqLogic_information">
         <form class="form-horizontal">
-          
-		  <div class="row">
-        	<div class="col-sm-6">
-        	  <legend><i class="fas fa-clipboard-list"></i> {{Général}}</legend>
+          <div class="row">
+            <div class="col-sm-6">
+              <legend><i class="fas fa-clipboard-list"></i> {{Général}}</legend>
               <div class="form-group">
                 <label class="col-sm-4 control-label">{{Nom}}</label>
                 <div class="col-sm-8">
                   <input type="text" class="eqLogicAttr form-control input-sm" data-l1key="name">
                 </div>
-            </div>
-             <div class="form-group">
+              </div>
+              <div class="form-group">
                 <label class="col-sm-4 control-label">{{ID unique}}</label>
                 <div class="col-sm-8">
                   <span class="eqLogicAttr label label-sm label-primary" data-l1key="id"></span>
@@ -87,8 +86,8 @@ sendVarToJS([
                   }
                   ?>
                 </div>
-             </div>
-             <div class="form-group">
+              </div>
+              <div class="form-group">
                 <label class="col-sm-4 control-label">{{ID logique}}</label>
                 <div class="col-sm-8">
                   <span class="eqLogicAttr label label-sm label-primary" data-l1key="logicalId"></span>
@@ -102,8 +101,8 @@ sendVarToJS([
                   <span class="eqLogicAttr label label-sm label-info" data-l1key="configuration" data-l2key="createtime"></span> -
                   <span class="eqLogicAttr label label-sm label-info" data-l1key="configuration" data-l2key="updatetime"></span>
                 </div>
-             </div>
-             <div class="form-group">
+              </div>
+              <div class="form-group">
                 <label class="col-sm-4 control-label">{{Tentative échouée}}</label>
                 <div class="col-sm-8">
                   <span class="label label-sm label-primary"><?php echo $eqLogic->getStatus('numberTryWithoutSuccess', 0) ?></span>
@@ -115,8 +114,8 @@ sendVarToJS([
                 <div class="col-sm-8">
                   <span class="label label-sm label-info"><?php echo $eqLogic->getStatus('lastCommunication') ?></span>
                 </div>
-            </div>
-             <div class="form-group">
+              </div>
+              <div class="form-group">
                 <label class="col-sm-4 control-label">{{Tag(s)}}</label>
                 <div class="col-sm-8">
                   <input class="eqLogicAttr form-control input-sm" data-l1key="tags">
@@ -131,22 +130,22 @@ sendVarToJS([
               </div>
             </div>
             <div class="col-sm-6">
-                    <legend>{{Image}}</legend>
-                    <div class="form-group">
-                    	<div class="col-sm-7 col-sm-offset-3">
-                    		<span class="btn btn-default btn-file">
-                    			<i class="fas fa-cloud-upload-alt"></i> {{Envoyer}}<input id="bt_uploadImageEqLogic" type="file" name="file" accept="image/*">
-                    		</span>
-                    		<a class="btn btn-danger" id="bt_removeEqLogicImage"><i class="fas fa-trash"></i> {{Enlever l'image}}</a>
-                   		</div>
-					</div>
-					<div class="form-group">
-						<div class="col-sm-7 col-sm-offset-3 eqLogicImg">
-							<img class="img-responsive" src="<?php echo $eqLogic->getImage(); ?>" width="240px" style="min-height : 50px" />
-                        </div>
-					</div>
-                    
-            </div>	        
+              <legend>{{Image}}</legend>
+              <div class="form-group">
+                <div class="col-sm-7 col-sm-offset-3">
+                  <span class="btn btn-default btn-file">
+                    <i class="fas fa-cloud-upload-alt"></i> {{Envoyer}}<input id="bt_uploadImageEqLogic" type="file" name="file" accept="image/*">
+                  </span>
+                  <a class="btn btn-danger" id="bt_removeEqLogicImage"><i class="fas fa-trash"></i> {{Enlever l'image}}</a>
+                </div>
+              </div>
+              <div class="form-group">
+                <div class="col-sm-7 col-sm-offset-3 eqLogicImg">
+                  <img class="img-responsive" src="<?php echo $eqLogic->getImage(); ?>" width="240px" style="min-height : 50px" />
+                </div>
+              </div>
+
+            </div>
           </div>
           <legend><i class="fas fa-list-alt"></i> {{Commandes}}</legend>
           <table class="table table-condensed">
@@ -503,48 +502,48 @@ sendVarToJS([
 
       <div role="tabpanel" class="tab-pane" id="eqLogic_specialAttributesPlugin">
         <form class="form-horizontal">
-        <br/>
+          <br />
           <div class="alert alert-info">{{Vous pouvez trouver ici toute informations complementaires demandées par un plugin sur les équipements Jeedom}}</div>
           <?php
-            try {
-              $plugins = plugin::listPlugin(true);
-              foreach ($plugins as $plugin) {
-                $specialAttributes = $plugin->getSpecialAttributes();
-                if (!isset($specialAttributes['eqLogic']) || !is_array($specialAttributes['eqLogic']) || count($specialAttributes['eqLogic']) == 0) {
-                  continue;
-                }
-                $spAttr = '<legend><i class="fas fa-users-cog"></i> {{Informations complémentaires demandées par}} ' . $plugin->getName() . '</legend>';
-                foreach ($specialAttributes['eqLogic'] as $key => $config) {
-                  $spAttr .= '<div class="form-group">';
-                  $spAttr .= '<label class="col-sm-3 control-label">' . $config['name'][translate::getLanguage()] . '</label>';
-                  $spAttr .= '<div class="col-sm-7">';
-                  switch ($config['type']) {
-                    case 'input':
-                      $spAttr .= '<input class="form-control eqLogicAttr" data-l1key="configuration" data-l2key="plugin::' . $plugin->getId() . '::' . $key . '"/>';
-                      break;
-                    case 'checkbox':
-                        $spAttr .= '<input type="checkbox" class="form-control eqLogicAttr" data-l1key="configuration" data-l2key="plugin::' . $plugin->getId() . '::' . $key . '"/>';
-                        break;
-                    case 'number':
-                      $spAttr .= '<input type="number" class="form-control eqLogicAttr" data-l1key="configuration" data-l2key="plugin::' . $plugin->getId() . '::' . $key . '" min="' . (isset($config['min']) ? $config['min'] : '') . '" max="' . (isset($config['max']) ? $config['max'] : '') . '" />';
-                      break;
-                    case 'select':
-                      $spAttr .= '<select class="form-control eqLogicAttr" data-l1key="configuration" data-l2key="plugin::' . $plugin->getId() . '::' . $key . '">';
-                      foreach ($config['values'] as $value) {
-                        $spAttr .= '<option value="' . $value['value'] . '">' . $value['name'] . '</option>';
-                      }
-                      $spAttr .= '</select>';
-                      break;
-                  }
-                  $spAttr .= '</div>';
-                  $spAttr .= '</div>';
-                }
-                echo $spAttr;
+          try {
+            $plugins = plugin::listPlugin(true);
+            foreach ($plugins as $plugin) {
+              $specialAttributes = $plugin->getSpecialAttributes();
+              if (!isset($specialAttributes['eqLogic']) || !is_array($specialAttributes['eqLogic']) || count($specialAttributes['eqLogic']) == 0) {
+                continue;
               }
-            } catch (\Exception $e) {
+              $spAttr = '<legend><i class="fas fa-users-cog"></i> {{Informations complémentaires demandées par}} ' . $plugin->getName() . '</legend>';
+              foreach ($specialAttributes['eqLogic'] as $key => $config) {
+                $spAttr .= '<div class="form-group">';
+                $spAttr .= '<label class="col-sm-3 control-label">' . $config['name'][translate::getLanguage()] . '</label>';
+                $spAttr .= '<div class="col-sm-7">';
+                switch ($config['type']) {
+                  case 'input':
+                    $spAttr .= '<input class="form-control eqLogicAttr" data-l1key="configuration" data-l2key="plugin::' . $plugin->getId() . '::' . $key . '"/>';
+                    break;
+                  case 'checkbox':
+                    $spAttr .= '<input type="checkbox" class="form-control eqLogicAttr" data-l1key="configuration" data-l2key="plugin::' . $plugin->getId() . '::' . $key . '"/>';
+                    break;
+                  case 'number':
+                    $spAttr .= '<input type="number" class="form-control eqLogicAttr" data-l1key="configuration" data-l2key="plugin::' . $plugin->getId() . '::' . $key . '" min="' . (isset($config['min']) ? $config['min'] : '') . '" max="' . (isset($config['max']) ? $config['max'] : '') . '" />';
+                    break;
+                  case 'select':
+                    $spAttr .= '<select class="form-control eqLogicAttr" data-l1key="configuration" data-l2key="plugin::' . $plugin->getId() . '::' . $key . '">';
+                    foreach ($config['values'] as $value) {
+                      $spAttr .= '<option value="' . $value['value'] . '">' . $value['name'] . '</option>';
+                    }
+                    $spAttr .= '</select>';
+                    break;
+                }
+                $spAttr .= '</div>';
+                $spAttr .= '</div>';
+              }
+              echo $spAttr;
             }
-            ?>
-          </form>
+          } catch (\Exception $e) {
+          }
+          ?>
+        </form>
       </div>
 
 
@@ -580,10 +579,10 @@ sendVarToJS([
         document.querySelectorAll('#md_eqLogicConfigure .advanceWidgetParameterColorTransparent').forEach(_transparent => {
           _transparent?.triggerEvent('change')
         })
-          
-       try {
-        	jeeFrontEnd.md_eqLogicConfigure.bckUploader.destroy()
-       } catch (error) {}
+
+        try {
+          jeeFrontEnd.md_eqLogicConfigure.bckUploader.destroy()
+        } catch (error) {}
         jeeFrontEnd.md_eqLogicConfigure.bckUploader = new jeeFileUploader({
           fileInput: document.getElementById('bt_uploadImageEqLogic'),
           replaceFileInput: false,
@@ -594,19 +593,19 @@ sendVarToJS([
               jeedomUtils.showAlert({
                 message: data.result.result,
                 level: 'danger'
-                })
-                return
-              }
-              if (isset(data.result.result.filepath)) {
-                document.querySelector('#md_eqLogicConfigure .eqLogicImg').seen().querySelector('img').src = data.result.result.filepath
-              } else {
-              	document.querySelector('#md_eqLogicConfigure .eqLogicImg').unseen()
-              }
-              jeedomUtils.showAlert({
-                message: '{{Image ajoutée avec succès}}',
-                level: 'success'
-                })
-              }
+              })
+              return
+            }
+            if (isset(data.result.result.filepath)) {
+              document.querySelector('#md_eqLogicConfigure .eqLogicImg').seen().querySelector('img').src = data.result.result.filepath
+            } else {
+              document.querySelector('#md_eqLogicConfigure .eqLogicImg').unseen()
+            }
+            jeedomUtils.showAlert({
+              message: '{{Image ajoutée avec succès}}',
+              level: 'success'
+            })
+          }
         })
 
         //Dynamic values:
@@ -648,13 +647,13 @@ sendVarToJS([
         }
       },
       synchModalToEq: function() {
-        if(document.querySelector('#div_pageContainer input.eqLogicAttr[data-l1key="name"]')){
+        if (document.querySelector('#div_pageContainer input.eqLogicAttr[data-l1key="name"]')) {
           document.querySelector('#div_pageContainer input.eqLogicAttr[data-l1key="name"]').value = document.querySelector('#eqLogic_information input.eqLogicAttr[data-l1key="name"').value
         }
-        if(document.querySelector('#div_pageContainer input.eqLogicAttr[data-l1key="isEnable"]')){
+        if (document.querySelector('#div_pageContainer input.eqLogicAttr[data-l1key="isEnable"]')) {
           document.querySelector('#div_pageContainer input.eqLogicAttr[data-l1key="isEnable"]').checked = document.querySelector('#eqLogic_information input.eqLogicAttr[data-l1key="isEnable"').checked
         }
-        if(document.querySelector('#div_pageContainer input.eqLogicAttr[data-l1key="isVisible"]')){
+        if (document.querySelector('#div_pageContainer input.eqLogicAttr[data-l1key="isVisible"]')) {
           document.querySelector('#div_pageContainer input.eqLogicAttr[data-l1key="isVisible"]').checked = document.querySelector('#eqLogic_information input.eqLogicAttr[data-l1key="isVisible"').checked
         }
       },
@@ -880,10 +879,10 @@ sendVarToJS([
         })
         return
       }
-      
+
       if (_target = event.target.closest('#bt_removeEqLogicImage')) {
-         jeeDialog.confirm('{{Êtes-vous sûr de vouloir enlever l\'image cet équipement ?}}', function(result) {
-         if (result) {
+        jeeDialog.confirm('{{Êtes-vous sûr de vouloir enlever l\'image cet équipement ?}}', function(result) {
+          if (result) {
             jeedom.eqLogic.removeImage({
               id: jeephp2js.md_eqLogicConfigure_Info.id,
               error: function(error) {
@@ -908,7 +907,6 @@ sendVarToJS([
         })
         return
       }
-      
     })
 
     document.getElementById('eqLogic_information')?.addEventListener('dblclick', function(event) {
@@ -992,9 +990,9 @@ sendVarToJS([
       var _target = null
 
       if (_target = event.target.closest('.eqLogicAttr[data-l1key="configuration"][data-l2key="battery::disable"]')) {
-        if(document.querySelector('.eqLogicAttr[data-l1key="configuration"][data-l2key="battery::disable"]').jeeValue() == 1){
+        if (document.querySelector('.eqLogicAttr[data-l1key="configuration"][data-l2key="battery::disable"]').jeeValue() == 1) {
           document.querySelectorAll('.eqLogicHideNoBattery').unseen();
-        }else{
+        } else {
           document.querySelectorAll('.eqLogicHideNoBattery').seen();
         }
       }

--- a/desktop/modal/eqLogic.configure.php
+++ b/desktop/modal/eqLogic.configure.php
@@ -169,9 +169,9 @@ sendVarToJS([
                 $display .= '<td>';
                 if ($cmd->getType() == 'info') {
                   $value = htmlspecialchars($cmd->execCmd());
-                  $title = '{{Date de valeur}} : ' . $cmd->getValueDate() . '<br>{{Date de collecte}} : ' .  $cmd->getCollectDate();
+                  $title = '{{Date de valeur}}: ' . $cmd->getValueDate() . '<br>{{Date de collecte}}: ' .  $cmd->getCollectDate();
                   if (strlen($value) > 50) {
-                    $title .= '<br>{{Valeur}} : ' . $value;
+                    $title .= '<br>{{Valeur}}: ' . $value;
                     $value = trim(substr($value, 0, 50)) . '...';
                   }
                   $display .= '<span class="eqLogicConfigure_cmdValue" data-cmd_id="' . $cmd->getid() . '" title=" ' . htmlspecialchars($title) . '">' . $value . ' ' . $cmd->getUnite() . '<span>';
@@ -611,18 +611,18 @@ sendVarToJS([
         //Dynamic values:
         document.querySelectorAll('#md_eqLogicConfigure .eqLogicConfigure_cmdValue').forEach(_cmd => {
           jeedom.cmd.addUpdateFunction(_cmd.getAttribute('data-cmd_id'), function(_options) {
-            _options.value = String(_options.value).replace(/<[^>]*>?/gm, '')
+            let displayValue = String(_options.value).replace(/<[^>]*>?/gm, '')
             let cmd = document.querySelector('#md_eqLogicConfigure .eqLogicConfigure_cmdValue[data-cmd_id="' + _options.cmd_id + '"]')
             if (cmd === null) {
               return
             }
-            let title = '{{Date de valeur}} : ' + _options.valueDate + '<br>{{Date de collecte}} : ' + _options.collectDate
-            if (_options.value.length > 50) {
-              title += '<br>{{Valeur}} : ' + _options.value
-              _options.value = _options.value.trim().substring(0, 50) + '...'
+            let title = '{{Date de valeur}}: ' + _options.valueDate + '<br>{{Date de collecte}}: ' + _options.collectDate
+            if (displayValue.length > 50) {
+              title += '<br>{{Valeur}}: ' + displayValue
+              displayValue = displayValue.trim().substring(0, 50) + '...'
             }
             cmd.setAttribute('title', title)
-            cmd.empty().innerHTML = _options.value + ' ' + _options.unit
+            cmd.empty().innerHTML = displayValue + ' ' + _options.unit
             cmd.style.color = 'var(--logo-primary-color)'
             setTimeout(function() {
               cmd.style.color = null


### PR DESCRIPTION
- Two table state display callbacks (`eqLogic.configure.php` and `plugin.template.js`) mutated the `value` property of the shared `cmd::update` event payload object in place, instead of using a local copy for their own HTML-sanitized display.
- This payload object is shared across every listener processing the same event (`jeedom.cmd.refreshValue`, `jeedom.history.graphUpdate`, and any other `addUpdateFunction` callback registered for the same command), so the mutation leaked into all code reading the value afterward, silently turning a numeric value into a string.
- This caused live history chart updates (`jeedom.history.graphUpdate`) to receive a string instead of a number whenever a page or modal containing one of these table displays was open, breaking the chart's live rendering for that command.
- While at it, aligned the tooltip date format across `eqLogic.configure.php`, `plugin.template.js`, `cmd.action.slider.shutter.html` and two mobile templates with the convention used across nearly all dashboard widget templates (`{{Date de valeur}}: ` before `{{Date de collecte}}: `, no space before the colon), and added the missing `{{}}` translation wrapper around those strings in `cmd.info.string.multiline.html` (mobile), which had never been translatable.
