### PR TITLE
Fix icon selector search crashing and not filtering object background images

### DIFF
--- a/desktop/modal/icon.selector.php
+++ b/desktop/modal/icon.selector.php
@@ -264,21 +264,24 @@ include_file('3rdparty', 'tree/tree', 'js');
         this.icon_tree.reload()
       },
       iconTreeOnScroll: function() {
-        var view = document.querySelector('#md_iconSelector .tab-content').getBoundingClientRect();
-        var legends = document.querySelectorAll('#tabicon .imgContainer legend');
-        var i = 0;
+        if (document.querySelector('#md_iconSelector div.tab-pane.active')?.id != 'tabicon') {
+          return;
+        }
+        const view = document.querySelector('#md_iconSelector .tab-content').getBoundingClientRect();
+        const legends = document.querySelectorAll('#tabicon .imgContainer legend');
+        let i = 0;
         while (i < legends.length && legends[i].getBoundingClientRect().bottom < view.top) {
-          document.querySelector('#treeFolder-icon .' + (legends[i].className)).parentNode.removeClass('selected');
+          document.querySelector('#treeFolder-icon .' + (legends[i].className))?.parentNode.removeClass('selected');
           i += 1;
         }
         if (i < legends.length && legends[i].getBoundingClientRect().bottom < view.bottom) { // In view
-          document.querySelector('#treeFolder-icon .' + (legends[i].className)).parentNode.addClass('selected');
+          document.querySelector('#treeFolder-icon .' + (legends[i].className))?.parentNode.addClass('selected');
           i += 1;
         } else { // Out of view, select last
-          document.querySelector('#treeFolder-icon .' + (legends[i - 1].className)).parentNode.addClass('selected');
+          document.querySelector('#treeFolder-icon .' + (legends[i - 1]?.className))?.parentNode.addClass('selected');
         }
         while (i < legends.length) {
-          document.querySelector('#treeFolder-icon .' + (legends[i].className)).parentNode.removeClass('selected');
+          document.querySelector('#treeFolder-icon .' + (legends[i].className))?.parentNode.removeClass('selected');
           i += 1;
         }
       },

--- a/desktop/modal/icon.selector.php
+++ b/desktop/modal/icon.selector.php
@@ -105,13 +105,13 @@ sendVarToJS([
     </ul>
   <?php } ?>
   <div class="tab-content" style="overflow-y:scroll;max-height: 100%">
-    <div id="tabicon" role="tabpanel" class="tab-pane active" <?php if (!init('selectIcon', 1) && init('showimg') != 1) echo ' style="display:none;"' ?>>
+    <div id="tabicon" role="tabpanel" class="tab-pane<?php echo (!$objectId) ? ' active' : '' ?>" <?php if (!init('selectIcon', 1) && init('showimg') != 1) echo ' style="display:none;"' ?>>
       <div class="imgContainer" <?php if (init('showimg') == 1) echo ' style="padding-top:10px;"' ?>>
         <div id="treeFolder-icon" class="div_treeFolder"></div>
         <div class="div_imageGallery"></div>
       </div>
     </div>
-    <div id="tabobjectbg" role="tabpanel" class="tab-pane active" <?php if (!$objectId) echo ' style="display:none;"' ?>>
+    <div id="tabobjectbg" role="tabpanel" class="tab-pane<?php echo ($objectId) ? ' active' : '' ?>" <?php if (!$objectId) echo ' style="display:none;"' ?>>
       <div class="imgContainer" <?php if (init('showimg') == 1) echo ' style="padding-top:10px;"' ?>>
         <div id="treeFolder-bg" class="div_treeFolder"></div>
         <div class="div_imageGallery"></div>


### PR DESCRIPTION
`document.querySelector('#md_iconSelector div.tab-pane.active')` is used to detect which tab is currently shown, but `#tabicon` and `#tabobjectbg` both had the `active` class hardcoded in the PHP template, with nothing ever toggling it between them. `querySelector` always returned `#tabicon` first, regardless of which pane was actually visible.

Two separate issues came from this and from an unrelated array bounds bug, both introduced in #2241:

- Typing in the search box while the icon tab wasn't showing (or in some cases even while it was) crashed with `Cannot read properties of null (reading 'parentNode')` in `iconTreeOnScroll()`: it always looked up `#tabicon`'s legends against the icon tree regardless of which tab was active, and separately, `legends[i - 1]` could be `undefined` depending on scroll position, unrelated to the active tab.
<img width="825" alt="image" src="https://github.com/user-attachments/assets/303063d8-e1d1-408e-907e-f44f726c49bc" />

- Searching within the object background image gallery never filtered anything, since the search handler scoped its filtering to whatever `.tab-pane.active` resolved to (always `#tabicon`) instead of `#tabobjectbg`.

Fix:

- Guard `iconTreeOnScroll()` to only run when the icon tab is actually active, and make its DOM lookups null-safe.
- Make `active` mutually exclusive between `#tabicon` and `#tabobjectbg`, based on `$objectId`, so tab-active detection reflects what's actually shown.

Noticed while working on the Font Awesome 7.3.1 upgrade (separate branch/PR), unrelated to it.
