### PR TITLE
Add automated documentation translation and publishing workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,68 @@
+name: Docs
+
+on:
+  push:
+    branches:
+      - release
+    paths:
+      - docs/**
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Tag/branch/SHA to publish from (backfill an already-shipped version). Leave empty to use the current ref."
+        required: false
+        default: ""
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  changes:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    outputs:
+      fr_fr: ${{ steps.filter.outputs.fr_fr }}
+      translated: ${{ steps.filter.outputs.translated }}
+      images: ${{ steps.filter.outputs.images }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            fr_fr:
+              - 'docs/fr_FR/**'
+            translated:
+              - 'docs/en_US/**'
+              - 'docs/es_ES/**'
+              - 'docs/de_DE/**'
+            images:
+              - 'docs/images/**'
+
+  translate:
+    needs: changes
+    if: needs.changes.outputs.fr_fr == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: jeedom/jeetranslate-docs@main
+        with:
+          deepl_api_key: ${{ secrets.DEEPL_API_KEY }}
+          target_languages: en_US,es_ES,de_DE
+
+  # publish:
+  #   needs: changes
+  #   if: >
+  #     always() &&
+  #     (github.event_name == 'workflow_dispatch' ||
+  #      needs.changes.outputs.translated == 'true' ||
+  #      needs.changes.outputs.images == 'true')
+  #   uses: jeedom/workflows/.github/workflows/docs-publish.yml@main
+  #   with:
+  #     repo_kind: core
+  #     source_ref: ${{ github.event.inputs.ref }}
+  #   secrets:
+  #     docs_repo_token: ${{ secrets.DOCS_REPO_TOKEN }}
+  # Kept disabled until jeedom/documentations' `rework` branch (jeedom/documentations#166)
+  # is merged to master: that branch restructures the target repo, publishing before then
+  # would write into the current, still-duplicated layout.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,15 +3,11 @@ name: Docs
 on:
   push:
     branches:
+      - develop
       - release
     paths:
       - docs/**
   workflow_dispatch:
-    inputs:
-      ref:
-        description: "Tag/branch/SHA to publish from (backfill an already-shipped version). Leave empty to use the current ref."
-        required: false
-        default: ""
 
 permissions:
   contents: write
@@ -19,17 +15,18 @@ permissions:
 
 jobs:
   changes:
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     outputs:
       fr_fr: ${{ steps.filter.outputs.fr_fr }}
       translated: ${{ steps.filter.outputs.translated }}
       images: ${{ steps.filter.outputs.images }}
+      manual: ${{ github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@v7
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
+          base: ${{ github.ref_name }}
           filters: |
             fr_fr:
               - 'docs/fr_FR/**'
@@ -42,27 +39,20 @@ jobs:
 
   translate:
     needs: changes
-    if: needs.changes.outputs.fr_fr == 'true'
+    if: needs.changes.outputs.fr_fr == 'true' || needs.changes.outputs.manual == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: jeedom/jeetranslate-docs@main
         with:
           deepl_api_key: ${{ secrets.DEEPL_API_KEY }}
-          target_languages: en_US,es_ES,de_DE
 
-  # publish:
-  #   needs: changes
-  #   if: >
-  #     always() &&
-  #     (github.event_name == 'workflow_dispatch' ||
-  #      needs.changes.outputs.translated == 'true' ||
-  #      needs.changes.outputs.images == 'true')
-  #   uses: jeedom/workflows/.github/workflows/docs-publish.yml@main
-  #   with:
-  #     repo_kind: core
-  #     source_ref: ${{ github.event.inputs.ref }}
-  #   secrets:
-  #     docs_repo_token: ${{ secrets.DOCS_REPO_TOKEN }}
-  # Kept disabled until jeedom/documentations' `rework` branch (jeedom/documentations#166)
-  # is merged to master: that branch restructures the target repo, publishing before then
-  # would write into the current, still-duplicated layout.
+  publish:
+    needs: changes
+    if: |
+      github.ref_name == 'release' &&
+      (needs.changes.outputs.translated == 'true' || needs.changes.outputs.images == 'true' || needs.changes.outputs.manual == 'true')
+    uses: jeedom/workflows/.github/workflows/docs-publish.yml@main
+    with:
+      repo_kind: core
+    secrets:
+      docs_repo_token: ${{ secrets.DOCS_REPO_TOKEN }}


### PR DESCRIPTION
Adds `.github/workflows/docs.yml`: on push to `release` touching `docs/**`, translates `docs/fr_FR` via `jeedom/jeetranslate-docs` when it changed, and publishes to `jeedom/documentations` via `jeedom/workflows/docs-publish.yml` once the translated locales (or images) actually land. A `workflow_dispatch` input allows backfilling an already-shipped version from an arbitrary ref.

Part of the documentation translation rework tracked in jeedom/documentations#166.

For context: closes #3252, which explored a different direction for this same underlying problem (per-repo GitHub Pages hosting + browser-native translation). This PR is part of a different approach instead: keep jeedom/documentations centralized, with an automated DeepL-based translation pipeline replacing the broken one.

~~**The `publish` job is intentionally commented out in this PR.** `jeedom/documentations` still has its old, duplicated layout on `master`; publishing now would write into it incorrectly. It must stay disabled until jeedom/documentations#166's `rework` branch merges to `master`, and until the `DOCS_REPO_TOKEN` organization secret described there exists. The `translate` job is safe to enable right away, it never touches `jeedom/documentations`.~~ (superseded, see Update below)

Update: this also enables the publish job (previously commented out above) and extends the automatic trigger to develop, not just release, so translations stay in sync continuously instead of piling up until a release cut, and a hotfix pushed directly to release still gets translated too.

The workflow_dispatch `ref` input mentioned above for backfilling an arbitrary ref has been removed: GitHub's native branch/tag picker already lets you pick any ref to run from, without the risk of translate and publish ending up checking out two different refs from a single dispatch. Manual dispatch now forces both translate (safe to run unconditionally: jeetranslate-docs only calls DeepL for entries genuinely missing from its translation memory, so it's a no-op when nothing needs translating) and publish (restricted to `github.ref_name == 'release'`, never `develop`).

This also applies the fixes found while validating the pipeline end-to-end on jeedom/plugin-wescontrol: `dorny/paths-filter` defaulted its diff base to the repository's default branch when unset, causing publish to silently detect zero changes on any push to a non-default branch (fixed with an explicit `base: ${{ github.ref_name }}`); and bumped `dorny/paths-filter` to v4 to drop its Node 20 deprecation warning.

Publish currently targets `jeedom/documentations`' `rework` branch by default, not `master`, which isn't the branch serving the live documentation site yet, so enabling it here has no effect on production docs even on a real release. Once `rework` merges into `master`, that default will be switched centrally in `jeedom/workflows/docs-publish.yml`, updating every caller at once.
