### PR TITLE
feat: Enhance register device management with lifetime configuration

### DIFF
--- a/core/ajax/user.ajax.php
+++ b/core/ajax/user.ajax.php
@@ -56,7 +56,7 @@ try {
 				'ip' => getClientIp(),
 				'session_id' => session_id(),
 			);
-			setcookie('registerDevice', sha512($_SESSION['user']->getHash()) . '-' . $rdk, ['expires' => time() + 365 * 24 * 3600, 'samesite' => 'Strict', 'httponly' => true, 'path' => '/', 'secure' => (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https')]);
+			setRegisterDeviceCookie(sha512($_SESSION['user']->getHash()) . '-' . $rdk);
 			@session_start();
 			$_SESSION['user']->refresh();
 			$_SESSION['user']->setOptions('registerDevice', $registerDevice);

--- a/core/api/jeeApi.php
+++ b/core/api/jeeApi.php
@@ -1411,11 +1411,17 @@ try {
 		if (!is_array($registerDevice)) {
 			$registerDevice = array();
 		}
-		$rdk = (!isset($params['rdk']) || !isset($registerDevice[sha512($params['rdk'])])) ? config::genKey() : $params['rdk'];
-		$registerDevice[sha512($rdk)] = array();
-		$registerDevice[sha512($rdk)]['datetime'] = date('Y-m-d H:i:s');
-		$registerDevice[sha512($rdk)]['ip'] = getClientIp();
-		$registerDevice[sha512($rdk)]['session_id'] = session_id();
+		$rdk = $params['rdk'] ?? '';
+		$rdkHash = ($rdk != '') ? sha512($rdk) : '';
+		if ($rdk == '' || !$_USER_GLOBAL->isRegisterDeviceValid($rdkHash)) {
+			$rdk = config::genKey();
+			$rdkHash = sha512($rdk);
+		}
+		$registerDevice[$rdkHash] = array(
+			'datetime' => date('Y-m-d H:i:s'),
+			'ip' => getClientIp(),
+			'session_id' => session_id(),
+		);
 		$_USER_GLOBAL->setOptions('registerDevice', $registerDevice);
 		$_USER_GLOBAL->save();
 		log::add('api', 'debug', 'RDK :' . $rdk);

--- a/core/class/config.class.php
+++ b/core/class/config.class.php
@@ -668,6 +668,13 @@ class config {
 		return $_value;
 	}
 
+	public static function preConfig_security_registerDeviceLifetime($_value): int {
+		if (!is_numeric($_value)) {
+			return 30;
+		}
+		return max(7, min(90, (int) $_value));
+	}
+
 	/*     * *********************Stats************************************* */
 
 	/**

--- a/core/class/jeedom.class.php
+++ b/core/class/jeedom.class.php
@@ -1279,6 +1279,7 @@ class jeedom {
 			DB::optimize();
 			listener::clean();
 			user::regenerateHashes();
+			user::cleanExpiredRegisterDevices();
 			jeeObject::cronDaily();
 			timeline::clean(false);
 		} catch (\Throwable $e) {

--- a/core/class/user.class.php
+++ b/core/class/user.class.php
@@ -640,6 +640,41 @@ class user {
 		return utils::getJsonAttr($this->options, $_key, $_default);
 	}
 
+	public static function registerDeviceLifetime(): int {
+		$registerDeviceLifetime = (int) config::byKey('security::registerDeviceLifetime', 'core', 30);
+		return $registerDeviceLifetime * 24 * 3600;
+	}
+
+	public static function cleanExpiredRegisterDevices(): void {
+		$expiration = time() - self::registerDeviceLifetime();
+		foreach (self::all() as $user) {
+			$registerDevice = $user->getOptions('registerDevice', array());
+			if (!is_array($registerDevice)) {
+				continue;
+			}
+			$changed = false;
+			foreach ($registerDevice as $key => $value) {
+				if (!is_array($value) || !isset($value['datetime']) || strtotime($value['datetime']) < $expiration) {
+					unset($registerDevice[$key]);
+					$changed = true;
+				}
+			}
+			if ($changed) {
+				$user->setOptions('registerDevice', $registerDevice);
+				$user->save();
+			}
+		}
+	}
+
+	public function isRegisterDeviceValid(string $_key, ?array $_registerDevice = null): bool {
+		$registerDevice = $_registerDevice ?? $this->getOptions('registerDevice', array());
+		return is_array($registerDevice)
+			&& isset($registerDevice[$_key])
+			&& is_array($registerDevice[$_key])
+			&& isset($registerDevice[$_key]['datetime'])
+			&& strtotime($registerDevice[$_key]['datetime']) >= time() - self::registerDeviceLifetime();
+	}
+
 	public function setOptions($_key, $_value) {
 		if ($_key == 'registerDevice' && is_array($_value) &&  count($_value) > 20) {
 			uasort($_value, function ($a, $b) {

--- a/core/config/default.config.ini
+++ b/core/config/default.config.ini
@@ -74,6 +74,7 @@ history::defautShowPeriod = -1 month
 history::smooth = -2
 
 ;security
+security::registerDeviceLifetime = 30
 security::maxFailedLogin = 6
 security::timeLoginFailed = 300
 security::bantime = 600

--- a/core/php/authentification.php
+++ b/core/php/authentification.php
@@ -53,7 +53,7 @@ if (user::isBan()) {
 }
 
 if (!isConnect() && isset($_COOKIE['registerDevice']) && !loginByHash($_COOKIE['registerDevice'])) {
-	setcookie('registerDevice', '', ['expires' => time() + 365 * 24 * 3600, 'samesite' => 'Strict', 'httponly' => true, 'path' => '/', 'secure' => (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https')]);
+	deleteRegisterDeviceCookie();
 }
 
 if (!isConnect() && $configs['sso:allowRemoteUser'] == 1) {
@@ -81,6 +81,8 @@ if (init('logout') == 1) {
 	echo "window.location.href='index.php';";
 	echo '</script>';
 }
+
+updateRegisterDeviceActivity();
 
 /* * **************************Definition des function************************** */
 
@@ -153,7 +155,10 @@ function loginByHash(string $_key): bool {
 	}
 	$rdk = sha512($key[1]);
 	$registerDevice = $user->getOptions('registerDevice', array());
-	if (!is_array($registerDevice) || !isset($registerDevice[$rdk])) {
+	if (!is_array($registerDevice)) {
+		$registerDevice = array();
+	}
+	if (!$user->isRegisterDeviceValid($rdk)) {
 		user::failedLogin([
 			'login' => $user->getLogin(),
 			'reason' => __('Périphérique non enregistré ou clé invalide', __FILE__),
@@ -168,6 +173,7 @@ function loginByHash(string $_key): bool {
 	);
 	$user->setOptions('registerDevice', $registerDevice);
 	$user->save();
+	setRegisterDeviceCookie($_key);
 	@session_start();
 	$_SESSION['user'] = $user;
 	@session_write_close();
@@ -179,14 +185,62 @@ function loginByHash(string $_key): bool {
 	return true;
 }
 
+function setRegisterDeviceCookie(string $_value) {
+	setcookie('registerDevice', $_value, registerCookieOptions(time() + user::registerDeviceLifetime()));
+}
+
+function deleteRegisterDeviceCookie() {
+	setcookie('registerDevice', '', registerCookieOptions(time() - 3600));
+}
+
+function deleteSessionCookie() {
+	setcookie('__Host-PHPSESSID', '', registerCookieOptions(time() - 3600));
+}
+
+function registerCookieOptions(int $_expires): array {
+	return ['expires' => $_expires, 'samesite' => 'Strict', 'httponly' => true, 'path' => '/', 'secure' => (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https')];
+}
+
+function updateRegisterDeviceActivity() {
+	if (!isset($_COOKIE['registerDevice']) || !isset($_SESSION['user']) || !is_object($_SESSION['user'])) {
+		return;
+	}
+	$key = explode('-', $_COOKIE['registerDevice'], 2);
+	if (count($key) != 2 || sha512($_SESSION['user']->getHash()) != $key[0]) {
+		return;
+	}
+	$registerDeviceKey = sha512($key[1]);
+	$registerDevice = $_SESSION['user']->getOptions('registerDevice', array());
+	if (!is_array($registerDevice)) {
+		return;
+	}
+
+	if (!$_SESSION['user']->isRegisterDeviceValid($registerDeviceKey, $registerDevice)) {
+		return;
+	}
+
+	$now = time();
+	$lastActivity = strtotime($registerDevice[$registerDeviceKey]['datetime']);
+	if ($lastActivity === false || $lastActivity < $now - 24 * 3600) {
+		$registerDevice[$registerDeviceKey] = array(
+			'datetime' => date('Y-m-d H:i:s', $now),
+			'ip' => getClientIp(),
+			'session_id' => session_id(),
+		);
+		setRegisterDeviceCookie($_COOKIE['registerDevice']);
+		$_SESSION['user']->setOptions('registerDevice', $registerDevice);
+		$_SESSION['user']->save();
+	}
+}
+
 function logout() {
 	log::audit('User logout', [
 		'login' => $_SESSION['user']->getLogin(),
 		'ip' => getClientIp(),
 	]);
 	@session_start();
-	setcookie('registerDevice', '', ['expires' => time() + 365 * 24 * 3600, 'samesite' => 'Strict', 'httponly' => true, 'path' => '/', 'secure' => (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https')]);
-	setcookie('__Host-PHPSESSID', '', ['expires' => time() + 365 * 24 * 3600, 'samesite' => 'Strict', 'httponly' => true, 'path' => '/', 'secure' => (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https')]);
+	deleteRegisterDeviceCookie();
+	deleteSessionCookie();
 	session_unset();
 	session_destroy();
 	return;

--- a/desktop/php/administration.php
+++ b/desktop/php/administration.php
@@ -1525,7 +1525,7 @@ $productName = config::byKey('product_name');
 								<sub>j</sub>
 							</label>
 							<div class="col-md-3 col-sm-4 col-xs-12">
-								<input type="number" class="configKey form-control" data-l1key="security::registerDeviceLifetime" min="7" max="90">
+								<input type="number" class="configKey form-control ispin" data-l1key="security::registerDeviceLifetime" min="7" max="90">
 							</div>
 						</div>
 						<div class="form-group">

--- a/desktop/php/administration.php
+++ b/desktop/php/administration.php
@@ -1520,6 +1520,15 @@ $productName = config::byKey('product_name');
 							</div>
 						</div>
 						<div class="form-group">
+							<label class="col-md-3 col-sm-4 col-xs-12 control-label">{{Durée de vie des périphériques enregistrés}}
+								<sup><i class="fas fa-question-circle" tooltip="{{Durée d'inactivité avant expiration du périphérique enregistré, entre 7 et 90 jours.}}"></i></sup>
+								<sub>j</sub>
+							</label>
+							<div class="col-md-3 col-sm-4 col-xs-12">
+								<input type="number" class="configKey form-control" data-l1key="security::registerDeviceLifetime" min="7" max="90">
+							</div>
+						</div>
+						<div class="form-group">
 							<label class="col-md-3 col-sm-4 col-xs-12 control-label">{{Nombre d'échecs tolérés}}
 								<sup><i class="fas fa-question-circle" tooltip="{{Passé ce nombre, l'IP sera bannie.}}"></i></sup>
 							</label>


### PR DESCRIPTION
## Description

Enhance register device management with lifetime configuration

- Introduced a new configuration option for register device lifetime: possible value between 7 days and 90 days with a default 30 days
- this time is a sliding window, no more an absolute expiration time, it is refreshed/extended once a day upon device activity
- Implemented methods to clean expired register devices and validate their status.



### Suggested changelog entry

- Ajout d’une durée d’expiration configurable pour les périphériques enregistrés, avec nettoyage automatique des entrées expirées.

### Related issues/external references

Fixes #3510 


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes)_
- [X] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement
