### PR TITLE
Refactor user hash regeneration to avoid double save side effects

### DIFF
--- a/core/class/jeedom.class.php
+++ b/core/class/jeedom.class.php
@@ -1184,7 +1184,7 @@ class jeedom {
 			report::clean();
 			DB::optimize();
 			listener::clean();
-			user::regenerateHash();
+			user::regenerateHashes();
 			jeeObject::cronDaily();
 			timeline::clean(false);
 		} catch (\Throwable $e) {

--- a/core/class/user.class.php
+++ b/core/class/user.class.php
@@ -31,7 +31,7 @@ class user {
 	private $options;
 	private $rights;
 	private $enable = 1;
-	private $hash;
+	private string $hash = '';
 	private $_changed = false;
 
 
@@ -404,16 +404,17 @@ class user {
 		return $return;
 	}
 
-	public static function regenerateHash() {
+	public static function regenerateHashes() {
 		foreach ((user::all()) as $user) {
-			if ($user->getProfils() != 'admin' || $user->getOptions('doNotRotateHash', 0) == 1 || $user->getEnable() == 0) {
-				continue;
+			if ($user->getHash() != '') {
+				if ($user->getProfils() != 'admin' || $user->getOptions('doNotRotateHash', 0) == 1 || $user->getEnable() == 0) {
+					continue;
+				}
+				if (strtotime($user->getOptions('hashGenerated')) > strtotime('now -3 month')) {
+					continue;
+				}
 			}
-			if (strtotime($user->getOptions('hashGenerated')) > strtotime('now -3 month')) {
-				continue;
-			}
-			$user->setHash('');
-			$user->getHash();
+			$user->regenerateHash()->save();
 		}
 	}
 
@@ -440,6 +441,9 @@ class user {
 			if ($this->getProfils() != 'admin') {
 				throw new Exception(__('Vous ne pouvez pas changer le profil du dernier administrateur', __FILE__));
 			}
+		}
+		if ($this->getHash() == '') {
+			$this->regenerateHash();
 		}
 	}
 
@@ -468,6 +472,16 @@ class user {
 
 	public function refresh(): void {
 		DB::refresh($this);
+	}
+
+	private function regenerateHash() {
+		do {
+			$_hash = config::genKey();
+		} while (is_object(self::byHash($_hash)));
+
+		$this->setHash($_hash);
+		$this->setOptions('hashGenerated', date('Y-m-d H:i:s'));
+		return $this;
 	}
 
 	/**
@@ -559,19 +573,13 @@ class user {
 	}
 
 	public function getHash() {
-		if ($this->hash == '' && $this->id != '') {
-			$hash = config::genKey();
-			while (is_object(self::byHash($hash))) {
-				$hash = config::genKey();
-			}
-			$this->setHash($hash);
-			$this->setOptions('hashGenerated', date('Y-m-d H:i:s'));
-			$this->save();
-		}
 		return $this->hash;
 	}
 
-	public function setHash($_hash) {
+	public function setHash(string $_hash) {
+		if ($_hash == '') {
+			return $this->regenerateHash();
+		}
 		$this->_changed = utils::attrChanged($this->_changed, $this->hash, $_hash);
 		$this->hash = $_hash;
 		return $this;

--- a/core/class/user.class.php
+++ b/core/class/user.class.php
@@ -31,7 +31,7 @@ class user {
 	private $options;
 	private $rights;
 	private $enable = 1;
-	private string $hash = '';
+	private ?string $hash = '';
 	private $_changed = false;
 
 
@@ -572,15 +572,15 @@ class user {
 		return $this;
 	}
 
-	public function getHash() {
-		return $this->hash;
+	public function getHash(): string {
+		return (string) $this->hash;
 	}
 
 	public function setHash(string $_hash) {
 		if ($_hash == '') {
 			return $this->regenerateHash();
 		}
-		$this->_changed = utils::attrChanged($this->_changed, $this->hash, $_hash);
+		$this->_changed = utils::attrChanged($this->_changed, $this->getHash(), $_hash);
 		$this->hash = $_hash;
 		return $this;
 	}

--- a/install/update/4.1.1.php
+++ b/install/update/4.1.1.php
@@ -1,11 +1,3 @@
 <?php
 require_once __DIR__ . '/../../core/php/core.inc.php';
-foreach (user::all() as $user) {
-  if($user->getProfils() != 'admin' || $user->getOptions('doNotRotateHash',0) == 1){
-    continue;
-  }
-  $user->setHash('');
-  $user->getHash();
-  $user->setOptions('hashGenerated',date('Y-m-d H:i:s'));
-  $user->save();
-}
+user::regenerateHashes();


### PR DESCRIPTION
## Summary

Fixes a bug where calling `user::getHash()` could trigger an unwanted **recursive/duplicate `save()`**, because the getter had a side effect: when the hash was empty, it generated a new one and called `$this->save()` from within the getter itself.

Since `DB::save()` builds the SQL `UPDATE`/`INSERT` query by calling the getter of every mapped property (via `DB::buildQuery()` / `DB::getField()`), invoking `getHash()` as part of a normal `save()` triggered a **second, nested `save()`** as a side effect — an accidental recursion that was very hard to trace (no explicit call to `getHash()` visible in the calling code).

## Root cause

- `getHash()` lazily generated a hash and called `$this->save()` when the hash was empty.
- `DB::buildQuery()` calls `getHash()` implicitly for every `save()` (to read the `hash` column value), so this getter was invoked far more often than expected, with a persistence side effect baked into a read operation.

## Changes

- `getHash()` is now a pure getter — it only returns `$this->hash`, no more side effects (no generation, no `save()`).
- Hash generation/rotation logic is centralized in a new private `regenerateHash()` method (uses `do...while` to generate a unique key via `config::genKey()` / `byHash()`, then sets `hashGenerated` option).
- `preSave()` now ensures a hash exists before persisting (`if ($this->getHash() == '') { $this->regenerateHash(); }`), so the hash is always generated as part of the normal save flow instead of lazily from a getter.
- `setHash('')` now delegates to `regenerateHash()`, keeping a single source of truth for hash generation.
- `hash` property is now strongly typed (`private string $hash = '';`), compatible with PHP 7.4+.
- Fixed `user::regenerateHashes()` (formerly `regenerateHash()`, static loop over all admins):
  - Users with an **empty hash** are now always regenerated, regardless of `doNotRotateHash`, `enable`, or the 3-month rotation window — those conditions only apply to *rotating* an existing hash, not to *generating a missing one*.

Changelog 

- [DEV] user::regenerateHash() has been renamed by user::regenerateHashes()
- [DEV] user::getHash() no longer generates and persists a missing hash as a side effect. Code that calls getHash() expecting an empty database value to be automatically repaired must now call save() explicitly after the operation that causes regeneration.
- [DEV] user::setHash('') now immediately generates a new hash in memory. Previously, it stored an empty value and deferred regeneration until a later getHash() call. The new hash is not persisted until save() is called.

## Why this matters

Getters must not have persistence side effects. This bug caused confusing duplicated log entries (`save()`/`preSave()` appearing twice) any time a hash needed to be (re)generated, and made debugging the actual save flow very difficult.