### PR TITLE
Remove PHP 7.3 workflow from GitHub Actions

### DIFF
--- a/.github/workflows/work.yml
+++ b/.github/workflows/work.yml
@@ -11,8 +11,6 @@ on:
 name : 'Test Core Jeedom'
 
 jobs:
-  php73:
-    uses: jeedom/workflows/.github/workflows/lint_Php73.yml@main
   php74:
     uses: jeedom/workflows/.github/workflows/lint_Php74.yml@main
   php82:


### PR DESCRIPTION
## Description

The PHP 7.3 workflow has been removed. 
Since Jeedom requires PHP 7.4 or higher, this workflow inevitably fails.

