### PR TITLE
Fix: Scenario triggers failing when trailing spaces are present

### DIFF
--- a/core/class/scenario.class.php
+++ b/core/class/scenario.class.php
@@ -815,6 +815,7 @@ class scenario {
 	 */
 	public function testTrigger($_event) {
 		foreach (($this->getTrigger()) as $trigger) {
+			$trigger = trim($trigger);
 			$trigger = str_replace(array('#variable(', ')#'), array('variable(', ')'), $trigger);
 			$trigger = str_replace(array('#genericType(', ')#'), array('genericType(', ')'), $trigger);
 			if ($trigger == $_event) {


### PR DESCRIPTION
## Description

This PR resolves an issue where scenario triggers containing a trailing space behave inconsistently.

With a trailing space:
- The scenario executes correctly when the trigger becomes “1”.
- But when the trigger returns to “0”, no scenario execution occurs, even though the command value updates properly.

The fix trims trailing whitespace before evaluating trigger values, ensuring consistent scenario execution for all state changes.

### Suggested changelog entry

- Déclencheurs de scénarios : correction d’un comportement erroné en présence d’espaces finaux

### Related issues/external references

Fixes https://community.jeedom.com/t/declencheur-avec-espace-a-la-fin/149602


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement
