### PR TITLE
add option to avoid infinite save loops in eqLogic import

### DIFF
--- a/core/class/eqLogic.class.php
+++ b/core/class/eqLogic.class.php
@@ -1358,7 +1358,7 @@ class eqLogic {
 		}
 	}
 
-	public function import($_configuration, $_dontRemove = false) {
+	public function import(array $_configuration, bool $_dontRemove = false, bool $_direct = false): void {
 		$cmdClass = $this->getEqType_name() . 'Cmd';
 		if (isset($_configuration['configuration'])) {
 			foreach ($_configuration['configuration'] as $key => $value) {
@@ -1455,7 +1455,7 @@ class eqLogic {
 				}
 			}
 		}
-		$this->save();
+		$this->save($_direct);
 	}
 
 	public function export($_withCmd = true) {

--- a/core/class/eqLogic.class.php
+++ b/core/class/eqLogic.class.php
@@ -1358,7 +1358,15 @@ class eqLogic {
 		}
 	}
 
-	public function import(array $_configuration, bool $_dontRemove = false, bool $_direct = false): void {
+	/**
+	 * import configuration into the eqLogic
+	 *
+	 * @param array $_configuration
+	 * @param boolean $_dontRemove
+	 * @param boolean $_direct - It will be propagated to the eqLogic::save() method, if true, it will not trigger pre/post insert/update/save hooks
+	 * @return void
+	 */
+	public function import(array $_configuration, bool $_dontRemove = false, bool $_direct = false) {
 		$cmdClass = $this->getEqType_name() . 'Cmd';
 		if (isset($_configuration['configuration'])) {
 			foreach ($_configuration['configuration'] as $key => $value) {


### PR DESCRIPTION
## Description
Updated the `import` method in `eqLogic.class.php` to add a new boolean parameter `$_direct`.

Save behavior enhancements: modified the call to `save()` within the `import` method to pass the new `$_direct` parameter, allowing for direct saving when specified.

### Suggested changelog entry
[DEV] breaking change: If you have overridden the import method in your class, you must adapt its signature accordingly. However, it is recommended not to override methods from eqLogic class.

### Related issues/external references

Fixes #3461

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes)_
- [x] New feature _(non-breaking change which adds functionality)_
- [X] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [X] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement
