### PR TITLE
Restore unreachable error handling when plugin::byId can't find a plugin

### DIFF
--- a/core/ajax/plugin.ajax.php
+++ b/core/ajax/plugin.ajax.php
@@ -47,8 +47,9 @@ try {
 		if (!isConnect('admin')) {
 			throw new Exception(__('401 - Accès non autorisé', __FILE__));
 		}
-		$plugin = plugin::byId(init('id'));
-		if (!is_object($plugin)) {
+		try {
+			$plugin = plugin::byId(init('id'));
+		} catch (Exception $e) {
 			throw new Exception(__('Plugin introuvable :', __FILE__) . ' ' . init('id'));
 		}
 		$plugin->setIsEnable(init('state'));
@@ -68,9 +69,10 @@ try {
 		}
 
 		$return = array('state' => 'nok', 'log' => 'nok');
-		$plugin = plugin::byId(init('id'));
-		if (is_object($plugin)) {
+		try {
+			$plugin = plugin::byId(init('id'));
 			$return = $plugin->dependancy_info();
+		} catch (Exception $e) {
 		}
 		ajax::success($return);
 	}
@@ -80,8 +82,9 @@ try {
 			throw new Exception(__('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
-		$plugin = plugin::byId(init('id'));
-		if (!is_object($plugin)) {
+		try {
+			$plugin = plugin::byId(init('id'));
+		} catch (Exception $e) {
 			ajax::success();
 		}
 		ajax::success($plugin->dependancy_install(true));
@@ -92,8 +95,9 @@ try {
 			throw new Exception(__('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
-		$plugin = plugin::byId(init('id'));
-		if (!is_object($plugin)) {
+		try {
+			$plugin = plugin::byId(init('id'));
+		} catch (Exception $e) {
 			ajax::success();
 		}
 		ajax::success($plugin->dependancy_changeAutoMode(init('mode')));
@@ -103,11 +107,12 @@ try {
 		if (!isConnect('admin')) {
 			throw new Exception(__('401 - Accès non autorisé', __FILE__));
 		}
-		$plugin_id = init('id');
 		$return = array('launchable_message' => '', 'launchable' => 'nok', 'state' => 'nok', 'log' => 'nok', 'auto' => 0);
-		$plugin = plugin::byId(init('id'));
-		if (is_object($plugin)) {
+		try {
+			$plugin = plugin::byId(init('id'));
 			$return = $plugin->deamon_info();
+		} catch (Exception $e) {
+			$plugin = null;
 		}
 		$return['plugin'] = utils::o2a($plugin);
 		ajax::success($return);
@@ -118,9 +123,9 @@ try {
 			throw new Exception(__('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
-		$plugin_id = init('id');
-		$plugin = plugin::byId(init('id'));
-		if (!is_object($plugin)) {
+		try {
+			$plugin = plugin::byId(init('id'));
+		} catch (Exception $e) {
 			ajax::success();
 		}
 		ajax::success($plugin->deamon_start(init('forceRestart', 0)));
@@ -131,8 +136,9 @@ try {
 			throw new Exception(__('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
-		$plugin = plugin::byId(init('id'));
-		if (!is_object($plugin)) {
+		try {
+			$plugin = plugin::byId(init('id'));
+		} catch (Exception $e) {
 			ajax::success();
 		}
 		ajax::success($plugin->deamon_stop());
@@ -143,8 +149,9 @@ try {
 			throw new Exception(__('401 - Accès non autorisé', __FILE__));
 		}
 		unautorizedInDemo();
-		$plugin = plugin::byId(init('id'));
-		if (!is_object($plugin)) {
+		try {
+			$plugin = plugin::byId(init('id'));
+		} catch (Exception $e) {
 			ajax::success();
 		}
 		ajax::success($plugin->deamon_changeAutoMode(init('mode')));

--- a/core/api/jeeApi.php
+++ b/core/api/jeeApi.php
@@ -1168,8 +1168,9 @@ try {
 		if (is_object($_USER_GLOBAL) && !in_array($_USER_GLOBAL->getProfils(), array('admin', 'user'))) {
 			throw new Exception(__('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
 		}
-		$plugin = plugin::byId($params['plugin_id']);
-		if (!is_object($plugin)) {
+		try {
+			$plugin = plugin::byId($params['plugin_id']);
+		} catch (Exception $e) {
 			$jsonrpc->makeSuccess(array('state' => 'nok', 'log' => 'nok'));
 		}
 		$jsonrpc->makeSuccess($plugin->dependancy_info());
@@ -1180,8 +1181,9 @@ try {
 			throw new Exception(__('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
 		}
 		unautorizedInDemo();
-		$plugin = plugin::byId($params['plugin_id']);
-		if (!is_object($plugin)) {
+		try {
+			$plugin = plugin::byId($params['plugin_id']);
+		} catch (Exception $e) {
 			$jsonrpc->makeSuccess();
 		}
 		$plugin->dependancy_install();
@@ -1192,8 +1194,9 @@ try {
 		if (is_object($_USER_GLOBAL) && !in_array($_USER_GLOBAL->getProfils(), array('admin', 'user'))) {
 			throw new Exception(__('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
 		}
-		$plugin = plugin::byId($params['plugin_id']);
-		if (!is_object($plugin)) {
+		try {
+			$plugin = plugin::byId($params['plugin_id']);
+		} catch (Exception $e) {
 			$jsonrpc->makeSuccess(array('launchable_message' => '', 'launchable' => 'nok', 'state' => 'nok', 'log' => 'nok', 'auto' => 0));
 		}
 		$jsonrpc->makeSuccess($plugin->deamon_info());
@@ -1216,8 +1219,9 @@ try {
 		if (is_object($_USER_GLOBAL) && !in_array($_USER_GLOBAL->getProfils(), array('admin'))) {
 			throw new Exception(__('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
 		}
-		$plugin = plugin::byId($params['plugin_id']);
-		if (!is_object($plugin)) {
+		try {
+			$plugin = plugin::byId($params['plugin_id']);
+		} catch (Exception $e) {
 			$jsonrpc->makeSuccess();
 		}
 		if (!isset($params['debug'])) {
@@ -1235,8 +1239,9 @@ try {
 			throw new Exception(__('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
 		}
 		unautorizedInDemo();
-		$plugin = plugin::byId($params['plugin_id']);
-		if (!is_object($plugin)) {
+		try {
+			$plugin = plugin::byId($params['plugin_id']);
+		} catch (Exception $e) {
 			$jsonrpc->makeSuccess();
 		}
 		$plugin->deamon_stop();
@@ -1248,8 +1253,9 @@ try {
 			throw new Exception(__('Vous n\'avez pas les droits de faire cette action', __FILE__), -32701);
 		}
 		unautorizedInDemo();
-		$plugin = plugin::byId($params['plugin_id']);
-		if (!is_object($plugin)) {
+		try {
+			$plugin = plugin::byId($params['plugin_id']);
+		} catch (Exception $e) {
 			$jsonrpc->makeSuccess();
 		}
 		$plugin->deamon_changeAutoMode($params['mode']);

--- a/core/class/jsonrpc.class.php
+++ b/core/class/jsonrpc.class.php
@@ -53,6 +53,13 @@ class jsonrpc {
 		}
 	}
 	
+	/**
+	 * Sends an error response and ends execution
+	 *
+	 * @param int $_code Error code
+	 * @param string $_message Error message
+	 * @return never
+	 */
 	public function makeError($_code, $_message) {
 		$return = array(
 			'jsonrpc' => '2.0',
@@ -71,6 +78,12 @@ class jsonrpc {
 		exit;
 	}
 	
+	/**
+	 * Sends a success response and ends execution
+	 *
+	 * @param mixed $_result Data to send in response
+	 * @return never
+	 */
 	public function makeSuccess($_result = null) {
 		if(is_object($_result)){
 			$_result = utils::o2a($_result);

--- a/core/class/scenarioExpression.class.php
+++ b/core/class/scenarioExpression.class.php
@@ -1809,8 +1809,9 @@ class scenarioExpression {
 							$cmd_parameters['message'] = __('Veuillez trouver ci-joint le rapport', __FILE__) . ' ' . $plan->getName() . ' ' . __('généré le', __FILE__) . ' ' . date('Y-m-d H:i:s');
 							break;
 						case 'plugin':
-							$plugin = plugin::byId($options['plugin_id']);
-							if (!is_object($plugin)) {
+							try {
+								$plugin = plugin::byId($options['plugin_id']);
+							} catch (Exception $e) {
 								throw new Exception(__('Panel introuvable - Vérifiez l\'id :', __FILE__) . ' ' . $options['plugin_id']);
 							}
 							self::setLog($scenario, __('Génération du rapport', __FILE__) . ' ' . $plugin->getName());

--- a/core/php/jeePlugin.php
+++ b/core/php/jeePlugin.php
@@ -38,8 +38,9 @@ try {
 	if ($plugin_id == '') {
 		throw new Exception(__('Le plugin ID ne peut être vide', __FILE__));
 	}
-	$plugin = plugin::byId($plugin_id);
-	if (!is_object($plugin)) {
+	try {
+		$plugin = plugin::byId($plugin_id);
+	} catch (Exception $e) {
 		throw new Exception(__('Plugin non trouvé :', __FILE__) . ' ' . init('plugin_id'));
 	}
 	$function = init('function');

--- a/core/php/jeecli.php
+++ b/core/php/jeecli.php
@@ -59,8 +59,9 @@ switch ($argv[1]) {
                 }
                 $update->save();
                 $update->doUpdate();
-                $plugin = plugin::byId($argv[3]);
-                if (!is_object($plugin)) {
+                try {
+                    $plugin = plugin::byId($argv[3]);
+                } catch (Exception $e) {
                     echo "Error plugin not found";
                     die();
                 }

--- a/core/php/utils.inc.php
+++ b/core/php/utils.inc.php
@@ -207,7 +207,7 @@ function redirect($_url, $_forceType = null) {
 		echo '</script>';
 	} else {
 		header("Location: $_url");
-        exit;
+		exit;
 	}
 	return;
 }
@@ -1161,13 +1161,13 @@ function evaluate($_string) {
 			$string = str_replace($matches[0][$i], '--preparsed' . $i . '--', $string);
 		}
 
-        $expr = preg_replace("/([^=<>!])=([^=])/", "$1==$2", $string); // Replace all '=' by '==' and avoid '==' '===' '>=' '<=' '!=' '!=='
+		$expr = preg_replace("/([^=<>!])=([^=])/", "$1==$2", $string); // Replace all '=' by '==' and avoid '==' '===' '>=' '<=' '!=' '!=='
 		for ($i = 0; $i < $c; $i++) {
 			$expr = str_replace('--preparsed' . $i . '--', $matches[0][$i], $expr);
 		}
 	} else {
-        $expr = preg_replace("/([^=<>!])=([^=])/", "$1==$2", $string); // Replace all '=' by '==' and avoid '==' '===' '>=' '<=' '!=' '!=='
-    }
+		$expr = preg_replace("/([^=<>!])=([^=])/", "$1==$2", $string); // Replace all '=' by '==' and avoid '==' '===' '>=' '<=' '!=' '!=='
+	}
 	try {
 		return $GLOBALS['ExpressionLanguage']->evaluate($expr);
 	} catch (Exception $e) {
@@ -1807,11 +1807,13 @@ function endsWith($haystack, $needle) {
 }
 
 function getWhiteListFolders($_plugin = 'all') {
-	$pluginsAll = ($_plugin != 'all') ? array($_plugin) : plugin::listPlugin(true,    false,   true,  true);
+	$pluginsAll = ($_plugin != 'all') ? array($_plugin) : plugin::listPlugin(true, false, true, true);
 	$result = array();
 	foreach ($pluginsAll as $pluginId) {
+		if (!plugin::isInstalled($pluginId)) {
+			continue;
+		}
 		$plugin = plugin::byId($pluginId);
-		if (!is_object($plugin)) continue;
 
 		$publicFolders = $plugin->getWhiteListFolders();
 		if (count($publicFolders) == 0) continue;


### PR DESCRIPTION
- `plugin::byId()` is the only `byId()` method in the entire `core/class/` directory that throws an exception instead of returning a falsy value when nothing is found (verified against all 27 other `byId()` implementations, which are plain DB lookups). Several call sites across `core` were written assuming the more common convention, guarding the result with `if (!is_object($plugin))`. Since `byId()` throws before ever returning, these guards were dead code, and the intended fallback behavior (a friendly error message, a graceful "not found" response, skipping one entry in a loop) was never reachable.
- Each affected call now wraps `plugin::byId()` in a `try`/`catch` (or, in `utils.inc.php`'s loop over multiple plugins, a `plugin::isInstalled()` pre-check), restoring the originally intended fallback behavior instead of letting a generic exception propagate to the nearest outer handler.
- In `core/ajax/plugin.ajax.php`, also removed two `$plugin_id = init('id')` assignments left unused in `getDeamonInfo` and `deamonStart`, found while touching these same blocks.
- `jsonrpc::makeError()` and `jsonrpc::makeSuccess()` are now documented with `@return never`, mirroring `ajax::success()`/`ajax::error()`'s existing annotations. Without it, PHPStan flagged `$plugin` as possibly undefined after the `try`/`catch` blocks in `core/api/jeeApi.php`, since it couldn't infer that the `catch` branch's call to `makeSuccess()` always ends execution.