### PR TITLE
Make plugin::byId/isInstalled cache handling and full parameter typing explicit

### DIFF
--- a/core/ajax/plugin.ajax.php
+++ b/core/ajax/plugin.ajax.php
@@ -30,7 +30,7 @@ try {
 		if (!isConnect('admin')) {
 			throw new Exception(__('401 - Accès non autorisé', __FILE__));
 		}
-		$plugin = plugin::byId(init('id'),init('full',0));
+		$plugin = plugin::byId(init('id'), (bool) init('full', 0));
 		$update = update::byLogicalId(init('id'));
 		$return = utils::o2a($plugin);
 		$return['activate'] = $plugin->isActive();

--- a/core/class/plugin.class.php
+++ b/core/class/plugin.class.php
@@ -59,8 +59,8 @@ class plugin {
 
 	public static function byId(string $_id, bool $_full = false): plugin {
 		global $JEEDOM_INTERNAL_CONFIG;
-		if (isset(self::$_cache[$_id . '::' . $_full])) {
-			return self::$_cache[$_id . '::' . $_full];
+		if (($cached = self::getFromCache($_id, $_full)) !== null) {
+			return $cached;
 		}
 		$path = self::resolvePath($_id);
 		if (!file_exists($path)) {
@@ -170,7 +170,7 @@ class plugin {
 				}
 			}
 		}
-		self::$_cache[$plugin->id . '::' . $_full] = $plugin;
+		self::addToCache($plugin->id, $_full, $plugin);
 		return $plugin;
 	}
 
@@ -200,6 +200,16 @@ class plugin {
 			return self::getPathById($_id);
 		}
 		return $_id;
+	}
+
+	private static function getFromCache(string $_id, bool $_full): ?plugin {
+		$key = $_id . '::' . ($_full ? '1' : '0');
+		return self::$_cache[$key] ?? null;
+	}
+
+	private static function addToCache(string $_id, bool $_full, plugin $_plugin): void {
+		$key = $_id . '::' . ($_full ? '1' : '0');
+		self::$_cache[$key] = $_plugin;
 	}
 
 	public function getPathToConfigurationById() {
@@ -603,7 +613,7 @@ class plugin {
 	}
 
 	public static function isInstalled(string $_pluginId): bool {
-		if (isset(self::$_cache[$_pluginId . '::'])) {
+		if (self::getFromCache($_pluginId, false) !== null) {
 			return true;
 		}
 		$path = self::resolvePath($_pluginId);


### PR DESCRIPTION

- `plugin::byId()` and `plugin::isInstalled()` no longer build cache keys with the `$_id . '::' . $_full` bool-to-string concatenation trick directly. Their static in-memory lookup cache is now encapsulated behind two private helpers, `getFromCache()` and `addToCache()`, so no call site needs to know the key format.
- `core/ajax/plugin.ajax.php` now casts the `full` request parameter to `bool` before calling `plugin::byId()`, instead of relying on PHP's implicit weak-type coercion of a raw `int`/`string` value.
