### PR TITLE
Refactor draft release notes workflow to remove tag date retrieval and improve PR fetching logic

### DIFF
--- a/.github/workflows/draft-release-notes.yml
+++ b/.github/workflows/draft-release-notes.yml
@@ -25,12 +25,6 @@ jobs:
           TAG=$(git describe --tags --abbrev=0)
           echo "tag=$TAG" >> $GITHUB_OUTPUT
 
-      - name: Get tag date
-        id: tagdate
-        run: |
-          DATE=$(git log -1 --format=%cI ${{ steps.lasttag.outputs.tag }})
-          echo "date=$DATE" >> $GITHUB_OUTPUT
-
       - name: Generate markdown file
         id: genmd
         run: |
@@ -38,12 +32,20 @@ jobs:
 
           echo "# All changes since release ${{ steps.lasttag.outputs.tag }}" > docs/release-notes.md
           echo "" >> docs/release-notes.md
-          PRS_JSON=$(gh pr list \
-            --state merged \
-            --base develop \
-            --limit 1000 \
-            --search "merged:>${{ steps.tagdate.outputs.date }}" \
-            --json number,title,mergedAt,url,labels)
+
+          # Use git ancestry (not commit dates) to find PRs not yet released: a release
+          # branch can be cut and stabilized for a while before the tag is actually pushed,
+          # so the tag's commit date can be later than PRs on develop meant for the *next*
+          # release. Relying on dates then wrongly excludes those PRs once the tag exists.
+          PR_NUMBERS=$(git log ${{ steps.lasttag.outputs.tag }}..HEAD --pretty=format:%s \
+            | grep -oP '(?:\(#|Merge pull request #)\K[0-9]+' \
+            | sort -un)
+
+          PRS_JSON="[]"
+          for num in $PR_NUMBERS; do
+            pr=$(gh pr view "$num" --json number,title,mergedAt,url,labels 2>/dev/null) || continue
+            [ -n "$pr" ] && PRS_JSON=$(jq --argjson pr "$pr" '. + [$pr]' <<< "$PRS_JSON")
+          done
 
           add_section() {
             local title="$1"

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -10,6 +10,7 @@
 | 2026-06-30 15:36:39 | Uncheck default plugins update | [#3406](https://github.com/jeedom/core/pull/3406) |
 | 2026-06-29 16:12:13 | Add history retention mode | [#3401](https://github.com/jeedom/core/pull/3401) |
 | 2026-06-25 16:40:35 | Update Jeedom logos to new branding | [#3392](https://github.com/jeedom/core/pull/3392) |
+| 2026-06-19 12:09:45 | Update display.php | [#3379](https://github.com/jeedom/core/pull/3379) |
 
 ## Breaking changes
 | Merge date | Title | PR |
@@ -17,6 +18,7 @@
 | 2026-09-01 08:12:25 | migrate password sha512 to php native | [#3476](https://github.com/jeedom/core/pull/3476) |
 | 2026-09-01 08:05:52 | add option to avoid infinite save loops in eqLogic import | [#3471](https://github.com/jeedom/core/pull/3471) |
 | 2026-08-17 12:18:51 | Centralize eqLogic remove confirmation and post-delete redirect | [#3415](https://github.com/jeedom/core/pull/3415) |
+| 2026-06-23 11:57:10 | chore: remove InfluxDB integration | [#3306](https://github.com/jeedom/core/pull/3306) |
 
 ## Fixes
 | Merge date | Title | PR |
@@ -42,6 +44,7 @@
 | 2026-07-16 09:33:46 | Harmonize wording of selection modal titles | [#3424](https://github.com/jeedom/core/pull/3424) |
 | 2026-06-30 11:29:16 | Prevent recording uppercase status in update database | [#3405](https://github.com/jeedom/core/pull/3405) |
 | 2026-06-25 13:40:05 | fix in case pdo hydratation set timeout to null | [#3393](https://github.com/jeedom/core/pull/3393) |
+| 2026-06-23 11:10:53 | Fix missing translations in cmd.configure modal | [#3384](https://github.com/jeedom/core/pull/3384) |
 
 ## Others
 | Merge date | Title | PR |
@@ -51,6 +54,7 @@
 | 2026-07-30 14:11:05 | Speed up plugin::isInstalled and use it instead of byId for existence checks | [#3446](https://github.com/jeedom/core/pull/3446) |
 | 2026-07-22 10:45:14 | Modernize Element.prototype.empty using replaceChildren | [#3417](https://github.com/jeedom/core/pull/3417) |
 | 2026-06-27 21:01:28 | Use guard clauses in cmd->addHistoryValue | [#3400](https://github.com/jeedom/core/pull/3400) |
+| 2026-06-23 11:59:28 | patch: remove nginx support | [#3376](https://github.com/jeedom/core/pull/3376) |
 
 ## Documentations
 | Merge date | Title | PR |
@@ -65,3 +69,7 @@
 | 2026-07-01 18:14:57 | chore(deps): bump actions/cache from 5 to 6 | [#3411](https://github.com/jeedom/core/pull/3411) |
 | 2026-06-26 16:47:36 | Remove V4-stable-update workflow | [#3397](https://github.com/jeedom/core/pull/3397) |
 
+## Uncategorized
+| Merge date | Title | PR |
+| --- | --- | --- |
+| 2026-06-23 14:25:02 | chore: merge back release to develop | [#3386](https://github.com/jeedom/core/pull/3386) |

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -10,7 +10,6 @@
 | 2026-06-30 15:36:39 | Uncheck default plugins update | [#3406](https://github.com/jeedom/core/pull/3406) |
 | 2026-06-29 16:12:13 | Add history retention mode | [#3401](https://github.com/jeedom/core/pull/3401) |
 | 2026-06-25 16:40:35 | Update Jeedom logos to new branding | [#3392](https://github.com/jeedom/core/pull/3392) |
-| 2026-06-19 12:09:45 | Update display.php | [#3379](https://github.com/jeedom/core/pull/3379) |
 
 ## Breaking changes
 | Merge date | Title | PR |
@@ -18,7 +17,6 @@
 | 2026-09-01 08:12:25 | migrate password sha512 to php native | [#3476](https://github.com/jeedom/core/pull/3476) |
 | 2026-09-01 08:05:52 | add option to avoid infinite save loops in eqLogic import | [#3471](https://github.com/jeedom/core/pull/3471) |
 | 2026-08-17 12:18:51 | Centralize eqLogic remove confirmation and post-delete redirect | [#3415](https://github.com/jeedom/core/pull/3415) |
-| 2026-06-23 11:57:10 | chore: remove InfluxDB integration | [#3306](https://github.com/jeedom/core/pull/3306) |
 
 ## Fixes
 | Merge date | Title | PR |
@@ -44,7 +42,6 @@
 | 2026-07-16 09:33:46 | Harmonize wording of selection modal titles | [#3424](https://github.com/jeedom/core/pull/3424) |
 | 2026-06-30 11:29:16 | Prevent recording uppercase status in update database | [#3405](https://github.com/jeedom/core/pull/3405) |
 | 2026-06-25 13:40:05 | fix in case pdo hydratation set timeout to null | [#3393](https://github.com/jeedom/core/pull/3393) |
-| 2026-06-23 11:10:53 | Fix missing translations in cmd.configure modal | [#3384](https://github.com/jeedom/core/pull/3384) |
 
 ## Others
 | Merge date | Title | PR |
@@ -54,7 +51,6 @@
 | 2026-07-30 14:11:05 | Speed up plugin::isInstalled and use it instead of byId for existence checks | [#3446](https://github.com/jeedom/core/pull/3446) |
 | 2026-07-22 10:45:14 | Modernize Element.prototype.empty using replaceChildren | [#3417](https://github.com/jeedom/core/pull/3417) |
 | 2026-06-27 21:01:28 | Use guard clauses in cmd->addHistoryValue | [#3400](https://github.com/jeedom/core/pull/3400) |
-| 2026-06-23 11:59:28 | patch: remove nginx support | [#3376](https://github.com/jeedom/core/pull/3376) |
 
 ## Documentations
 | Merge date | Title | PR |
@@ -69,7 +65,3 @@
 | 2026-07-01 18:14:57 | chore(deps): bump actions/cache from 5 to 6 | [#3411](https://github.com/jeedom/core/pull/3411) |
 | 2026-06-26 16:47:36 | Remove V4-stable-update workflow | [#3397](https://github.com/jeedom/core/pull/3397) |
 
-## Uncategorized
-| Merge date | Title | PR |
-| --- | --- | --- |
-| 2026-06-23 14:25:02 | chore: merge back release to develop | [#3386](https://github.com/jeedom/core/pull/3386) |


### PR DESCRIPTION
# Problem
The draft-release-notes.yml workflow determined which PRs to include in the release notes by filtering on date (g`h pr list --search "merged:>DATE",` where DATE is the commit date of the last tag).

This date-based filtering is incorrect when a release branch is prepared and stabilized for several days/weeks before the tag is actually pushed: the tag's commit date can then be later than PRs merged to develop in the meantime, even though those PRs were intended for the next release (not the one being prepared).
As a result, once the tag was created, those PRs were permanently excluded from future release notes, even though they had never actually been published.

# Solution
Replace date-based filtering with Git ancestry-based filtering:

Extract PR numbers directly from `git log <last_tag>..HEAD`, by parsing commit messages ((#1234) for squash merges, Merge pull request #1234 for regular merges).
Fetch each PR's metadata (title, mergedAt, url, labels) via `gh pr view <number>`.
This approach accurately reflects which PRs are truly reachable from HEAD but not from the last tag, regardless of when the tag was actually pushed.

# Changes
Removed the Get tag date step (no longer needed).
Replaced the `gh pr list --search "merged:>DATE"` call with PR extraction via git log + gh pr view per number.
The rest of the generation logic (sections by label, sorting, markdown table) is unchanged.