### PR TITLE
Fix history charts on views/designs never showing the continuation-to-now dash

### DIFF
--- a/core/ajax/cmd.ajax.php
+++ b/core/ajax/cmd.ajax.php
@@ -312,59 +312,42 @@ try {
 		global $JEEDOM_INTERNAL_CONFIG;
 		$return = array();
 		$data = array();
-		$dateStart = null;
-		$dateEnd = null;
-		if (init('dateRange') != '' && init('dateRange') != 'all') {
-			if (is_json(init('dateRange'))) {
-				$dateRange = json_decode(init('dateRange'), true);
-				if (isset($dateRange['start'])) {
-					$dateStart = $dateRange['start'];
-				}
-				if (isset($dateRange['end'])) {
-					$dateEnd = $dateRange['end'];
-				}
-			} else {
-				$dateEnd = date('Y-m-d H:i:s');
-				$dateStart = date('Y-m-d H:i:s', strtotime('- ' . init('dateRange') . ' ' . $dateEnd));
-			}
-		}
-
-		if (init('dateStart') != '') {
-			$dateStart = init('dateStart');
-		}
-
-		if (init('dateEnd') != '') {
-			$dateEnd = init('dateEnd');
-			if ($dateEnd == date('Y-m-d')) {
-				$dateEnd = date('Y-m-d H:i:s');
-			}
-		}
-
-		if (init('allowFuture', 0) == 0 && config::byKey('history::allowFuture', 'core', 0) == '0' && strtotime($dateEnd) > strtotime('now')) {
+		$dateRange = init('dateRange');
+		$dateStart = init('dateStart') ?: null;
+		$dateEnd = init('dateEnd') ?: null;
+		if ($dateEnd == date('Y-m-d')) {
 			$dateEnd = date('Y-m-d H:i:s');
 		}
 
-		if ($dateStart == '' && init('dateRange') == '') {
-			$dateStart =  init('startDate', date('Y-m-d', strtotime(config::byKey('history::defautShowPeriod') . ' ' . date('Y-m-d'))));
+		if ($dateRange != '' && $dateRange != 'all') {
+			if (is_json($dateRange)) {
+				$decodedRange = json_decode($dateRange, true);
+				if ($dateStart === null && isset($decodedRange['start'])) {
+					$dateStart = $decodedRange['start'];
+				}
+				if ($dateEnd === null && isset($decodedRange['end'])) {
+					$dateEnd = $decodedRange['end'];
+				}
+			} else {
+				if ($dateEnd === null) {
+					$dateEnd = date('Y-m-d H:i:s');
+				}
+				if ($dateStart === null) {
+					$dateStart = date('Y-m-d H:i:s', strtotime('- ' . $dateRange . ' ' . $dateEnd));
+				}
+			}
+		} else if ($dateRange == '' && $dateStart === null) {
+			$dateStart = init('startDate', date('Y-m-d', strtotime(config::byKey('history::defautShowPeriod') . ' ' . date('Y-m-d'))));
 		}
 
-		if ($dateStart == '' && init('dateRange') != 'all') {
-			$now = new DateTime();
-			$dateStart = $now->modify('- ' . init('dateRange'))->format('Y-m-d');
+		if ($dateEnd !== null && init('allowFuture', 0) == 0 && config::byKey('history::allowFuture', 'core', 0) == '0' && strtotime($dateEnd) > strtotime('now')) {
+			$dateEnd = date('Y-m-d H:i:s');
 		}
 
 		$return['maxValue'] = '';
 		$return['minValue'] = '';
-		if ($dateStart === null) {
-			$return['dateStart'] = '';
-		} else {
-			$return['dateStart'] = $dateStart;
-		}
-		if ($dateEnd === null) {
-			$return['dateEnd'] = '';
-		} else {
-			$return['dateEnd'] = $dateEnd;
-		}
+		$return['dateStart'] = ($dateStart === null) ? '' : $dateStart;
+		$return['dateEnd'] = ($dateEnd === null) ? date('Y-m-d H:i:s') : $dateEnd;
 
 		if (is_numeric(init('id'))) {
 			$cmd = cmd::byId(init('id'));


### PR DESCRIPTION
- Views and designs (`plan.js`/`view.js` graph widgets) configured with the "Tous" (all) period never showed the dashed "continue to now" segment that indicates stale data, even when the underlying command's last value was genuinely more than a minute old.
- Root cause: `cmd.ajax.php`'s `getHistory` action only resolved `dateEnd` to the current time for a relative date range (e.g. "7 days") or when an explicit `dateEnd` was provided. With `dateRange=all` and no explicit dates (exactly what these widgets send), `dateEnd` stayed unresolved, so the client received an empty value, `new Date('')` produced an Invalid Date in JS, and the staleness check (`diffms > 60000`) always evaluated to false.
- Rewrote the whole `dateStart`/`dateEnd` resolution block in `getHistory`, which had grown into a hard-to-follow sequence of overlapping conditions (including a latent, never-actually-reachable bug where a JSON `dateRange` with an `end` but no `start` key would feed the raw JSON string into `DateTime::modify()`).
- `dateEnd` is still left `null` for the actual history query when nothing resolves it, so `history::allowFuture` keeps working exactly as before (a genuinely unbounded query, not artificially capped at "now"). Only the value returned to the client for the staleness check defaults to "now" when otherwise unresolved.
- Verified against every current caller (history page, comparison mode, views, designs, mobile equivalents) with no behavior change, except one currently-unused combination (a relative `dateRange` combined with an explicit `dateEnd` but no explicit `dateStart`), where the computed `dateStart` is now relative to that explicit `dateEnd` instead of always relative to "now". Arguably the more correct behavior either way.