### PR TITLE
Enhance Samba command security with temporary authentication file

### DIFF
--- a/core/repo/samba.repo.php
+++ b/core/repo/samba.repo.php
@@ -131,8 +131,23 @@ class repo_samba {
 		);
 	}
 
-	public static function makeSambaCommand($_cmd, $_type = 'backup') {
-		return system::getCmdSudo() . 'smbclient  -t 120 ' . config::byKey('samba::' . $_type . '::share') . ' -U "' . config::byKey('samba::' . $_type . '::username') . '%' . config::byKey('samba::' . $_type . '::password') . '" -I ' . config::byKey('samba::' . $_type . '::ip') . ' -c "' . $_cmd . '"';
+	private static function makeSambaCommand(string $_cmd, string $_type = 'backup'): string {
+		$authfile = self::createAuthFile($_type);
+		return '(' . system::getCmdSudo() . 'smbclient  -t 120 ' . config::byKey('samba::' . $_type . '::share') . ' -A ' . $authfile . ' -I ' . config::byKey('samba::' . $_type . '::ip') . ' -c "' . $_cmd . '"; ec=$?; ' . system::getCmdSudo() . 'rm -f ' . $authfile . '; exit $ec)';
+	}
+
+	/**
+	 * Write username/password to a private temp file so they never appear in the process command line
+	 * @param string $_type
+	 * @return string path to the authentication file
+	 */
+	private static function createAuthFile(string $_type): string {
+		$authfile = jeedom::getTmpFolder('samba') . '/.smbauth_' . bin2hex(random_bytes(16));
+		$content = 'username = ' . config::byKey('samba::' . $_type . '::username') . "\n"
+			. 'password = ' . config::byKey('samba::' . $_type . '::password') . "\n";
+		file_put_contents($authfile, $content);
+		chmod($authfile, 0600);
+		return $authfile;
 	}
 
 	public static function sortByDatetime($a, $b) {


### PR DESCRIPTION
## Description
This pull request addresses a security issue where Samba credentials—especially the password—were exposed in clear text in logs (cron_execution) when a Samba backup failed.


### Suggested changelog entry
- Amélioration: n'expose plus le mot de passe samba dans les logs en cas d'erreur; de plus les mots de passe complexes comprenant des caractères spéciaux devraient être mieux acceptés

### Related issues/external references

Fixes #3474


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have checked there is no other PR open for the same change.
- [X] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [X] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [X] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.

