### PR TITLE
Drop bullseye from CI and Docker Hub build matrices

### DIFF
--- a/.github/workflows/docker-image-latest.yml
+++ b/.github/workflows/docker-image-latest.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        debian: [bullseye, bookworm, trixie]
+        debian: [bookworm, trixie]
         database: [0, 1]
 
     steps:

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -1,4 +1,4 @@
-# build docker image based on debian bullseye, bookworm and trixie
+# build docker image based on debian bookworm and trixie
 # start all containers and run sick.php
 # stop & clean
 name: Docker Test Image
@@ -27,20 +27,6 @@ jobs:
         # Check out the repo, using current branch
         # https://github.com/marketplace/actions/checkout
         uses: actions/checkout@v7
-
-      - name: Build jeedom:bullseye
-        # build current image for bullseye
-        run: |
-          docker build -t jeedom:bullseye --build-arg DEBIAN=bullseye --build-arg DATABASE=1 --build-arg VERSION=$PR_BRANCH .
-      - name: run jeedom:bullseye and check
-        # run current image for bullseye and check it
-        run: |
-          docker run -p 80:80 -d --rm --name jeedom_bullseye jeedom:bullseye
-          until [ "`docker inspect -f {{.State.Health.Status}} jeedom_bullseye`" == "healthy" ]; do
-            echo "waiting container to be healthy..."
-            sleep 5;
-          done;
-          docker exec jeedom_bullseye php sick.php
 
       - name: Build jeedom:bookworm
         # build current image for bookworm
@@ -73,6 +59,6 @@ jobs:
       - name: Clean docker image
         continue-on-error: true
         run: |
-          docker stop jeedom_bullseye jeedom_bookworm jeedom_trixie || true
-          docker rm jeedom_bullseye jeedom_bookworm jeedom_trixie || true
-          docker rmi jeedom:bullseye jeedom:bookworm jeedom:trixie || true
+          docker stop jeedom_bookworm jeedom_trixie || true
+          docker rm jeedom_bookworm jeedom_trixie || true
+          docker rmi jeedom:bookworm jeedom:trixie || true


### PR DESCRIPTION
`bullseye-security` (Debian 11) is failing to fetch several packages (404 on `deb.debian.org`, e.g. `sudo`, `gnupg`, `libaom0`, `libpam-cap`), breaking the Docker build on every PR (`docker-test.yml`) and would break Docker Hub image publishing the same way (`docker-image-latest.yml`).

Debian 11 is no longer officially supported since `os::min` was raised to 12 (#3483), so bullseye is dropped from both build matrices instead of chasing a repository issue on an already-unsupported OS version.