### PR TITLE
Fix stale dashed tail not clearing on live history chart update

### DIFF
--- a/core/js/history.class.js
+++ b/core/js/history.class.js
@@ -184,6 +184,10 @@ jeedom.history.graphUpdate = function(_params) {
       }
       const serie = jeedom.history.chart[chart].chart.series.find(s => s?.options.id == cmd_id)
       if (serie) {
+        if (serie.zones.length) {
+          serie.points[serie.points.length - 1].remove(false)
+          serie.update({ zones: [] }, false)
+        }
         serie.addPoint([Date.now() + (-new Date().getTimezoneOffset() * 60 * 1000), value])
         jeedom.history.setAxisScales(chart, { redraw: true })
       }


### PR DESCRIPTION
- When a chart's last known value is more than a minute old, `drawChart` extends the line to "now" with a synthetic flat point, styled as a dashed zone to indicate it's not real data.
- `graphUpdate` (used for live updates via `cmd::update`) only appended the new point without ever clearing this synthetic point or its dashed zone, so once a chart had this treatment, any subsequent live update stayed dashed and kept the stale flat segment in front of the new real data.
- `graphUpdate` now removes the synthetic point and resets the zones before adding the new real value, so the chart correctly returns to a solid line as soon as fresh data arrives.