### PR TITLE
Chore: Remove the OS/package update feature from Jeedom.

### DIFF
--- a/core/ajax/jeedom.ajax.php
+++ b/core/ajax/jeedom.ajax.php
@@ -328,22 +328,6 @@ try {
 		ajax::success();
 	}
 
-	if (init('action') == 'systemGetUpgradablePackage') {
-		if (init('type') == 'all') {
-			$return = system::getUpgradablePackage('apt', init('forceRefresh', false));
-			$return = array_merge($return, system::getUpgradablePackage('pip2', init('forceRefresh', false)));
-			$return = array_merge($return, system::getUpgradablePackage('pip3', init('forceRefresh', false)));
-			ajax::success($return);
-		} else {
-			ajax::success(system::getUpgradablePackage(init('type'), init('forceRefresh', false)));
-		}
-	}
-
-	if (init('action') == 'systemUpgradablePackage') {
-		unautorizedInDemo();
-		ajax::success(system::upgradePackage(init('type')));
-	}
-
 	if (init('action') == 'health') {
 		ajax::success(jeedom::health());
 	}

--- a/core/class/system.class.php
+++ b/core/class/system.class.php
@@ -198,123 +198,6 @@ class system {
 		return $arch;
 	}
 
-	public static function getUpgradablePackage(string $_type, bool $_forceRefresh = false) {
-		$return = array($_type => array());
-		switch ($_type) {
-			case 'apt':
-				if ($_forceRefresh) {
-					shell_exec(system::getCmdSudo() . ' apt update 2>/dev/null');
-				}
-				$lines = explode("\n", shell_exec(system::getCmdSudo() . ' apt list --upgradable 2>/dev/null'));
-				foreach ($lines as $line) {
-					if (strpos($line, '/') === false) {
-						continue;
-					}
-					$infos = array_values(array_filter(explode(" ", $line)));
-					$name = explode("/", $infos[0])[0];
-					$return[$_type][$name] = array(
-						'name' => $name,
-						'type' => 'apt',
-						'platform' => $infos[2],
-						'current_version' => trim($infos[5], ']'),
-						'new_version' => $infos[1],
-					);
-				}
-				break;
-			case 'pip3':
-				if (version_compare(self::getOsVersion(), '12', '>=')) {
-					return array();
-				}
-				$ignore_package = array('dbus-python', 'gpg', 'pycairo', 'pycurl', 'PyGObject');
-				$ignore_arg = '';
-				foreach ($ignore_package as $package) {
-					$ignore_arg .= " --exclude {$package}";
-				}
-				$datas = json_decode(shell_exec(system::getCmdSudo() . " pip3 list {$ignore_arg} --outdated --format=json 2>/dev/null"), true);
-				if (count($datas) > 0) {
-					foreach ($datas as $value) {
-						$return[$_type][$value['name']] = array(
-							'name' => $value['name'],
-							'type' => 'pip3',
-							'current_version' => $value['version'],
-							'new_version' => $value['latest_version'],
-						);
-					}
-				}
-				break;
-			case 'pip2':
-				if (self::os_incompatible('pip2', '', [])) {
-					return array();
-				}
-				$datas = json_decode(shell_exec(system::getCmdSudo() . ' pip list --outdated --format=json 2>/dev/null'), true);
-				if (count($datas) > 0) {
-					foreach ($datas as $value) {
-						$return[$_type][$value['name']] = array(
-							'name' => $value['name'],
-							'type' => 'pip2',
-							'current_version' => $value['version'],
-							'new_version' => $value['latest_version'],
-						);
-					}
-				}
-				break;
-		}
-		return $return;
-	}
-
-	public static function upgradePackage(string $_type, $_package = null) {
-		$cmd = "set -x\n";
-		$cmd .= "echo '*******************Begin of package upgrade type " . $_type . "******************'\n";
-		switch ($_type) {
-			case 'apt':
-				if ($_package == null) {
-					$cmd .= system::getCmdSudo() . " apt update\n";
-					$cmd .= system::getCmdSudo() . ' apt -o Dpkg::Options::="--force-confdef" -y upgrade' . "\n";
-				} else {
-					$cmd .= self::installPackage($_type, $_package);
-				}
-				break;
-			case 'pip3':
-				if (version_compare(self::getOsVersion(), '12', '>=')) {
-					return;
-				}
-				if ($_package == null) {
-					$packages = self::getUpgradablePackage($_type);
-					if (count($packages) == '') {
-						return;
-					}
-					foreach ($packages[$_type] as $package) {
-						$cmd .= self::installPackage($_type, $package['name']) . "\n";
-					}
-				} else {
-					$cmd .= self::installPackage($_type, $_package) . "\n";
-				}
-				break;
-			case 'pip2':
-				if (self::os_incompatible('pip2', '', [])) {
-					return;
-				}
-				if ($_package == null) {
-					$packages = self::getUpgradablePackage($_type);
-					if (count($packages) == '') {
-						return '';
-					}
-					foreach ($packages[$_type] as $package) {
-						$cmd .= self::installPackage($_type, $package['name']) . "\n";
-					}
-				} else {
-					$cmd .= self::installPackage($_type, $_package) . "\n";
-				}
-				break;
-		}
-		$cmd .= "echo '*******************End of package installation******************'\n";
-		if (file_exists('/tmp/jeedom_fix_package')) {
-			shell_exec(system::getCmdSudo() . ' rm /tmp/jeedom_fix_package');
-		}
-		file_put_contents('/tmp/jeedom_fix_package', $cmd);
-		self::launchScriptPackage();
-	}
-
 	private static function getPython3VenvDir(string $_plugin) {
 		if ($_plugin == '') return '';
 		return __DIR__ . "/../../plugins/{$_plugin}/resources/python_venv";
@@ -368,17 +251,6 @@ class system {
 				if ($npm != '') {
 					self::$_installPackage[$type_key]['npm'] = array(
 						'version' => $npm
-					);
-				}
-				break;
-			case 'pip2':
-				if (version_compare(self::getOsVersion(), '11', '>=')) {
-					return self::$_installPackage[$type_key];
-				}
-				$datas = json_decode(shell_exec(self::getCmdSudo() . ' pip2 list --format=json 2>/dev/null'), true);
-				foreach ($datas as $value) {
-					self::$_installPackage[$type_key][mb_strtolower($value['name'])] = array(
-						'version' => $value['version']
 					);
 				}
 				break;
@@ -454,9 +326,6 @@ class system {
 			return true;
 		}
 		if (version_compare(self::getOsVersion(), '11', '>=')) {
-			if ($_type == 'pip2') {
-				return true;
-			}
 			if ($_type == 'apt' && strpos($_package, 'python-') !== false) {
 				return true;
 			}
@@ -831,11 +700,6 @@ class system {
 					return self::getCmdSudo() . ' chmod +x ' . __DIR__ . '/../../resources/install_nodejs.sh;' . self::getCmdSudo() . ' ' . __DIR__ . '/../../resources/install_nodejs.sh';
 				}
 				return self::getCmdSudo() . ' apt install -o Dpkg::Options::="--force-confdef" -y ' . $_package;
-			case 'pip2':
-				if (version_compare(self::getOsVersion(), '11', '>=')) {
-					return '';
-				}
-				return self::getCmdSudo() . ' pip2 install --force-reinstall --upgrade ' . $_package;
 			case 'pip3':
 				if ($_version != '') {
 					if (preg_match('/[<>]/', $_version)) {

--- a/core/js/jeedom.class.js
+++ b/core/js/jeedom.class.js
@@ -55,12 +55,12 @@ if (!isset(jeedom.cache.getConfiguration)) {
   jeedom.cache.getConfiguration = null
 }
 
-jeedom.changes = function() {
+jeedom.changes = function () {
   const paramsRequired = []
   const paramsSpecifics = {
     global: false,
     noDisplayError: true,
-    success: function(data) {
+    success: function (data) {
       if (jeedom.connect > 0) {
         jeedom.connect = 0
       }
@@ -102,7 +102,7 @@ jeedom.changes = function() {
       }
       jeedom.changes_timeout = setTimeout(jeedom.changes, 1)
     },
-    error: function(_error) {
+    error: function (_error) {
       if (typeof (user_id) != "undefined" && jeedom.connect == 100) {
         if (_error.message !== 'Unknown error') {
           jeedom.notify('{{Erreur de connexion}}', '{{Erreur lors de la connexion}} : ' + _error.message)
@@ -128,7 +128,7 @@ jeedom.changes = function() {
   domUtils.ajax(paramsAJAX)
 }
 
-jeedom.init = function() {
+jeedom.init = function () {
   jeedom.datetime = jeeFrontEnd.serverDatetime
   jeedom.display.version = document.body.dataset.uimode
 
@@ -192,24 +192,24 @@ jeedom.init = function() {
     ]
   })
 
-  document.body.addEventListener('cmd::update', function(_event) {
+  document.body.addEventListener('cmd::update', function (_event) {
     jeedom.cmd.refreshValue(_event.detail)
     jeedom.history.graphUpdate(_event.detail)
   })
 
-  document.body.addEventListener('eqLogic::update', function(_event) {
+  document.body.addEventListener('eqLogic::update', function (_event) {
     jeedom.eqLogic.refreshValue(_event.detail)
   })
 
-  document.body.addEventListener('jeeObject::summary::update', function(_event) {
+  document.body.addEventListener('jeeObject::summary::update', function (_event) {
     jeedom.object.summaryUpdate(_event.detail)
   })
 
-  document.body.addEventListener('scenario::update', function(_event) {
+  document.body.addEventListener('scenario::update', function (_event) {
     jeedom.scenario.refreshValue(_event.detail)
   })
 
-  document.body.addEventListener('ui::update', function(_event) {
+  document.body.addEventListener('ui::update', function (_event) {
     if (isset(_event.detail.page) && _event.detail.page != '') {
       if (jeedom.display.version == 'mobile') {
         if (!PAGE_HISTORY || PAGE_HISTORY.length == 0 || !PAGE_HISTORY[PAGE_HISTORY.length - 1].page || PAGE_HISTORY[PAGE_HISTORY.length - 1].page != _event.detail.page) {
@@ -225,7 +225,7 @@ jeedom.init = function() {
     document.querySelectorAll(_event.detail.container).setJeeValues(_event.detail.data, _event.detail.type)
   })
 
-  document.body.addEventListener('jeedom::gotoplan', function(_event) {
+  document.body.addEventListener('jeedom::gotoplan', function (_event) {
     if (getUrlVars('p') == 'plan' && 'function' == typeof (jeeFrontEnd.plan.displayPlan)) {
       if (_event.detail != jeephp2js.planHeader_id) {
         jeephp2js.planHeader_id = _event.detail
@@ -234,7 +234,7 @@ jeedom.init = function() {
     }
   })
 
-  document.body.addEventListener('jeedom::alert', function(_event) {
+  document.body.addEventListener('jeedom::alert', function (_event) {
     if (!isset(_event.detail.message) || _event.detail.message.trim() == '') {
       if (isset(_event.detail.page) && _event.detail.page != '') {
         if (getUrlVars('p') == _event.detail.page || (jeedom.display.version == 'mobile' && isset(CURRENT_PAGE) && CURRENT_PAGE == _event.detail.page)) {
@@ -261,27 +261,27 @@ jeedom.init = function() {
     }
   })
 
-  document.body.addEventListener('jeedom::alertPopup', function(_event) {
+  document.body.addEventListener('jeedom::alertPopup', function (_event) {
     alert(_event.detail)
   })
 
-  document.body.addEventListener('jeedom::coloredIcons', function(_event) {
+  document.body.addEventListener('jeedom::coloredIcons', function (_event) {
     document.body.setAttribute('data-coloredIcons', _event.detail)
   })
 
-  document.body.addEventListener('message::refreshMessageNumber', function() {
+  document.body.addEventListener('message::refreshMessageNumber', function () {
     jeedom.refreshMessageNumber()
   })
 
-  document.body.addEventListener('update::refreshUpdateNumber', function() {
+  document.body.addEventListener('update::refreshUpdateNumber', function () {
     jeedom.refreshUpdateNumber()
   })
 
-  document.body.addEventListener('notify', function(_event) {
+  document.body.addEventListener('notify', function (_event) {
     jeedom.notify(_event.detail.title, _event.detail.message, _event.detail.theme)
   })
 
-  document.body.addEventListener('checkThemechange', function(_event) {
+  document.body.addEventListener('checkThemechange', function (_event) {
     document.getElementById('jeedom_theme_currentcss').setAttribute('data-nochange', 0)
 
     if (isset(_event.detail.theme_start_day_hour)) {
@@ -296,7 +296,7 @@ jeedom.init = function() {
     jeedomUtils.checkThemechange()
   })
 
-  document.body.addEventListener('changeTheme', function(_event) {
+  document.body.addEventListener('changeTheme', function (_event) {
     jeedomUtils.changeTheme(_event.detail)
   })
   if (typeof user_id !== 'undefined') {
@@ -304,7 +304,7 @@ jeedom.init = function() {
   }
 }
 
-jeedom.getPageType = function(_modal) {
+jeedom.getPageType = function (_modal) {
   if (isset(_modal) && _modal == true) {
     let modalType = undefined
     const modals = Array.prototype.slice.call(document.querySelectorAll('.jeeDialogMain')).filter(item => item.isVisible())
@@ -325,15 +325,15 @@ jeedom.getPageType = function(_modal) {
 }
 
 jeedom.MESSAGE_NUMBER
-jeedom.refreshMessageNumber = function() {
+jeedom.refreshMessageNumber = function () {
   jeedom.message.number({
-    error: function(error) {
+    error: function (error) {
       jeedomUtils.showAlert({
         message: error.message,
         level: 'danger'
       })
     },
-    success: function(_number) {
+    success: function (_number) {
       jeedom.MESSAGE_NUMBER = _number
       if (_number == 0 || _number == '0') {
         document.getElementById('span_nbMessage').unseen()
@@ -345,17 +345,17 @@ jeedom.refreshMessageNumber = function() {
 }
 
 jeedom.UPDATE_NUMBER
-jeedom.refreshUpdateNumber = function() {
+jeedom.refreshUpdateNumber = function () {
   if (jeedom.update == undefined) return //mobile
   if (document.getElementById('span_nbUpdate') === null) return // for a not admin profil
   jeedom.update.number({
-    error: function(error) {
+    error: function (error) {
       jeedomUtils.showAlert({
         message: error.message,
         level: 'danger'
       })
     },
-    success: function(_number) {
+    success: function (_number) {
       jeedom.UPDATE_NUMBER = _number
       if (_number == 0 || _number == '0') {
         document.getElementById('span_nbUpdate').unseen()
@@ -366,7 +366,7 @@ jeedom.refreshUpdateNumber = function() {
   })
 }
 
-jeedom.notify = function(_title, _text, _class_name) {
+jeedom.notify = function (_title, _text, _class_name) {
   if (_title == '' && _text == '') {
     return true
   }
@@ -374,7 +374,7 @@ jeedom.notify = function(_title, _text, _class_name) {
     const options = {
       title: _title,
       message: _text,
-      onclick: function() {
+      onclick: function () {
         jeeDialog.clearToasts()
         jeeDialog.dialog({
           id: 'jee_modal',
@@ -393,7 +393,7 @@ jeedom.notify = function(_title, _text, _class_name) {
   }
 }
 
-jeedom.getStringUsedBy = function(_params) {
+jeedom.getStringUsedBy = function (_params) {
   const paramsRequired = ['search']
   const paramsSpecifics = {}
   try {
@@ -412,7 +412,7 @@ jeedom.getStringUsedBy = function(_params) {
   domUtils.ajax(paramsAJAX)
 }
 
-jeedom.getIdUsedBy = function(_params) {
+jeedom.getIdUsedBy = function (_params) {
   const paramsRequired = ['search']
   const paramsSpecifics = {}
   try {
@@ -431,10 +431,10 @@ jeedom.getIdUsedBy = function(_params) {
   domUtils.ajax(paramsAJAX)
 }
 
-jeedom.getConfiguration = function(_params) {
+jeedom.getConfiguration = function (_params) {
   const paramsRequired = ['key']
   const paramsSpecifics = {
-    pre_success: function(data) {
+    pre_success: function (data) {
       jeedom.cache.getConfiguration = data.result
       const keys = _params.key.split(':')
       data.result = jeedom.cache.getConfiguration
@@ -473,7 +473,7 @@ jeedom.getConfiguration = function(_params) {
   domUtils.ajax(paramsAJAX)
 }
 
-jeedom.getInfoApplication = function(_params) {
+jeedom.getInfoApplication = function (_params) {
   const paramsRequired = []
   const paramsSpecifics = {}
   try {
@@ -491,7 +491,7 @@ jeedom.getInfoApplication = function(_params) {
   domUtils.ajax(paramsAJAX)
 }
 
-jeedom.haltSystem = function(_params) {
+jeedom.haltSystem = function (_params) {
   const paramsRequired = []
   const paramsSpecifics = {}
   try {
@@ -509,7 +509,7 @@ jeedom.haltSystem = function(_params) {
   domUtils.ajax(paramsAJAX)
 }
 
-jeedom.ssh = function(_params) {
+jeedom.ssh = function (_params) {
   if (isPlainObject(_params)) {
     command = _params.command
   } else {
@@ -535,7 +535,7 @@ jeedom.ssh = function(_params) {
   return 'Execute command : ' + command
 }
 
-jeedom.db = function(_params) {
+jeedom.db = function (_params) {
   if (isPlainObject(_params)) {
     command = _params.command
   } else {
@@ -561,7 +561,7 @@ jeedom.db = function(_params) {
   return 'Execute command : ' + command
 }
 
-jeedom.dbcorrectTable = function(_params) {
+jeedom.dbcorrectTable = function (_params) {
   const paramsRequired = ['table']
   const paramsSpecifics = {}
   try {
@@ -580,7 +580,7 @@ jeedom.dbcorrectTable = function(_params) {
   domUtils.ajax(paramsAJAX)
 }
 
-jeedom.rebootSystem = function(_params) {
+jeedom.rebootSystem = function (_params) {
   const paramsRequired = []
   const paramsSpecifics = {}
   try {
@@ -598,7 +598,7 @@ jeedom.rebootSystem = function(_params) {
   domUtils.ajax(paramsAJAX)
 }
 
-jeedom.systemCorrectPackage = function(_params) {
+jeedom.systemCorrectPackage = function (_params) {
   const paramsRequired = ['package']
   const paramsSpecifics = {}
   try {
@@ -617,7 +617,7 @@ jeedom.systemCorrectPackage = function(_params) {
   domUtils.ajax(paramsAJAX)
 }
 
-jeedom.health = function(_params) {
+jeedom.health = function (_params) {
   const paramsRequired = []
   const paramsSpecifics = {}
   try {
@@ -635,7 +635,7 @@ jeedom.health = function(_params) {
   domUtils.ajax(paramsAJAX)
 }
 
-jeedom.forceSyncHour = function(_params) {
+jeedom.forceSyncHour = function (_params) {
   const paramsRequired = []
   const paramsSpecifics = {}
   try {
@@ -653,7 +653,7 @@ jeedom.forceSyncHour = function(_params) {
   domUtils.ajax(paramsAJAX)
 }
 
-jeedom.getCronSelectModal = function(_options, _callback) {
+jeedom.getCronSelectModal = function (_options, _callback) {
   document.getElementById('mod_insertCronValue')?.remove()
   document.body.insertAdjacentHTML('beforeend', '<div id="mod_insertCronValue"></div>')
   jeeDialog.dialog({
@@ -668,7 +668,7 @@ jeedom.getCronSelectModal = function(_options, _callback) {
         label: '{{Valider}}',
         className: 'success',
         callback: {
-          click: function(event) {
+          click: function (event) {
             const args = {}
             args.cron = {}
             args.value = mod_insertCron.getValue()
@@ -683,7 +683,7 @@ jeedom.getCronSelectModal = function(_options, _callback) {
         label: '{{Annuler}}',
         className: 'warning',
         callback: {
-          click: function(event) {
+          click: function (event) {
             document.getElementById('mod_insertCronValue')._jeeDialog.destroy()
           }
         }
@@ -692,7 +692,7 @@ jeedom.getCronSelectModal = function(_options, _callback) {
   })
 }
 
-jeedom.getSelectActionModal = function(_options, _callback) {
+jeedom.getSelectActionModal = function (_options, _callback) {
   if (!isset(_options)) {
     _options = {}
   }
@@ -706,13 +706,13 @@ jeedom.getSelectActionModal = function(_options, _callback) {
     width: 800,
     top: '20vh',
     contentUrl: 'index.php?v=d&modal=action.insert',
-    callback: function() { mod_insertAction.setOptions(_options) },
+    callback: function () { mod_insertAction.setOptions(_options) },
     buttons: {
       confirm: {
         label: '{{Valider}}',
         className: 'success',
         callback: {
-          click: function(event) {
+          click: function (event) {
             const args = {}
             args.human = mod_insertAction.getValue()
             if (args.human.trim() != '' && 'function' === typeof (_callback)) {
@@ -726,7 +726,7 @@ jeedom.getSelectActionModal = function(_options, _callback) {
         label: '{{Annuler}}',
         className: 'warning',
         callback: {
-          click: function(event) {
+          click: function (event) {
             document.getElementById('mod_insertActionValue')._jeeDialog.destroy()
           }
         }
@@ -735,7 +735,7 @@ jeedom.getSelectActionModal = function(_options, _callback) {
   })
 }
 
-jeedom.getGraphData = function(_params) {
+jeedom.getGraphData = function (_params) {
   const paramsRequired = []
   const paramsSpecifics = {}
   try {
@@ -755,7 +755,7 @@ jeedom.getGraphData = function(_params) {
   domUtils.ajax(paramsAJAX)
 }
 
-jeedom.getDocumentationUrl = function(_params) {
+jeedom.getDocumentationUrl = function (_params) {
   const paramsRequired = []
   const paramsSpecifics = {}
   try {
@@ -776,7 +776,7 @@ jeedom.getDocumentationUrl = function(_params) {
   domUtils.ajax(paramsAJAX)
 }
 
-jeedom.addWarnme = function(_params) {
+jeedom.addWarnme = function (_params) {
   const paramsRequired = []
   const paramsSpecifics = {}
   try {
@@ -796,7 +796,7 @@ jeedom.addWarnme = function(_params) {
   domUtils.ajax(paramsAJAX)
 }
 
-jeedom.getFileFolder = function(_params) {
+jeedom.getFileFolder = function (_params) {
   const paramsRequired = ['type', 'path']
   const paramsSpecifics = {}
   try {
@@ -816,7 +816,7 @@ jeedom.getFileFolder = function(_params) {
   domUtils.ajax(paramsAJAX)
 }
 
-jeedom.getFileContent = function(_params) {
+jeedom.getFileContent = function (_params) {
   const paramsRequired = ['path']
   const paramsSpecifics = {}
   try {
@@ -835,7 +835,7 @@ jeedom.getFileContent = function(_params) {
   domUtils.ajax(paramsAJAX)
 }
 
-jeedom.setFileContent = function(_params) {
+jeedom.setFileContent = function (_params) {
   const paramsRequired = ['path', 'content']
   const paramsSpecifics = {}
   try {
@@ -855,7 +855,7 @@ jeedom.setFileContent = function(_params) {
   domUtils.ajax(paramsAJAX)
 }
 
-jeedom.deleteFile = function(_params) {
+jeedom.deleteFile = function (_params) {
   const paramsRequired = ['path']
   const paramsSpecifics = {}
   try {
@@ -874,7 +874,7 @@ jeedom.deleteFile = function(_params) {
   domUtils.ajax(paramsAJAX)
 }
 
-jeedom.createFolder = function(_params) {
+jeedom.createFolder = function (_params) {
   const paramsRequired = ['path', 'name']
   const paramsSpecifics = {}
   try {
@@ -894,7 +894,7 @@ jeedom.createFolder = function(_params) {
   domUtils.ajax(paramsAJAX)
 }
 
-jeedom.renameFolder = function(_params) {
+jeedom.renameFolder = function (_params) {
   const paramsRequired = ['src', 'dst']
   const paramsSpecifics = {}
   try {
@@ -914,7 +914,7 @@ jeedom.renameFolder = function(_params) {
   domUtils.ajax(paramsAJAX)
 }
 
-jeedom.deleteFolder = function(_params) {
+jeedom.deleteFolder = function (_params) {
   const paramsRequired = ['path']
   const paramsSpecifics = {}
   try {
@@ -933,7 +933,7 @@ jeedom.deleteFolder = function(_params) {
   domUtils.ajax(paramsAJAX)
 }
 
-jeedom.createFile = function(_params) {
+jeedom.createFile = function (_params) {
   const paramsRequired = ['path', 'name']
   const paramsSpecifics = {}
   try {
@@ -953,7 +953,7 @@ jeedom.createFile = function(_params) {
   domUtils.ajax(paramsAJAX)
 }
 
-jeedom.emptyRemoveHistory = function(_params) {
+jeedom.emptyRemoveHistory = function (_params) {
   const paramsRequired = []
   const paramsSpecifics = {}
   try {
@@ -971,7 +971,7 @@ jeedom.emptyRemoveHistory = function(_params) {
   domUtils.ajax(paramsAJAX)
 }
 
-jeedom.version = function(_params) {
+jeedom.version = function (_params) {
   const paramsRequired = []
   const paramsSpecifics = {}
   try {
@@ -989,7 +989,7 @@ jeedom.version = function(_params) {
   domUtils.ajax(paramsAJAX)
 }
 
-jeedom.removeImageIcon = function(_params) {
+jeedom.removeImageIcon = function (_params) {
   const paramsRequired = ['filepath']
   const paramsSpecifics = {}
   try {
@@ -1008,7 +1008,7 @@ jeedom.removeImageIcon = function(_params) {
   domUtils.ajax(paramsAJAX)
 }
 
-jeedom.cleanFileSystemRight = function(_params) {
+jeedom.cleanFileSystemRight = function (_params) {
   const paramsRequired = []
   const paramsSpecifics = {}
   try {
@@ -1026,7 +1026,7 @@ jeedom.cleanFileSystemRight = function(_params) {
   domUtils.ajax(paramsAJAX)
 }
 
-jeedom.consistency = function(_params) {
+jeedom.consistency = function (_params) {
   const paramsRequired = []
   const paramsSpecifics = {}
   try {
@@ -1044,7 +1044,7 @@ jeedom.consistency = function(_params) {
   domUtils.ajax(paramsAJAX)
 }
 
-jeedom.cleanDatabase = function(_params) {
+jeedom.cleanDatabase = function (_params) {
   const paramsRequired = []
   const paramsSpecifics = {}
   try {
@@ -1062,7 +1062,7 @@ jeedom.cleanDatabase = function(_params) {
   domUtils.ajax(paramsAJAX)
 }
 
-jeedom.massEditSave = function(_params) {
+jeedom.massEditSave = function (_params) {
   const paramsRequired = ['type', 'objects']
   const paramsSpecifics = {}
   try {
@@ -1082,7 +1082,7 @@ jeedom.massEditSave = function(_params) {
   domUtils.ajax(paramsAJAX)
 }
 
-jeedom.massReplace = function(_params) {
+jeedom.massReplace = function (_params) {
   const paramsRequired = ['options', 'eqlogics', 'cmds']
   const paramsSpecifics = {}
   try {
@@ -1099,45 +1099,6 @@ jeedom.massReplace = function(_params) {
     options: _params.options,
     eqlogics: _params.eqlogics,
     cmds: _params.cmds
-  }
-  domUtils.ajax(paramsAJAX)
-}
-
-jeedom.systemGetUpgradablePackage = function(_params) {
-  const paramsRequired = ['type']
-  const paramsSpecifics = {}
-  try {
-    jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
-  } catch (e) {
-    (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
-    return
-  }
-  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  const paramsAJAX = jeedom.private.getParamsAJAX(params)
-  paramsAJAX.url = 'core/ajax/jeedom.ajax.php'
-  paramsAJAX.data = {
-    action: 'systemGetUpgradablePackage',
-    type: _params.type,
-    forceRefresh: _params.forceRefresh || false
-  }
-  domUtils.ajax(paramsAJAX)
-}
-
-jeedom.systemUpgradablePackage = function(_params) {
-  const paramsRequired = ['type']
-  const paramsSpecifics = {}
-  try {
-    jeedom.private.checkParamsRequired(_params || {}, paramsRequired)
-  } catch (e) {
-    (_params.error || paramsSpecifics.error || jeedom.private.default_params.error)(e)
-    return
-  }
-  const params = domUtils.extend({}, jeedom.private.default_params, paramsSpecifics, _params || {})
-  const paramsAJAX = jeedom.private.getParamsAJAX(params)
-  paramsAJAX.url = 'core/ajax/jeedom.ajax.php'
-  paramsAJAX.data = {
-    action: 'systemUpgradablePackage',
-    type: _params.type,
   }
   domUtils.ajax(paramsAJAX)
 }

--- a/desktop/js/update.js
+++ b/desktop/js/update.js
@@ -21,13 +21,11 @@ if (!jeeFrontEnd.update) {
     replaceLogLines: ['OK', '. OK', '.OK', 'OK .', 'OK.'],
     regExLogProgress: /\[PROGRESS\]\[(\d.*)]/gm,
     updtDataTable: null,
-    osDataTable: null,
     init: function () {
       window.jeeP = this
       this.hasUpdate = false
       this.progress = -2
       this.alertTimeout = null
-      this.osUpdateChecked = 0
       //___log interceptor beautifier___
       this.prevUpdateText = ''
       this.newLogClean = '<pre id="pre_updateInfo_clean" style="display:none;"><i>{{Aucune mise à jour en cours.}}</i></pre>'

--- a/desktop/js/update.js
+++ b/desktop/js/update.js
@@ -473,7 +473,7 @@ if (!jeeFrontEnd.update) {
           osTable.tBodies[0].empty()
 
           var tr_updates = []
-          for (var type of Object.keys(data)) { //apt pip2 pip3
+          for (var type of Object.keys(data)) { //apt pip3
             var OSPackages = Object.keys(data[type])
             if (OSPackages.length > 0) {
               document.querySelector('#os .bt_OsPackageUpdate[data-type="' + type + '"]').removeClass('disabled')

--- a/desktop/js/update.js
+++ b/desktop/js/update.js
@@ -22,7 +22,7 @@ if (!jeeFrontEnd.update) {
     regExLogProgress: /\[PROGRESS\]\[(\d.*)]/gm,
     updtDataTable: null,
     osDataTable: null,
-    init: function() {
+    init: function () {
       window.jeeP = this
       this.hasUpdate = false
       this.progress = -2
@@ -34,22 +34,22 @@ if (!jeeFrontEnd.update) {
       this._UpdateObserver_ = null
       this.printUpdate()
     },
-    checkAllUpdate: function() {
+    checkAllUpdate: function () {
       jeedomUtils.hideAlert()
       document.getElementById('progressbarContainer').addClass('hidden')
       jeedom.update.checkAll({
-        error: function(error) {
+        error: function (error) {
           jeedomUtils.showAlert({
             message: error.message,
             level: 'danger'
           })
         },
-        success: function() {
+        success: function () {
           jeeP.printUpdate()
         }
       })
     },
-    getJeedomLog: function(_autoUpdate, _log) {
+    getJeedomLog: function (_autoUpdate, _log) {
       domUtils.ajax({
         type: 'POST',
         url: 'core/ajax/log.ajax.php',
@@ -60,14 +60,14 @@ if (!jeeFrontEnd.update) {
         },
         dataType: 'json',
         global: false,
-        error: function(request, status, error) {
-          setTimeout(function() {
+        error: function (request, status, error) {
+          setTimeout(function () {
             jeeP.getJeedomLog(_autoUpdate, _log)
           }, 1000)
         },
-        success: function(data) {
+        success: function (data) {
           if (data.state != 'ok') {
-            setTimeout(function() {
+            setTimeout(function () {
               jeeP.getJeedomLog(_autoUpdate, _log)
             }, 1000)
             return
@@ -107,7 +107,7 @@ if (!jeeFrontEnd.update) {
           }
           document.getElementById('pre_' + _log + 'Info').innerHTML = log
           if (init(_autoUpdate, 0) == 1) {
-            setTimeout(function() {
+            setTimeout(function () {
               jeeP.getJeedomLog(_autoUpdate, _log)
             }, 1000)
           } else {
@@ -117,15 +117,15 @@ if (!jeeFrontEnd.update) {
         }
       })
     },
-    printUpdate: function() {
+    printUpdate: function () {
       jeedom.update.get({
-        error: function(error) {
+        error: function (error) {
           jeedomUtils.showAlert({
             message: error.message,
             level: 'danger'
           })
         },
-        success: function(data) {
+        success: function (data) {
           let tbody = document.querySelector('#table_update tbody')
           tbody.empty()
           if (isset(jeeFrontEnd.update.updtDataTable)) jeeFrontEnd.update.updtDataTable.refresh()
@@ -147,7 +147,7 @@ if (!jeeFrontEnd.update) {
           jeedomUtils.initDataTables('#coreplugin', false, true)
           jeeFrontEnd.update.updtDataTable = document.querySelector('#table_update')._dataTable
 
-          jeeFrontEnd.update.updtDataTable.on('columns.sort', function(column, direction) {
+          jeeFrontEnd.update.updtDataTable.on('columns.sort', function (column, direction) {
             let tbody = document.querySelector('#table_update tbody')
             tbody.prepend(tbody.querySelector('tr[data-type="core"]'))
           })
@@ -175,20 +175,20 @@ if (!jeeFrontEnd.update) {
         configuration: {
           "update::lastCheck": 0
         },
-        error: function(error) {
+        error: function (error) {
           jeedomUtils.showAlert({
             message: error.message,
             level: 'danger'
           })
         },
-        success: function(data) {
+        success: function (data) {
           let span = document.getElementById('span_lastUpdateCheck')
           span.title = '{{Dernière vérification des mises à jour}}'
           span.jeeValue(data['update::lastCheck'])
         }
       })
     },
-    addUpdate: function(_update) {
+    addUpdate: function (_update) {
       if (init(_update.status) == '') {
         _update.status = 'ok'
       }
@@ -305,7 +305,7 @@ if (!jeeFrontEnd.update) {
       newRow.setJeeValues(_update, '.updateAttr')
       return newRow
     },
-    updateProgressBar: function() {
+    updateProgressBar: function () {
       let progressBar = document.getElementById('div_progressbar')
       if (jeeP.progress == -4) {
         progressBar.removeClass('active progress-bar-info progress-bar-success progress-bar-danger')
@@ -346,7 +346,7 @@ if (!jeeFrontEnd.update) {
       progressBar.setAttribute('aria-valuenow', jeeP.progress)
       progressBar.innerHTML = jeeP.progress + '%'
     },
-    alertTimeout: function() {
+    alertTimeout: function () {
       jeeP.progress = -4
       this.updateProgressBar()
       jeedomUtils.showAlert({
@@ -355,9 +355,9 @@ if (!jeeFrontEnd.update) {
       })
     },
     //listen change in log to update cleaned one:
-    createUpdateObserver: function() {
-      this._UpdateObserver_ = new MutationObserver(function(mutations) {
-        mutations.forEach(function(mutation) {
+    createUpdateObserver: function () {
+      this._UpdateObserver_ = new MutationObserver(function (mutations) {
+        mutations.forEach(function (mutation) {
           if (mutation.type == 'childList' && mutation.removedNodes.length >= 1) {
             jeeFrontEnd.update.cleanUpdateLog()
           }
@@ -374,7 +374,7 @@ if (!jeeFrontEnd.update) {
       var targetNode = document.getElementById('pre_updateInfo')
       if (targetNode) this._UpdateObserver_.observe(targetNode, this.observerConfig)
     },
-    cleanUpdateLog: function() {
+    cleanUpdateLog: function () {
       var currentUpdateText = document.getElementById('pre_updateInfo').innerHTML
       if (currentUpdateText == '') return false
       if (this.prevUpdateText == currentUpdateText) return false
@@ -412,7 +412,7 @@ if (!jeeFrontEnd.update) {
         //remove points ...
         matches = line.match(/[.]{2,}/g)
         if (matches) {
-          matches.forEach(function(match) {
+          matches.forEach(function (match) {
             line = line.replace(match, '')
           })
         }
@@ -428,7 +428,7 @@ if (!jeeFrontEnd.update) {
         if (!nextLine.replace('OK', '').match(letters)) {
           matches = nextLine.match(/[.]{2,}/g)
           if (matches) {
-            matches.forEach(function(match) {
+            matches.forEach(function (match) {
               nextLine = nextLine.replace(match, '')
             })
           }
@@ -455,18 +455,18 @@ if (!jeeFrontEnd.update) {
       jeeP.alertTimeout = setTimeout(jeeP.alertTimeout, 60000 * 10)
     },
     //packages updates:
-    printOsUpdate: function(_forceRefresh) {
+    printOsUpdate: function (_forceRefresh) {
       this.osUpdateChecked = 1
       jeedom.systemGetUpgradablePackage({
         type: 'all',
         forceRefresh: _forceRefresh,
-        error: function(error) {
+        error: function (error) {
           jeedomUtils.showAlert({
             message: error.message,
             level: 'danger'
           })
         },
-        success: function(data) {
+        success: function (data) {
           document.querySelectorAll('#os .bt_OsPackageUpdate').addClass('disabled')
 
           var osTable = document.getElementById('table_osUpdate')
@@ -502,7 +502,7 @@ if (!jeeFrontEnd.update) {
         }
       })
     },
-    addOsUpdate: function(_update) {
+    addOsUpdate: function (_update) {
       var tr = '<tr>'
       tr += '<td>'
       tr += '<span class="osUpdateAttr" data-l1key="type"></span>'
@@ -521,14 +521,14 @@ if (!jeeFrontEnd.update) {
       return newRow
     },
     //modal update:
-    getUpdateModal: function() {
+    getUpdateModal: function () {
       jeeDialog.dialog({
         id: 'md_update',
         title: "{{Options de mise à jour}}",
         width: window.innerWidth > 600 ? 580 : window.innerWidth,
         height: window.innerHeight > 500 ? 440 : window.innerHeight - 80,
         top: window.innerHeight > 500 ? 120 : 0,
-        callback: function() {
+        callback: function () {
           var contentEl = jeeDialog.get('#md_update', 'content')
           if (contentEl.querySelector('#md_specifyUpdate') == null) {
             var newContent = document.getElementById('md_specifyUpdate-template').cloneNode(true)
@@ -542,7 +542,7 @@ if (!jeeFrontEnd.update) {
             jeedomUtils.initTooltips(document.getElementById('md_update'))
           }
 
-          contentEl.querySelector('input[data-l1key="force"]').addEventListener('click', function(event) {
+          contentEl.querySelector('input[data-l1key="force"]').addEventListener('click', function (event) {
             let mdSpec = document.getElementById('md_update')
             let check_backupBefore = mdSpec.querySelector('.updateOption[data-l1key="backup::before"]')
             if (event.target.checked) {
@@ -555,7 +555,7 @@ if (!jeeFrontEnd.update) {
             }
           })
         },
-        onShown: function() {
+        onShown: function () {
           jeeDialog.get('#md_update', 'content').querySelector('#md_specifyUpdate').removeClass('hidden')
         },
         buttons: {
@@ -563,7 +563,7 @@ if (!jeeFrontEnd.update) {
             label: '<i class="fas fa-sync-alt"></i> {{Mettre à jour}}',
             className: 'success',
             callback: {
-              click: function(event) {
+              click: function (event) {
                 var options = document.getElementById('md_specifyUpdate').getJeeValues('.updateOption')[0]
                 jeedomUtils.hideAlert()
                 jeeDialog.get('#md_update').hide()
@@ -573,13 +573,13 @@ if (!jeeFrontEnd.update) {
                 jeeP.updateProgressBar()
                 jeedom.update.doAll({
                   options: options,
-                  error: function(error) {
+                  error: function (error) {
                     jeedomUtils.showAlert({
                       message: error.message,
                       level: 'danger'
                     })
                   },
-                  success: function() {
+                  success: function () {
                     jeeP.getJeedomLog(1, 'update')
                   }
                 })
@@ -608,7 +608,7 @@ if (jeephp2js.isUpdating == '1') {
 
 /*Events delegations
 */
-document.getElementById('div_pageContainer').addEventListener('click', function(event) {
+document.getElementById('div_pageContainer').addEventListener('click', function (event) {
   var _target = null
   if (_target = event.target.closest('#bt_checkAllUpdate')) {
     if (!document.querySelector('a[data-target="#coreplugin"]').hasClass('active')) document.querySelector('a[data-target="#coreplugin"]').click()
@@ -641,20 +641,20 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
 
     jeedom.plugin.get({
       id: logicalId,
-      error: function(error) {
+      error: function (error) {
         jeedomUtils.showAlert({
           message: error.message,
           level: 'danger'
         })
       },
-      success: function(data) {
+      success: function (data) {
         var isActivated = (data.activate !== undefined && data.activate !== null) ? data.activate : 1
         var confirmationMessage = '{{Êtes-vous sûr de vouloir mettre à jour le plugin}} ' + logicalId + ' ?'
         if (isActivated != 1) {
           confirmationMessage = '{{Attention : Le plugin}} ' + logicalId + ' {{n\'est pas activé. Êtes-vous sûr de vouloir le mettre à jour ?}}'
         }
 
-        jeeDialog.confirm(confirmationMessage, function(result) {
+        jeeDialog.confirm(confirmationMessage, function (result) {
           if (result) {
             jeeP.progress = -1
             document.getElementById('progressbarContainer').removeClass('hidden')
@@ -663,13 +663,13 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
             jeedomUtils.hideAlert()
             jeedom.update.do({
               id: id,
-              error: function(error) {
+              error: function (error) {
                 jeedomUtils.showAlert({
                   message: error.message,
                   level: 'danger'
                 })
               },
-              success: function() {
+              success: function () {
                 jeeP.getJeedomLog(1, 'update')
               }
             })
@@ -683,18 +683,18 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
   if (_target = event.target.closest('#table_update .remove')) {
     var id = _target.closest('tr').getAttribute('data-id')
     var logicalId = _target.closest('tr').getAttribute('data-logicalid')
-    jeeDialog.confirm('{{Êtes-vous sûr de vouloir supprimer le plugin}} ' + logicalId + ' ?', function(result) {
+    jeeDialog.confirm('{{Êtes-vous sûr de vouloir supprimer le plugin}} ' + logicalId + ' ?', function (result) {
       if (result) {
         jeedomUtils.hideAlert()
         jeedom.update.remove({
           id: id,
-          error: function(error) {
+          error: function (error) {
             jeedomUtils.showAlert({
               message: error.message,
               level: 'danger'
             })
           },
-          success: function() {
+          success: function () {
             jeeP.printUpdate()
           }
         })
@@ -708,13 +708,13 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
     jeedomUtils.hideAlert()
     jeedom.update.check({
       id: id,
-      error: function(error) {
+      error: function (error) {
         jeedomUtils.showAlert({
           message: error.message,
           level: 'danger'
         })
       },
-      success: function() {
+      success: function () {
         jeeP.printUpdate()
       }
     })
@@ -724,13 +724,13 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
   if (_target = event.target.closest('#bt_saveUpdate')) {
     jeedom.update.saves({
       updates: document.querySelectorAll('#table_update tbody tr').getJeeValues('.updateAttr'),
-      error: function(error) {
+      error: function (error) {
         jeedomUtils.showAlert({
           message: error.message,
           level: 'danger'
         })
       },
-      success: function(data) {
+      success: function (data) {
         jeedomUtils.loadPage('index.php?v=d&p=update&saveSuccessFull=1')
       }
     })
@@ -749,19 +749,19 @@ document.getElementById('div_pageContainer').addEventListener('click', function(
       return
     }
     let type = _target.getAttribute('data-type')
-    jeeDialog.confirm('{{Êtes-vous sûr de vouloir mettre à jour les packages de type}} ' + type + ' ? {{Attention cette opération est toujours risquée et peut prendre plusieurs dizaines de minutes}}.', function(result) {
+    jeeDialog.confirm('{{Êtes-vous sûr de vouloir mettre à jour les packages de type}} ' + type + ' ? {{Attention cette opération est toujours risquée et peut prendre plusieurs dizaines de minutes}}.', function (result) {
       if (!result) {
         return
       }
       jeedom.systemUpgradablePackage({
         type: type,
-        error: function(error) {
+        error: function (error) {
           jeedomUtils.showAlert({
             message: error.message,
             level: 'danger'
           })
         },
-        success: function(data) {
+        success: function (data) {
           jeedomUtils.showAlert({
             message: '{{Mise à jour lancée avec succès.}}',
             level: 'success'

--- a/desktop/js/update.js
+++ b/desktop/js/update.js
@@ -72,9 +72,9 @@ if (!jeeFrontEnd.update) {
             }, 1000)
             return
           }
-          var log = ''
+          let log = ''
           if (Array.isArray(data.result)) {
-            for (var i in data.result.reverse()) {
+            for (const i in data.result.reverse()) {
               log += data.result[i] + "\n"
               //Update end success:
               if (data.result[i].indexOf('[END ' + _log.toUpperCase() + ' SUCCESS]') != -1) {
@@ -126,18 +126,18 @@ if (!jeeFrontEnd.update) {
           })
         },
         success: function (data) {
-          let tbody = document.querySelector('#table_update tbody')
+          const tbody = document.querySelector('#table_update tbody')
           tbody.empty()
           if (isset(jeeFrontEnd.update.updtDataTable)) jeeFrontEnd.update.updtDataTable.refresh()
 
-          var tr_updates = []
-          for (var i in data) {
+          const tr_updates = []
+          for (const i in data) {
             if (!isset(data[i].status)) continue
             if (data[i].type == 'core' || data[i].type == 'plugin') {
               tr_updates.push(jeeP.addUpdate(data[i]))
             }
           }
-          for (var tr of tr_updates) {
+          for (const tr of tr_updates) {
             tbody.appendChild(tr)
           }
           jeedomUtils.initTooltips(tbody)
@@ -148,7 +148,7 @@ if (!jeeFrontEnd.update) {
           jeeFrontEnd.update.updtDataTable = document.querySelector('#table_update')._dataTable
 
           jeeFrontEnd.update.updtDataTable.on('columns.sort', function (column, direction) {
-            let tbody = document.querySelector('#table_update tbody')
+            const tbody = document.querySelector('#table_update tbody')
             tbody.prepend(tbody.querySelector('tr[data-type="core"]'))
           })
           jeeFrontEnd.update.updtDataTable.columns().sort(0, 'desc')
@@ -182,7 +182,7 @@ if (!jeeFrontEnd.update) {
           })
         },
         success: function (data) {
-          let span = document.getElementById('span_lastUpdateCheck')
+          const span = document.getElementById('span_lastUpdateCheck')
           span.title = '{{Dernière vérification des mises à jour}}'
           span.jeeValue(data['update::lastCheck'])
         }
@@ -192,7 +192,7 @@ if (!jeeFrontEnd.update) {
       if (init(_update.status) == '') {
         _update.status = 'ok'
       }
-      var labelClass = 'label-success'
+      let labelClass = 'label-success'
       if (_update.status == 'update') {
         labelClass = 'label-warning'
         if (_update.type == 'core' || _update.type == 'plugin') {
@@ -200,14 +200,14 @@ if (!jeeFrontEnd.update) {
         }
       }
 
-      var tr = '<tr>'
+      let tr = '<tr>'
       tr += '<td style="width:40px"><span class="updateAttr text-uppercase label ' + labelClass + '" data-l1key="status"></span></td>'
       tr += '<td>'
       tr += '<span class="hidden-1280"><span class="updateAttr" data-l1key="source"></span> / <span class="updateAttr" data-l1key="type"></span> : </span>'
       if (_update.name == 'jeedom') {
         tr += '<span class="updateAttr label label-info text-capitalize" data-l1key="name"></span>'
         if (_update.branch) {
-          var updClass
+          let updClass
           switch (_update.branch.toLowerCase()) {
             case 'alpha':
               updClass = 'label-danger'
@@ -224,7 +224,7 @@ if (!jeeFrontEnd.update) {
       else {
         tr += '<span class="label label-info"><span class="updateAttr text-capitalize" data-l1key="plugin" data-l2key="name"></span> (<span class="updateAttr" data-l1key="name"></span>)</span>'
         if (_update.configuration && _update.configuration.version) {
-          var updClass
+          let updClass
           switch (_update.configuration.version.toLowerCase()) {
             case 'stable':
             case 'master':
@@ -297,7 +297,7 @@ if (!jeeFrontEnd.update) {
       }
       tr += '</td>'
       tr += '</tr>'
-      let newRow = document.createElement('tr')
+      const newRow = document.createElement('tr')
       newRow.innerHTML = tr
       newRow.setAttribute('data-id', init(_update.id))
       newRow.setAttribute('data-logicalId', init(_update.logicalId))
@@ -306,7 +306,7 @@ if (!jeeFrontEnd.update) {
       return newRow
     },
     updateProgressBar: function () {
-      let progressBar = document.getElementById('div_progressbar')
+      const progressBar = document.getElementById('div_progressbar')
       if (jeeP.progress == -4) {
         progressBar.removeClass('active progress-bar-info progress-bar-success progress-bar-danger')
           .addClass('progress-bar-warning')
@@ -371,20 +371,19 @@ if (!jeeFrontEnd.update) {
         subtree: true
       }
 
-      var targetNode = document.getElementById('pre_updateInfo')
+      const targetNode = document.getElementById('pre_updateInfo')
       if (targetNode) this._UpdateObserver_.observe(targetNode, this.observerConfig)
     },
     cleanUpdateLog: function () {
-      var currentUpdateText = document.getElementById('pre_updateInfo').innerHTML
+      const currentUpdateText = document.getElementById('pre_updateInfo').innerHTML
       if (currentUpdateText == '') return false
       if (this.prevUpdateText == currentUpdateText) return false
-      var lines = currentUpdateText.split("\n")
-      var l = lines.length
+      const lines = currentUpdateText.split("\n")
 
       //update progress bar and clean text!
-      var linesRev = lines.slice().reverse()
-      for (var i = 0; i < l; i++) {
-        var regExpResult = this.regExLogProgress.exec(linesRev[i])
+      const linesRev = lines.slice().reverse()
+      for (let i = 0; i < lines.length; i++) {
+        const regExpResult = this.regExLogProgress.exec(linesRev[i])
         if (regExpResult !== null) {
           jeeP.progress = regExpResult[1]
           jeeP.updateProgressBar()
@@ -392,15 +391,16 @@ if (!jeeFrontEnd.update) {
         }
       }
 
-      var newLogText = ''
-      for (var i = 0; i < l; i++) {
-        var line = lines[i]
+      let newLogText = ''
+      for (let i = 0; i < lines.length; i++) {
+        let line = lines[i]
         if (line == '') continue
         if (line.startsWith('[PROGRESS]')) line = ''
 
+        let matches
         //check ok at end of line:
         if (line.endsWith('OK')) {
-          var matches = line.match(/[. ]{1,}OK/g)
+          matches = line.match(/[. ]{1,}OK/g)
           if (matches) {
             line = line.replace(matches[0], '')
             line += ' | OK'
@@ -419,12 +419,12 @@ if (!jeeFrontEnd.update) {
         line = line.trim()
 
         //check ok on next line, escaping progress inbetween:
-        var offset = 1
+        let offset = 1
         if (lines[i + 1].startsWith('[PROGRESS]')) {
-          var offset = 2
+          offset = 2
         }
-        var nextLine = lines[i + offset]
-        var letters = /^[0-9a-zA-Z]+$/
+        let nextLine = lines[i + offset]
+        const letters = /^[0-9a-zA-Z]+$/
         if (!nextLine.replace('OK', '').match(letters)) {
           matches = nextLine.match(/[.]{2,}/g)
           if (matches) {
@@ -469,22 +469,22 @@ if (!jeeFrontEnd.update) {
         success: function (data) {
           document.querySelectorAll('#os .bt_OsPackageUpdate').addClass('disabled')
 
-          var osTable = document.getElementById('table_osUpdate')
+          const osTable = document.getElementById('table_osUpdate')
           osTable.tBodies[0].empty()
 
-          var tr_updates = []
-          for (var type of Object.keys(data)) { //apt pip3
-            var OSPackages = Object.keys(data[type])
+          const tr_updates = []
+          for (const type of Object.keys(data)) { //apt pip3
+            const OSPackages = Object.keys(data[type])
             if (OSPackages.length > 0) {
               document.querySelector('#os .bt_OsPackageUpdate[data-type="' + type + '"]').removeClass('disabled')
-              for (var OSPackage of OSPackages) {
+              for (const OSPackage of OSPackages) {
                 tr_updates.push(jeeFrontEnd.update.addOsUpdate(data[type][OSPackage]))
               }
             }
 
           }
 
-          for (var tr of tr_updates) {
+          for (const tr of tr_updates) {
             osTable.tBodies[0].appendChild(tr)
           }
 
@@ -503,7 +503,7 @@ if (!jeeFrontEnd.update) {
       })
     },
     addOsUpdate: function (_update) {
-      var tr = '<tr>'
+      let tr = '<tr>'
       tr += '<td>'
       tr += '<span class="osUpdateAttr" data-l1key="type"></span>'
       tr += '</td>'
@@ -513,7 +513,7 @@ if (!jeeFrontEnd.update) {
       tr += '<td style="width:160px;"><span class="label label-primary" data-l1key="localVersion">' + _update.current_version + '</span></td>'
       tr += '<td style="width:160px;"><span class="label label-primary" data-l1key="remoteVersion">' + _update.new_version + '</span></td>'
       tr += '</tr>'
-      let newRow = document.createElement('tr')
+      const newRow = document.createElement('tr')
       newRow.innerHTML = tr
       newRow.setAttribute('data-logicalId', init(_update.name))
       newRow.setAttribute('data-type', init(_update.type))
@@ -529,9 +529,9 @@ if (!jeeFrontEnd.update) {
         height: window.innerHeight > 500 ? 440 : window.innerHeight - 80,
         top: window.innerHeight > 500 ? 120 : 0,
         callback: function () {
-          var contentEl = jeeDialog.get('#md_update', 'content')
+          const contentEl = jeeDialog.get('#md_update', 'content')
           if (contentEl.querySelector('#md_specifyUpdate') == null) {
-            var newContent = document.getElementById('md_specifyUpdate-template').cloneNode(true)
+            const newContent = document.getElementById('md_specifyUpdate-template').cloneNode(true)
             newContent.setAttribute('id', 'md_specifyUpdate')
             contentEl.appendChild(newContent)
             newContent.querySelector('#bt_warnChangelogCore').href = document.getElementById('bt_changelogCore').href
@@ -543,8 +543,8 @@ if (!jeeFrontEnd.update) {
           }
 
           contentEl.querySelector('input[data-l1key="force"]').addEventListener('click', function (event) {
-            let mdSpec = document.getElementById('md_update')
-            let check_backupBefore = mdSpec.querySelector('.updateOption[data-l1key="backup::before"]')
+            const mdSpec = document.getElementById('md_update')
+            const check_backupBefore = mdSpec.querySelector('.updateOption[data-l1key="backup::before"]')
             if (event.target.checked) {
               check_backupBefore.setAttribute('data-state', check_backupBefore.checked)
               check_backupBefore.checked = false
@@ -564,7 +564,7 @@ if (!jeeFrontEnd.update) {
             className: 'success',
             callback: {
               click: function (event) {
-                var options = document.getElementById('md_specifyUpdate').getJeeValues('.updateOption')[0]
+                const options = document.getElementById('md_specifyUpdate').getJeeValues('.updateOption')[0]
                 jeedomUtils.hideAlert()
                 jeeDialog.get('#md_update').hide()
                 jeeP.progress = 0
@@ -609,7 +609,7 @@ if (jeephp2js.isUpdating == '1') {
 /*Events delegations
 */
 document.getElementById('div_pageContainer').addEventListener('click', function (event) {
-  var _target = null
+  let _target = null
   if (_target = event.target.closest('#bt_checkAllUpdate')) {
     if (!document.querySelector('a[data-target="#coreplugin"]').hasClass('active')) document.querySelector('a[data-target="#coreplugin"]').click()
     jeeP.checkAllUpdate()
@@ -636,8 +636,8 @@ document.getElementById('div_pageContainer').addEventListener('click', function 
 
   if (_target = event.target.closest('#table_update .update')) {
     if (_target.hasClass('disabled')) return
-    var id = _target.closest('tr').getAttribute('data-id')
-    var logicalId = _target.closest('tr').getAttribute('data-logicalid')
+    const id = _target.closest('tr').getAttribute('data-id')
+    const logicalId = _target.closest('tr').getAttribute('data-logicalid')
 
     jeedom.plugin.get({
       id: logicalId,
@@ -648,8 +648,8 @@ document.getElementById('div_pageContainer').addEventListener('click', function 
         })
       },
       success: function (data) {
-        var isActivated = (data.activate !== undefined && data.activate !== null) ? data.activate : 1
-        var confirmationMessage = '{{Êtes-vous sûr de vouloir mettre à jour le plugin}} ' + logicalId + ' ?'
+        const isActivated = (data.activate !== undefined && data.activate !== null) ? data.activate : 1
+        let confirmationMessage = '{{Êtes-vous sûr de vouloir mettre à jour le plugin}} ' + logicalId + ' ?'
         if (isActivated != 1) {
           confirmationMessage = '{{Attention : Le plugin}} ' + logicalId + ' {{n\'est pas activé. Êtes-vous sûr de vouloir le mettre à jour ?}}'
         }
@@ -681,8 +681,8 @@ document.getElementById('div_pageContainer').addEventListener('click', function 
   }
 
   if (_target = event.target.closest('#table_update .remove')) {
-    var id = _target.closest('tr').getAttribute('data-id')
-    var logicalId = _target.closest('tr').getAttribute('data-logicalid')
+    const id = _target.closest('tr').getAttribute('data-id')
+    const logicalId = _target.closest('tr').getAttribute('data-logicalid')
     jeeDialog.confirm('{{Êtes-vous sûr de vouloir supprimer le plugin}} ' + logicalId + ' ?', function (result) {
       if (result) {
         jeedomUtils.hideAlert()
@@ -704,7 +704,7 @@ document.getElementById('div_pageContainer').addEventListener('click', function 
   }
 
   if (_target = event.target.closest('#table_update .checkUpdate')) {
-    var id = _target.closest('tr').getAttribute('data-id')
+    const id = _target.closest('tr').getAttribute('data-id')
     jeedomUtils.hideAlert()
     jeedom.update.check({
       id: id,
@@ -748,7 +748,7 @@ document.getElementById('div_pageContainer').addEventListener('click', function 
     if (_target.getAttribute('disabled')) {
       return
     }
-    let type = _target.getAttribute('data-type')
+    const type = _target.getAttribute('data-type')
     jeeDialog.confirm('{{Êtes-vous sûr de vouloir mettre à jour les packages de type}} ' + type + ' ? {{Attention cette opération est toujours risquée et peut prendre plusieurs dizaines de minutes}}.', function (result) {
       if (!result) {
         return

--- a/desktop/js/update.js
+++ b/desktop/js/update.js
@@ -85,7 +85,6 @@ if (!jeeFrontEnd.update) {
                   clearTimeout(jeeP.alertTimeout)
                 }
                 _autoUpdate = 0
-                document.querySelectorAll('.bt_refreshOsPackageUpdate').removeClass('disabled')
                 jeedomUtils.reloadPagePrompt('{{Mise(s) à jour terminée(s) avec succès.}}')
               }
               //update error:
@@ -101,7 +100,6 @@ if (!jeeFrontEnd.update) {
                   level: 'danger'
                 })
                 _autoUpdate = 0
-                document.querySelectorAll('.bt_refreshOsPackageUpdate').removeClass('disabled')
               }
             }
           }
@@ -454,72 +452,6 @@ if (!jeeFrontEnd.update) {
       clearTimeout(jeeP.alertTimeout)
       jeeP.alertTimeout = setTimeout(jeeP.alertTimeout, 60000 * 10)
     },
-    //packages updates:
-    printOsUpdate: function (_forceRefresh) {
-      this.osUpdateChecked = 1
-      jeedom.systemGetUpgradablePackage({
-        type: 'all',
-        forceRefresh: _forceRefresh,
-        error: function (error) {
-          jeedomUtils.showAlert({
-            message: error.message,
-            level: 'danger'
-          })
-        },
-        success: function (data) {
-          document.querySelectorAll('#os .bt_OsPackageUpdate').addClass('disabled')
-
-          const osTable = document.getElementById('table_osUpdate')
-          osTable.tBodies[0].empty()
-
-          const tr_updates = []
-          for (const type of Object.keys(data)) { //apt pip3
-            const OSPackages = Object.keys(data[type])
-            if (OSPackages.length > 0) {
-              document.querySelector('#os .bt_OsPackageUpdate[data-type="' + type + '"]').removeClass('disabled')
-              for (const OSPackage of OSPackages) {
-                tr_updates.push(jeeFrontEnd.update.addOsUpdate(data[type][OSPackage]))
-              }
-            }
-
-          }
-
-          for (const tr of tr_updates) {
-            osTable.tBodies[0].appendChild(tr)
-          }
-
-          if (osTable._dataTable) {
-            osTable._dataTable.refresh()
-          } else {
-            jeeFrontEnd.update.osDataTable = new DataTable(osTable, {
-              columns: [
-                { select: 0, sort: "asc" }
-              ],
-              paging: false,
-              searchable: true
-            })
-          }
-        }
-      })
-    },
-    addOsUpdate: function (_update) {
-      let tr = '<tr>'
-      tr += '<td>'
-      tr += '<span class="osUpdateAttr" data-l1key="type"></span>'
-      tr += '</td>'
-      tr += '<td>'
-      tr += '<span class="osUpdateAttr" data-l1key="name"></span>'
-      tr += '</td>'
-      tr += '<td style="width:160px;"><span class="label label-primary" data-l1key="localVersion">' + _update.current_version + '</span></td>'
-      tr += '<td style="width:160px;"><span class="label label-primary" data-l1key="remoteVersion">' + _update.new_version + '</span></td>'
-      tr += '</tr>'
-      const newRow = document.createElement('tr')
-      newRow.innerHTML = tr
-      newRow.setAttribute('data-logicalId', init(_update.name))
-      newRow.setAttribute('data-type', init(_update.type))
-      newRow.setJeeValues(_update, '.osUpdateAttr')
-      return newRow
-    },
     //modal update:
     getUpdateModal: function () {
       jeeDialog.dialog({
@@ -569,7 +501,6 @@ if (!jeeFrontEnd.update) {
                 jeeDialog.get('#md_update').hide()
                 jeeP.progress = 0
                 document.getElementById('progressbarContainer').removeClass('hidden')
-                document.querySelector('.bt_refreshOsPackageUpdate').addClass('disabled')
                 jeeP.updateProgressBar()
                 jeedom.update.doAll({
                   options: options,
@@ -601,7 +532,6 @@ if (jeephp2js.isUpdating == '1') {
   jeedomUtils.hideAlert()
   jeeP.progress = 7
   document.getElementById('progressbarContainer').removeClass('hidden')
-  document.querySelector('.bt_refreshOsPackageUpdate').addClass('disabled')
   jeeP.updateProgressBar()
   jeeP.getJeedomLog(1, 'update')
 }
@@ -658,7 +588,6 @@ document.getElementById('div_pageContainer').addEventListener('click', function 
           if (result) {
             jeeP.progress = -1
             document.getElementById('progressbarContainer').removeClass('hidden')
-            document.querySelector('.bt_refreshOsPackageUpdate').addClass('disabled')
             jeeP.updateProgressBar()
             jeedomUtils.hideAlert()
             jeedom.update.do({
@@ -733,46 +662,6 @@ document.getElementById('div_pageContainer').addEventListener('click', function 
       success: function (data) {
         jeedomUtils.loadPage('index.php?v=d&p=update&saveSuccessFull=1')
       }
-    })
-    return
-  }
-
-  if (_target = event.target.closest('.bt_refreshOsPackageUpdate')) {
-    if (jeeP.osUpdateChecked == 0 || _target.getAttribute('data-forceRefresh') == "1") {
-      jeeP.printOsUpdate(_target.getAttribute('data-forceRefresh'))
-    }
-    return
-  }
-
-  if (_target = event.target.closest('.bt_OsPackageUpdate')) {
-    if (_target.getAttribute('disabled')) {
-      return
-    }
-    const type = _target.getAttribute('data-type')
-    jeeDialog.confirm('{{Êtes-vous sûr de vouloir mettre à jour les packages de type}} ' + type + ' ? {{Attention cette opération est toujours risquée et peut prendre plusieurs dizaines de minutes}}.', function (result) {
-      if (!result) {
-        return
-      }
-      jeedom.systemUpgradablePackage({
-        type: type,
-        error: function (error) {
-          jeedomUtils.showAlert({
-            message: error.message,
-            level: 'danger'
-          })
-        },
-        success: function (data) {
-          jeedomUtils.showAlert({
-            message: '{{Mise à jour lancée avec succès.}}',
-            level: 'success'
-          })
-          jeeDialog.dialog({
-            id: 'jee_modal',
-            title: "{{Log de mise à jour}}",
-            contentUrl: 'index.php?v=d&modal=log.display&log=packages'
-          })
-        }
-      })
     })
     return
   }

--- a/desktop/php/update.php
+++ b/desktop/php/update.php
@@ -102,7 +102,6 @@ if (strpos($logUpdate, 'END UPDATE') || count(system::ps('install/update.php', '
 					<span class="input-group-btn">
 						<a class="bt_refreshOsPackageUpdate btn btn-success roundedLeft" data-forceRefresh="1"><i class="fas fa-sync"></i> {{Mettre à jour la liste}}</a>
 						<a class="bt_OsPackageUpdate btn btn-warning disabled" data-type="apt"><i class="fas fa-sync"></i> {{Mettre à jour les packages OS}}</a>
-						<a class="bt_OsPackageUpdate btn btn-warning disabled" data-type="pip2"><i class="fas fa-sync"></i> {{Mettre à jour les packages Python2}}</a>
 						<a class="bt_OsPackageUpdate btn btn-warning roundedRight disabled" data-type="pip3"><i class="fas fa-sync"></i> {{Mettre à jour les packages Python3}}</a>
 					</span>
 				</div>

--- a/desktop/php/update.php
+++ b/desktop/php/update.php
@@ -63,9 +63,6 @@ if (strpos($logUpdate, 'END UPDATE') || count(system::ps('install/update.php', '
 
 		<ul class="nav nav-tabs" role="tablist">
 			<li role="presentation" class="active"><a data-target="#coreplugin" aria-controls="home" role="tab" data-toggle="tab"><i class="fas fa-archive"></i> {{Core et plugins}}</a></li>
-			<?php if (!in_array(jeedom::getHardwareName(), array('miniplus', 'smart', 'Atlas', 'Luna'))) { ?>
-				<li role="presentation"><a data-target="#os" aria-controls="profile" role="tab" data-toggle="tab" class="bt_refreshOsPackageUpdate" data-forceRefresh="0"><i class="fas fa-box"></i> {{OS/Package}}</a></li>
-			<?php } ?>
 			<li role="presentation"><a data-target="#log" aria-controls="profile" role="tab" data-toggle="tab"><i class="fas fa-info"></i> {{Informations}}</a></li>
 		</ul>
 
@@ -92,33 +89,6 @@ if (strpos($logUpdate, 'END UPDATE') || count(system::ps('install/update.php', '
 				<div id="div_log">
 					<pre id="pre_updateInfo"></pre>
 				</div>
-			</div>
-
-
-			<div role="tabpanel" class="tab-pane" id="os" style="overflow:auto;overflow-x: hidden">
-				<div class="alert alert-info">{{IMPORTANT : Ne sont affichés ici que les packages Linux n’étant pas à jour. Une liste vide signifiant que votre système Linux est à jour.}}</div>
-
-				<div class="input-group pull-right" style="display:inline-flex">
-					<span class="input-group-btn">
-						<a class="bt_refreshOsPackageUpdate btn btn-success roundedLeft" data-forceRefresh="1"><i class="fas fa-sync"></i> {{Mettre à jour la liste}}</a>
-						<a class="bt_OsPackageUpdate btn btn-warning disabled" data-type="apt"><i class="fas fa-sync"></i> {{Mettre à jour les packages OS}}</a>
-						<a class="bt_OsPackageUpdate btn btn-warning roundedRight disabled" data-type="pip3"><i class="fas fa-sync"></i> {{Mettre à jour les packages Python3}}</a>
-					</span>
-				</div>
-
-				<table class="ui-table-reflow table table-condensed" id="table_osUpdate">
-					<thead>
-						<tr>
-							<th style="width:50px">{{Type}}</th>
-							<th>{{Nom}}</th>
-							<th>{{Version installée}}</th>
-							<th>{{Dernière version}}</th>
-						</tr>
-					</thead>
-					<tbody>
-					</tbody>
-				</table>
-
 			</div>
 		</div>
 

--- a/docs/fr_FR/update.md
+++ b/docs/fr_FR/update.md
@@ -66,14 +66,6 @@ Sur chaque ligne, vous pouvez utiliser les fonctions suivantes:
 >
 > Quand vous lancez une mise à jour, une barre de progression apparaît au dessus du tableau. Évitez d'autres manipulations pendant la mise à jour.
 
-## Onglet OS/Package
-
-> **IMPORTANT**
->
-> Cet onglet est reservé aux utilisateurs avancés et uniquement aux utilisateurs avancé, la moindre mauvaise action ici peut CASSER votre Jeedom (sans possibilité de recourir au support)
-
-Cet onglet permet de voir les mises à jour disponible pour l'os (apt), package python (pip2 et pip3) ainsi que mettre à jour les packages qui le nécessite. 
-
 ## Onglet Informations
 
 En cours de mise à jour ou après celle-ci, cet onglet permet de lire en temps réel le log de cette mise à jour.


### PR DESCRIPTION
## Description

Remove the obsolete OS/package update feature: 
- Python 2 is no longer supported, 
- Python 3 package updates are becoming obsolete with Debian 12 and 13 (because they are managed in plugins venv),
- only APT updates remained available on DIY boxes, where users can and should manage them themselves so it does not make sense to keep it in the core.

I took the opportunity to also refactor the `var` declarations in update.js and replace them by `let` and `const`

### Suggested changelog entry

- Breaking change: Remove the OS/package update feature from Jeedom (it was only available on DIY boxes)

### Related issues/external references

Fixes https://community.jeedom.com/t/core-develop-deb13-retours/150813

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [X] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement