### PR TITLE
Chore: Update PHP version checks to require PHP 7.4 or higher

### DIFF
--- a/core/ajax/user.ajax.php
+++ b/core/ajax/user.ajax.php
@@ -56,11 +56,7 @@ try {
 				'ip' => getClientIp(),
 				'session_id' => session_id(),
 			);
-			if (version_compare(PHP_VERSION, '7.3') >= 0) {
-				setcookie('registerDevice', sha512($_SESSION['user']->getHash()) . '-' . $rdk, ['expires' => time() + 365 * 24 * 3600, 'samesite' => 'Strict', 'httponly' => true, 'path' => '/', 'secure' => (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https')]);
-			} else {
-				setcookie('registerDevice', sha512($_SESSION['user']->getHash()) . '-' . $rdk, time() + 365 * 24 * 3600, "/; samesite=strict", '', (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https'), true);
-			}
+			setcookie('registerDevice', sha512($_SESSION['user']->getHash()) . '-' . $rdk, ['expires' => time() + 365 * 24 * 3600, 'samesite' => 'Strict', 'httponly' => true, 'path' => '/', 'secure' => (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https')]);
 			@session_start();
 			$_SESSION['user']->refresh();
 			$_SESSION['user']->setOptions('registerDevice', $registerDevice);

--- a/core/php/authentification.php
+++ b/core/php/authentification.php
@@ -53,11 +53,7 @@ if (user::isBan()) {
 }
 
 if (!isConnect() && isset($_COOKIE['registerDevice']) && !loginByHash($_COOKIE['registerDevice'])) {
-	if (version_compare(PHP_VERSION, '7.3') >= 0) {
-		setcookie('registerDevice', '', ['expires' => time() + 365 * 24 * 3600, 'samesite' => 'Strict', 'httponly' => true, 'path' => '/', 'secure' => (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https')]);
-	} else {
-		setcookie('registerDevice', '', time() + 365 * 24 * 3600, "/; samesite=Strict", '', (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https'), true);
-	}
+	setcookie('registerDevice', '', ['expires' => time() + 365 * 24 * 3600, 'samesite' => 'Strict', 'httponly' => true, 'path' => '/', 'secure' => (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https')]);
 }
 
 if (!isConnect() && $configs['sso:allowRemoteUser'] == 1) {
@@ -189,13 +185,8 @@ function logout() {
 		'ip' => getClientIp(),
 	]);
 	@session_start();
-	if (version_compare(PHP_VERSION, '7.3') >= 0) {
-		setcookie('registerDevice', '', ['expires' => time() + 365 * 24 * 3600, 'samesite' => 'Strict', 'httponly' => true, 'path' => '/', 'secure' => (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https')]);
-		setcookie('__Host-PHPSESSID', '', ['expires' => time() + 365 * 24 * 3600, 'samesite' => 'Strict', 'httponly' => true, 'path' => '/', 'secure' => (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https')]);
-	} else {
-		setcookie('registerDevice', '', time() + 365 * 24 * 3600, "/; samesite=Strict", '', (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https'), true);
-		setcookie('__Host-PHPSESSID', '', time() + 365 * 24 * 3600, "/; samesite=Strict", '', (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https'), true);
-	}
+	setcookie('registerDevice', '', ['expires' => time() + 365 * 24 * 3600, 'samesite' => 'Strict', 'httponly' => true, 'path' => '/', 'secure' => (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https')]);
+	setcookie('__Host-PHPSESSID', '', ['expires' => time() + 365 * 24 * 3600, 'samesite' => 'Strict', 'httponly' => true, 'path' => '/', 'secure' => (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https')]);
 	session_unset();
 	session_destroy();
 	return;

--- a/install/install.php
+++ b/install/install.php
@@ -39,8 +39,8 @@ try {
 	}
 	echo "****Install jeedom at (" . date('Y-m-d H:i:s') . ")****\n";
 	/*         * ***************************INSTALLATION************************** */
-	if (version_compare(PHP_VERSION, '7', '<')) {
-		throw new Exception('Jeedom nécessite PHP 7 ou plus (actuellement : ' . PHP_VERSION . ')');
+	if (version_compare(PHP_VERSION, '7.4', '<')) {
+		throw new Exception('Jeedom nécessite PHP 7.4 ou plus (actuellement : ' . PHP_VERSION . ')');
 	}
 	echo "\nInstallation of Jeedom\n";
 	echo "Installating database...";


### PR DESCRIPTION
## Description

Update PHP version checks to require PHP 7.4 or higher

### Suggested changelog entry

N/A
- No functional change for supported systems (already running PHP 7.4+).
- Pure cleanup + installer update.

### Related issues/external references

Fixes #3508 


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement
