### PR TITLE
Simplify OpenVPN and virtual plugin auto-install checks

### DIFF
--- a/core/class/jeeObject.class.php
+++ b/core/class/jeeObject.class.php
@@ -559,7 +559,7 @@ class jeeObject {
 			$update->setConfiguration('version', 'stable');
 			$update->save();
 			$update->doUpdate();
-			sleep(2);
+			// sleep(2); // legacy workaround from 2016 (3cbb2d597), no dependancy_install() here and doUpdate() is fully synchronous, unclear it was ever needed. Kept commented instead of removed pending real-world confirmation.
 		}
 		try {
 			$plugin = plugin::byId('virtual');

--- a/core/class/jeeObject.class.php
+++ b/core/class/jeeObject.class.php
@@ -147,7 +147,7 @@ class jeeObject {
 	}
 
 	public static function fromHumanReadable($_input) {
-		if(empty($_input)){
+		if (empty($_input)) {
 			return $_input;
 		}
 		$isJson = false;
@@ -503,7 +503,7 @@ class jeeObject {
 			if (!isset($def[$key]['hidenulnumber'])) {
 				$def[$key]['hidenulnumber'] = 0;
 			}
-            
+
 			$return[$key]['icon'] = array();
 			if (isset($def[$key]['icon']) && $def[$key]['icon'] != '') {
 				$def[$key]['icon'] = substr(substr($def[$key]['icon'], 10), 0, -6);
@@ -517,7 +517,7 @@ class jeeObject {
 				$return[$key]['icon']['name'] = $iconName;
 				$return[$key]['icon']['color'] = $iconColor;
 			}
-            
+
 			$return[$key]['iconnul'] = array();
 			if (isset($def[$key]['iconnul']) && $def[$key]['iconnul'] != '') {
 				$def[$key]['iconnul'] = substr(substr($def[$key]['iconnul'], 10), 0, -6);
@@ -530,9 +530,8 @@ class jeeObject {
 				$return[$key]['iconnul']['type'] = $libName;
 				$return[$key]['iconnul']['name'] = $iconName;
 				$return[$key]['iconnul']['color'] = $iconColor;
-			}
-			else $return[$key]['iconnul'] = $return[$key]['icon'];
-          
+			} else $return[$key]['iconnul'] = $return[$key]['icon'];
+
 			$return[$key]['displayzerovalue'] = $allowDisplayZero;
 			$return[$key]['hidenulnumber'] = $def[$key]['hidenulnumber'];
 			$return[$key]['value'] = $result;
@@ -550,22 +549,7 @@ class jeeObject {
 			return;
 		}
 		global $JEEDOM_INTERNAL_CONFIG;
-		try {
-			$plugin = plugin::byId('virtual');
-			if (!is_object($plugin)) {
-				$update = update::byLogicalId('virtual');
-				if (!is_object($update)) {
-					$update = new update();
-				}
-				$update->setLogicalId('virtual');
-				$update->setSource('market');
-				$update->setConfiguration('version', 'stable');
-				$update->save();
-				$update->doUpdate();
-				sleep(2);
-				$plugin = plugin::byId('virtual');
-			}
-		} catch (Exception $e) {
+		if (!plugin::isInstalled('virtual')) {
 			$update = update::byLogicalId('virtual');
 			if (!is_object($update)) {
 				$update = new update();
@@ -576,7 +560,11 @@ class jeeObject {
 			$update->save();
 			$update->doUpdate();
 			sleep(2);
+		}
+		try {
 			$plugin = plugin::byId('virtual');
+		} catch (Exception $e) {
+			$plugin = null;
 		}
 		if (!is_object($plugin) || !class_exists('virtual') || !class_exists('virtualCmd')) {
 			throw new Exception(__('Le plugin virtuel doit être installé', __FILE__));

--- a/core/class/network.class.php
+++ b/core/class/network.class.php
@@ -302,21 +302,7 @@ class network {
 		if (config::byKey('dns::token') == '') {
 			return;
 		}
-		try {
-			$plugin = plugin::byId('openvpn');
-			if (!is_object($plugin)) {
-				$update = update::byLogicalId('openvpn');
-				if (!is_object($update)) {
-					$update = new update();
-				}
-				$update->setLogicalId('openvpn');
-				$update->setSource('market');
-				$update->setConfiguration('version', 'stable');
-				$update->save();
-				$update->doUpdate();
-				$plugin = plugin::byId('openvpn');
-			}
-		} catch (Exception $e) {
+		if (!plugin::isInstalled('openvpn')) {
 			$update = update::byLogicalId('openvpn');
 			if (!is_object($update)) {
 				$update = new update();
@@ -326,7 +312,11 @@ class network {
 			$update->setConfiguration('version', 'stable');
 			$update->save();
 			$update->doUpdate();
+		}
+		try {
 			$plugin = plugin::byId('openvpn');
+		} catch (Exception $e) {
+			$plugin = null;
 		}
 		if (!is_object($plugin) || !class_exists('openvpn')) {
 			throw new Exception(__('Le plugin OpenVPN doit être installé', __FILE__));


### PR DESCRIPTION
- `network::dns_create()` (OpenVPN) and `jeeObject::createSummaryToVirtual()` (virtual) both had duplicated install-retry logic between a `try` block and its `catch`, with a dead `if (!is_object($plugin))` branch that could never trigger since `plugin::byId()` never returns a non-object without throwing. Both now use `plugin::isInstalled()` to decide whether an install is needed, removing the duplication and the unreachable branch.
- As a side effect, this also restores reachability of the intended error message when the second `plugin::byId()` attempt fails after a failed install (previously, an uncaught exception from that second call bypassed the friendly "plugin must be installed" message).
- `createSummaryToVirtual()`'s `sleep(2)` after `doUpdate()` is commented out rather than removed: it dates back to a 2016 fix with no documented root cause, `doUpdate()` is fully synchronous today, and unlike OpenVPN this flow never calls `dependancy_install()`. Kept as a comment pending real-world confirmation it's safe to drop entirely.
